### PR TITLE
[Feature]: Pass AbortSignal to useResolve fn; abort on deps change and unmount

### DIFF
--- a/examples/src/components/DataFetcher.tsx
+++ b/examples/src/components/DataFetcher.tsx
@@ -14,9 +14,15 @@ interface User {
   email: string;
 }
 
-/** Simulates a 1.5 s network request. */
-async function fetchUser(): Promise<User> {
-  await new Promise((resolve) => setTimeout(resolve, 1500));
+/** Simulates a 1.5 s network request. Respects the provided AbortSignal. */
+async function fetchUser(signal: AbortSignal): Promise<User> {
+  await new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, 1500);
+    signal.addEventListener('abort', () => {
+      clearTimeout(t);
+      reject(new DOMException('Aborted', 'AbortError'));
+    });
+  });
   return { id: 1, name: 'Jane Doe', email: 'jane@example.com' };
 }
 

--- a/src/__tests__/render.test.ts
+++ b/src/__tests__/render.test.ts
@@ -335,7 +335,7 @@ describe('render – generator components with useResolve', () => {
     function* DataComp() {
       const data = yield* useResolve(
         {
-          fn: () => promise,
+          fn: (_signal) => promise,
           loading: createElement('span', { id: 'loading' }, 'Loading…'),
           error: createElement('span', { id: 'error' }, 'Error'),
         },
@@ -365,7 +365,7 @@ describe('render – generator components with useResolve', () => {
     function* DataComp() {
       const data = yield* useResolve(
         {
-          fn: () => promise,
+          fn: (_signal) => promise,
           loading: createElement('span', { id: 'loading' }, 'Loading…'),
           error: createElement('span', { id: 'error' }, 'Error'),
         },
@@ -396,7 +396,7 @@ describe('render – generator components with useResolve', () => {
       setLabel = sl;
       const data = yield* useResolve(
         {
-          fn: () => promise,
+          fn: (_signal) => promise,
           loading: createElement('span', { id: 'loading' }, 'Loading…'),
           error: createElement('span', null, 'Error'),
         },
@@ -429,7 +429,7 @@ describe('render – generator components with useResolve', () => {
       setLabel = sl;
       const data = yield* useResolve(
         {
-          fn: () => promise,
+          fn: (_signal) => promise,
           loading: createElement('span', { id: 'loading' }, 'Loading…'),
           error: createElement('span', null, 'Error'),
         },
@@ -471,7 +471,7 @@ describe('render – generator components with useResolve', () => {
       setId = si;
       const data = yield* useResolve(
         {
-          fn: () => {
+          fn: (_signal) => {
             fetchCount++;
             return id === 1 ? firstPromise : secondPromise;
           },
@@ -518,7 +518,7 @@ describe('render – generator components with useResolve', () => {
       setId = si;
       const data = yield* useResolve(
         {
-          fn: () => (id === 1 ? firstPromise : secondPromise),
+          fn: (_signal) => (id === 1 ? firstPromise : secondPromise),
           loading: createElement('span', { id: 'loading' }, 'Loading…'),
           error: createElement('span', null, 'Error'),
         },
@@ -543,6 +543,70 @@ describe('render – generator components with useResolve', () => {
     resolveFirst('user1');
     await firstPromise;
     expect(container.querySelector('#result')!.textContent).toBe('2:user2');
+  });
+
+  it('aborts the previous AbortSignal when deps change', async () => {
+    const abortedSignals: AbortSignal[] = [];
+    let setId: ((v: number) => void) | null = null;
+
+    function* DataComp() {
+      const [id, si] = yield* useState(1);
+      setId = si;
+      yield* useResolve(
+        {
+          fn: (signal) => {
+            signal.addEventListener('abort', () => abortedSignals.push(signal));
+            return new Promise(() => {}); // never resolves
+          },
+          loading: createElement('span', { id: 'loading' }, 'Loading…'),
+          error: createElement('span', null, 'Error'),
+        },
+        [id],
+      );
+      return createElement('span', {}, 'done');
+    }
+
+    render(createElement(DataComp as never, {}), container);
+    expect(abortedSignals).toHaveLength(0);
+
+    // Changing deps should abort the first signal and start a new fetch.
+    setId!(2);
+    expect(abortedSignals).toHaveLength(1);
+    expect(abortedSignals[0].aborted).toBe(true);
+  });
+
+  it('aborts the AbortSignal when the component unmounts', async () => {
+    let capturedSignal: AbortSignal | null = null;
+    let setShow: ((v: boolean) => void) | null = null;
+
+    function* Inner() {
+      yield* useResolve(
+        {
+          fn: (signal) => {
+            capturedSignal = signal;
+            return new Promise(() => {}); // never resolves
+          },
+          loading: createElement('span', { id: 'loading' }, 'Loading…'),
+          error: createElement('span', null, 'Error'),
+        },
+        [],
+      );
+      return createElement('span', {}, 'done');
+    }
+
+    function* Outer() {
+      const [show, ss] = yield* useState(true);
+      setShow = ss;
+      return show ? createElement(Inner as never, {}) : null;
+    }
+
+    render(createElement(Outer as never, {}), container);
+    expect(capturedSignal).not.toBeNull();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    // Unmount Inner by hiding it – the AbortSignal should be aborted.
+    setShow!(false);
+    expect(capturedSignal!.aborted).toBe(true);
   });
 });
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -35,6 +35,8 @@ export const USE_MEMO = Symbol('useMemo');
 /** @internal */
 export const USE_RESOLVE_RAW = Symbol('useResolveRaw');
 /** @internal */
+export const USE_RESOLVE = Symbol('useResolve');
+/** @internal */
 export const USE_RENDER = Symbol('useRender');
 
 // ---------------------------------------------------------------------------
@@ -194,8 +196,12 @@ export type Renderable = Child | AnyComponentFn;
 
 /** Options accepted by `useResolve`. */
 export interface UseResolveOptions<T> {
-  /** A factory that creates the promise. Called once per component instance (or when `deps` change). */
-  fn: () => Promise<T>;
+  /**
+   * A factory that creates the promise. Called once per component instance (or when `deps` change).
+   * The provided `AbortSignal` is aborted when `deps` change or the component unmounts — pass it
+   * to `fetch` or any other cancellable API to avoid stale responses.
+   */
+  fn: (signal: AbortSignal) => Promise<T>;
   /** Shown while the promise is pending. Can be a VNode or component function. */
   loading: Renderable;
   /** Shown when the promise rejects. Can be a VNode or component function. */
@@ -278,9 +284,10 @@ export function* useResolve<T>(
   options: UseResolveOptions<T>,
   deps: unknown[],
 ): Generator<unknown, T, unknown> {
-  // Directly yield the USE_MEMO descriptor — useMemo's overloads require deps
-  // as fn args, but here deps are captured by closure for change-detection only.
-  const promise = (yield { type: USE_MEMO, fn: options.fn, deps }) as Promise<T>;
+  // USE_RESOLVE handles both memoization and AbortController lifecycle.
+  // The renderer creates a new AbortController on first call or when deps change,
+  // passes its signal to fn, and aborts the previous controller automatically.
+  const promise = (yield { type: USE_RESOLVE, fn: options.fn, deps }) as Promise<T>;
   const { data, loading, error } = yield* useResolveRaw<T, unknown>(promise);
 
   if (loading) {

--- a/src/render.ts
+++ b/src/render.ts
@@ -14,6 +14,7 @@ import {
   USE_ID,
   USE_MEMO,
   USE_RESOLVE_RAW,
+  USE_RESOLVE,
   USE_RENDER,
   depsChanged,
   type ResolveRawResult,
@@ -211,6 +212,12 @@ interface GenInstance {
    * `useResolve` promise statuses are preserved.
    */
   hookStates: unknown[];
+  /**
+   * Per-hook-slot cleanup functions (parallel to `hookStates`).
+   * Called when the component unmounts or a hook resets its state (e.g.
+   * `useResolve` aborts its AbortController when deps change).
+   */
+  cleanupFns: ((() => void) | undefined)[];
 }
 
 /** Map from a generator component's host span to its instance. */
@@ -231,6 +238,7 @@ const HOOK_SYMBOLS = new Set<symbol>([
   USE_MEMO,
   USE_CONTEXT,
   USE_RESOLVE_RAW,
+  USE_RESOLVE,
   USE_RENDER,
 ]);
 
@@ -244,6 +252,24 @@ function isHookDescriptor(value: unknown): boolean {
 }
 
 /**
+ * Recursively call cleanup functions for a slot and all its descendants.
+ * Called when a slot is about to be replaced or removed from the DOM.
+ */
+function unmountSlot(slot: Slot): void {
+  for (const child of slot.childSlots) {
+    unmountSlot(child);
+  }
+  if (slot.genInstance) {
+    for (const child of slot.genInstance.slots) {
+      unmountSlot(child);
+    }
+    for (const fn of slot.genInstance.cleanupFns) {
+      fn?.();
+    }
+  }
+}
+
+/**
  * Process a single hook descriptor and return the value to send back to the
  * generator via `gen.next(value)`.
  */
@@ -251,6 +277,7 @@ function processOneDescriptor(
   descriptor: { type: symbol; [key: string]: unknown },
   hookIndex: number,
   hookStates: unknown[],
+  cleanupFns: ((() => void) | undefined)[],
   rerender: () => void,
   resume: () => void,
 ): unknown {
@@ -337,6 +364,29 @@ function processOneDescriptor(
       return { data: undefined, loading: true, error: undefined } as ResolveRawResult<unknown>;
     }
 
+    case USE_RESOLVE: {
+      type ResolveState = {
+        deps: unknown[];
+        promise: Promise<unknown>;
+        controller: AbortController;
+      };
+      const fn = descriptor['fn'] as (signal: AbortSignal) => Promise<unknown>;
+      const deps = descriptor['deps'] as unknown[];
+      const existing = hookStates[hookIndex] as ResolveState | undefined;
+
+      if (!existing || depsChanged(existing.deps, deps)) {
+        // Abort the previous controller before starting a new fetch.
+        existing?.controller.abort();
+        const controller = new AbortController();
+        const promise = fn(controller.signal);
+        hookStates[hookIndex] = { deps, promise, controller } satisfies ResolveState;
+        // Register cleanup so the controller is aborted on component unmount.
+        cleanupFns[hookIndex] = () => controller.abort();
+        return promise;
+      }
+      return existing.promise;
+    }
+
     case USE_RENDER: {
       const deps = descriptor['deps'] as unknown[];
       let slot = hookStates[hookIndex] as UseRenderState<unknown> | undefined;
@@ -385,6 +435,7 @@ function processOneDescriptor(
 function runHooks(
   gen: Generator<unknown, Child, unknown>,
   hookStates: unknown[],
+  cleanupFns: ((() => void) | undefined)[],
   rerender: () => void,
   resume: () => void,
 ): { vnode: Child; gen: Generator<unknown, Child, unknown> | null } {
@@ -393,7 +444,14 @@ function runHooks(
 
   while (!result.done && isHookDescriptor(result.value)) {
     const descriptor = result.value as { type: symbol; [key: string]: unknown };
-    const value = processOneDescriptor(descriptor, hookIndex++, hookStates, rerender, resume);
+    const value = processOneDescriptor(
+      descriptor,
+      hookIndex++,
+      hookStates,
+      cleanupFns,
+      rerender,
+      resume,
+    );
     result = gen.next(value);
   }
 
@@ -531,6 +589,7 @@ function mountGeneratorComponent(fn: GeneratorComponentFn, props: Record<string,
 
   const capturedCtx = _getCtxMap();
   const hookStates: unknown[] = [];
+  const cleanupFns: ((() => void) | undefined)[] = [];
 
   // `instance` is fully populated below before any external code can observe it.
   // eslint-disable-next-line prefer-const
@@ -578,7 +637,13 @@ function mountGeneratorComponent(fn: GeneratorComponentFn, props: Record<string,
     let vnode: Child;
     try {
       const gen = instance.fn(instance.props, rerender);
-      const { vnode: v, gen: newGen } = runHooks(gen, instance.hookStates, rerender, resume);
+      const { vnode: v, gen: newGen } = runHooks(
+        gen,
+        instance.hookStates,
+        instance.cleanupFns,
+        rerender,
+        resume,
+      );
       instance.gen = newGen;
       vnode = v;
     } finally {
@@ -594,10 +659,10 @@ function mountGeneratorComponent(fn: GeneratorComponentFn, props: Record<string,
   let initialVNode: Child;
   try {
     const gen = fn(props, rerender);
-    const { vnode, gen: initialGen } = runHooks(gen, hookStates, rerender, resume);
+    const { vnode, gen: initialGen } = runHooks(gen, hookStates, cleanupFns, rerender, resume);
     initialVNode = vnode;
     const { nodes, slots } = buildVNodeList([initialVNode]);
-    instance = { fn, gen: initialGen, props, host, capturedCtx, slots, hookStates };
+    instance = { fn, gen: initialGen, props, host, capturedCtx, slots, hookStates, cleanupFns };
     genInstanceMap.set(host, instance);
     for (const n of nodes) host.appendChild(n);
   } finally {
@@ -681,6 +746,7 @@ function reconcileSlots(parent: HTMLElement, prevSlots: Slot[], nextVNodes: Chil
     nextSlots.push(slot);
 
     if (replaced) {
+      if (prevSlot) unmountSlot(prevSlot);
       if (prevSlot && prevSlot.node.parentNode === parent) {
         parent.replaceChild(node, prevSlot.node);
       } else {
@@ -699,6 +765,7 @@ function reconcileSlots(parent: HTMLElement, prevSlots: Slot[], nextVNodes: Chil
   // Remove any extra old DOM nodes
   for (let i = flatNext.length; i < prevSlots.length; i++) {
     const old = prevSlots[i];
+    unmountSlot(old);
     if (old.node.parentNode === parent) {
       parent.removeChild(old.node);
     }


### PR DESCRIPTION
## Summary
`useResolveOptions.fn` now receives an `AbortSignal` as its first argument. The renderer creates a new `AbortController` each time `deps` change and aborts the previous one, preventing stale responses from updating the UI. The signal is also aborted when the component unmounts, enabling clean cancellation of any in-flight requests.

## Changes
- Added `USE_RESOLVE` symbol and dedicated handler in `render.ts` that owns the `AbortController` lifecycle
- Added `unmountSlot()` helper that recursively calls cleanup functions when a slot is replaced or removed from the DOM
- Added `cleanupFns: ((() => void) | undefined)[]` to `GenInstance` (parallel to `hookStates`)
- Changed `UseResolveOptions.fn` type from `() => Promise<T>` to `(signal: AbortSignal) => Promise<T>`
- Rewrote `useResolve` to yield a `USE_RESOLVE` descriptor instead of `USE_MEMO`, delegating abort management to the renderer
- Updated `DataFetcher` example to accept and honour the `AbortSignal`

## Testing
87 tests pass (2 new):
- `aborts the previous AbortSignal when deps change`
- `aborts the AbortSignal when the component unmounts`

## Lint and formatting
Prettier check passes on all modified files.

## Build
`npm run build` completes without errors.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)