### PR TITLE
refactor: replace Prettier with Biome, enable stricter TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    name: Lint, Test & Build
+    name: Test, Build & Format
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    name: Test, Build & Format
+    name: Lint, Test & Build
     runs-on: ubuntu-latest
 
     steps:
@@ -22,8 +22,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Format check
-        run: npm run format:check
+      - name: Lint & format check
+        run: npm run lint
 
       - name: Test
         run: npm test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "singleQuote": true,
-  "trailingComma": "all",
-  "printWidth": 100
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 **Before pushing code or opening a PR, you MUST execute this sequence in order:**
 
 1.  **Branch Sync:** `git checkout dev && git pull origin dev && git checkout -`
-2.  **Lint & Format:** `npm run format`
+2.  **Lint & Format:** `npm run lint:fix`
 3.  **Type Check & Build:** `npm run build`
 4.  **Unit Tests:** `npm test`
 5.  **Visual Tests:** `npm run test:visual`
@@ -48,7 +48,9 @@ yielderact is a minimal JSX UI library using JavaScript generator functions.
 - `npm run build` — Compile TS to `dist/`
 - `npm test` — Run Jest unit tests (jsdom)
 - `npm run test:visual` — Run Playwright visual tests
-- `npm run format` — Fix formatting with Prettier
+- `npm run lint` — Check lint & formatting (Biome)
+- `npm run lint:fix` — Auto-fix lint & formatting issues
+- `npm run format` — Auto-fix formatting only (Biome)
 - `npm test -- <path>` — Run specific test file
 
 ### 3. Creating a Pull Request
@@ -91,7 +93,8 @@ function* Counter(_props: object) {
 
 - **Self-Updating Documentation:** If you discover a "gotcha" or a more efficient way to run this project, update the "Non-Obvious Rules" or "Execution Policy" in this file immediately.
 - **NPM Script Policy:** Never use `npx`. Always use the existing `npm run` scripts to ensure version consistency.
-- **TypeScript:** Strictly typed; `any` is forbidden.
+- **Linting:** Biome (`biome.json`) handles linting and formatting. Prettier was removed.
+- **TypeScript:** Strictly typed; `any` is forbidden. `noUncheckedIndexedAccess` and `noPropertyAccessFromIndexSignature` are enabled.
 - **Special Props:** Always support the `$shown={boolean}` prop.
 - **Dependencies:** Zero-dependency goal.
 - **JSX Config:** `react-jsx` with `jsxImportSource: "yielderact"`.

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noConfusingVoidType": "error"
+      },
+      "complexity": {
+        "noExcessiveCognitiveComplexity": {
+          "level": "warn",
+          "options": { "maxAllowedComplexity": 15 }
+        },
+        "noForEach": "warn",
+        "useFlatMap": "error",
+        "useLiteralKeys": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "useConst": "error",
+        "noParameterAssign": "error",
+        "useExportType": "error",
+        "useImportType": "error",
+        "useNodejsImportProtocol": "off"
+      },
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error",
+        "useExhaustiveDependencies": "off",
+        "useYield": "off"
+      },
+      "performance": {
+        "noAccumulatingSpread": "warn"
+      },
+      "a11y": {
+        "useButtonType": "off"
+      }
+    }
+  },
+  "files": {
+    "ignoreUnknown": true
+  }
+}

--- a/examples/playwright.config.ts
+++ b/examples/playwright.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
   fullyParallel: true,
   retries: process.env.CI ? 2 : 0,
-  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report" }]],
 
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: "http://localhost:5173",
     headless: true,
-    screenshot: 'only-on-failure',
+    screenshot: "only-on-failure",
   },
 
   /**
@@ -17,24 +17,24 @@ export default defineConfig({
    * The server is shut down automatically after all tests complete.
    */
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:5173',
+    command: "npm run dev",
+    url: "http://localhost:5173",
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,
   },
 
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
     },
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
   ],
 });

--- a/examples/src/components/AbortSignalEffectDemo.tsx
+++ b/examples/src/components/AbortSignalEffectDemo.tsx
@@ -8,19 +8,19 @@
  * increments it directly.
  * Unmounting the panel aborts all signals.
  */
-import { $state, $effect } from 'yielderact';
+import { $effect, $state } from "yielderact";
 
 function* SignalRow({ userId, activeId }: { userId: number; activeId: number }) {
-  const [status, setStatus] = yield* $state<string>('idle');
+  const [status, setStatus] = yield* $state<string>("idle");
   const [abortCount, setAbortCount] = yield* $state(0);
 
   yield* $effect(
     (signal) => {
       if (activeId !== userId) {
-        setStatus('inactive');
+        setStatus("inactive");
         return;
       }
-      setStatus('polling');
+      setStatus("polling");
 
       let stopped = false;
       const poll = async () => {
@@ -31,7 +31,7 @@ function* SignalRow({ userId, activeId }: { userId: number; activeId: number }) 
           await new Promise<void>((resolve, reject) => {
             const timer = setTimeout(resolve, 400);
             signal.addEventListener(
-              'abort',
+              "abort",
               () => {
                 clearTimeout(timer);
                 reject(signal.reason);
@@ -47,11 +47,11 @@ function* SignalRow({ userId, activeId }: { userId: number; activeId: number }) 
       poll();
 
       signal.addEventListener(
-        'abort',
+        "abort",
         () => {
           stopped = true;
           setAbortCount((c) => c + 1);
-          setStatus('aborted');
+          setStatus("aborted");
         },
         { once: true },
       );
@@ -65,7 +65,7 @@ function* SignalRow({ userId, activeId }: { userId: number; activeId: number }) 
   return (
     <tr
       data-testid={`signal-row-${userId}`}
-      style={{ background: isActive ? '#e8f5e9' : 'transparent' }}
+      style={{ background: isActive ? "#e8f5e9" : "transparent" }}
     >
       <td>
         <strong data-testid={`row-uid-${userId}`}>User {userId}</strong>
@@ -73,7 +73,7 @@ function* SignalRow({ userId, activeId }: { userId: number; activeId: number }) 
       <td data-testid={`row-status-${userId}`}>{status}</td>
       <td
         data-testid={`row-abort-count-${userId}`}
-        style={{ color: abortCount > 0 ? 'red' : 'green' }}
+        style={{ color: abortCount > 0 ? "red" : "green" }}
       >
         {abortCount}
       </td>
@@ -97,13 +97,13 @@ export function* AbortSignalEffectDemo() {
         function needed. The abort count tracks how many times each signal has been aborted.
       </p>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
         {[1, 2, 3].map((n) => (
           <button
             $key={n}
             data-testid={`user-btn-${n}`}
             onClick={() => setActiveId(n)}
-            style={{ fontWeight: activeId === n ? 'bold' : 'normal' }}
+            style={{ fontWeight: activeId === n ? "bold" : "normal" }}
           >
             User {n}
           </button>
@@ -111,7 +111,7 @@ export function* AbortSignalEffectDemo() {
       </div>
 
       <label
-        style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.75rem' }}
+        style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.75rem" }}
       >
         <input
           type="checkbox"
@@ -124,14 +124,14 @@ export function* AbortSignalEffectDemo() {
 
       <table
         $shown={showPanel}
-        style={{ borderCollapse: 'collapse', width: '100%' }}
+        style={{ borderCollapse: "collapse", width: "100%" }}
         data-testid="signal-table"
       >
         <thead>
           <tr>
-            <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>User</th>
-            <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>Status</th>
-            <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem' }}>Abort count</th>
+            <th style={{ textAlign: "left", padding: "0.25rem 0.5rem" }}>User</th>
+            <th style={{ textAlign: "left", padding: "0.25rem 0.5rem" }}>Status</th>
+            <th style={{ textAlign: "left", padding: "0.25rem 0.5rem" }}>Abort count</th>
           </tr>
         </thead>
         <tbody>

--- a/examples/src/components/ConfirmDialog.tsx
+++ b/examples/src/components/ConfirmDialog.tsx
@@ -5,40 +5,40 @@
  *  • Variant 1: JSX passed directly to $render; the child uses $resume.
  *  • Variant 2: Inline render function receives resume as a prop.
  */
-import { $render, $resume, $ref, $state } from 'yielderact';
+import { $ref, $render, $resume, $state } from "yielderact";
 
 // ---------------------------------------------------------------------------
 // Variant 1 – child component uses $resume
 // ---------------------------------------------------------------------------
 
-type Answer = 'ACCEPTED' | 'REJECTED' | 'NONE';
+type Answer = "ACCEPTED" | "REJECTED" | "NONE";
 
 function* ProceedDialog({ acceptText, rejectText }: { acceptText: string; rejectText: string }) {
   const resume = yield* $resume<Answer>();
   return (
-    <div style={{ display: 'flex', gap: '0.5rem' }}>
+    <div style={{ display: "flex", gap: "0.5rem" }}>
       <button
-        onClick={() => resume('ACCEPTED')}
+        onClick={() => resume("ACCEPTED")}
         style={{
-          padding: '0.4rem 1rem',
-          background: '#0070f3',
-          color: '#fff',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: 'pointer',
+          padding: "0.4rem 1rem",
+          background: "#0070f3",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
         }}
       >
         {acceptText}
       </button>
       <button
-        onClick={() => resume('REJECTED')}
+        onClick={() => resume("REJECTED")}
         style={{
-          padding: '0.4rem 1rem',
-          background: '#e00',
-          color: '#fff',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: 'pointer',
+          padding: "0.4rem 1rem",
+          background: "#e00",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
         }}
       >
         {rejectText}
@@ -48,10 +48,10 @@ function* ProceedDialog({ acceptText, rejectText }: { acceptText: string; reject
 }
 
 function* Variant1() {
-  const answer = yield* $ref<Answer>('NONE');
+  const answer = yield* $ref<Answer>("NONE");
   const [, rerender] = yield* $state(0);
 
-  while (answer.current === 'NONE') {
+  while (answer.current === "NONE") {
     answer.current = yield* $render<Answer>(
       <ProceedDialog acceptText="Accept" rejectText="Reject" />,
     );
@@ -59,13 +59,13 @@ function* Variant1() {
 
   return (
     <p>
-      Variant 1 result: <strong>{answer.current}</strong>{' '}
+      Variant 1 result: <strong>{answer.current}</strong>{" "}
       <button
         onClick={() => {
-          answer.current = 'NONE';
+          answer.current = "NONE";
           rerender((n) => n + 1);
         }}
-        style={{ marginLeft: '0.5rem', cursor: 'pointer' }}
+        style={{ marginLeft: "0.5rem", cursor: "pointer" }}
       >
         Reset
       </button>
@@ -78,35 +78,35 @@ function* Variant1() {
 // ---------------------------------------------------------------------------
 
 function* Variant2() {
-  const answer = yield* $ref<Answer>('NONE');
+  const answer = yield* $ref<Answer>("NONE");
   const [, rerender] = yield* $state(0);
 
-  while (answer.current === 'NONE') {
+  while (answer.current === "NONE") {
     answer.current = yield* $render<Answer>(
       ({ resume }) => (
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
           <button
-            onClick={() => resume('ACCEPTED')}
+            onClick={() => resume("ACCEPTED")}
             style={{
-              padding: '0.4rem 1rem',
-              background: '#0070f3',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
+              padding: "0.4rem 1rem",
+              background: "#0070f3",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
             }}
           >
             Accept (inline)
           </button>
           <button
-            onClick={() => resume('REJECTED')}
+            onClick={() => resume("REJECTED")}
             style={{
-              padding: '0.4rem 1rem',
-              background: '#e00',
-              color: '#fff',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer',
+              padding: "0.4rem 1rem",
+              background: "#e00",
+              color: "#fff",
+              border: "none",
+              borderRadius: "4px",
+              cursor: "pointer",
             }}
           >
             Reject (inline)
@@ -119,13 +119,13 @@ function* Variant2() {
 
   return (
     <p>
-      Variant 2 result: <strong>{answer.current}</strong>{' '}
+      Variant 2 result: <strong>{answer.current}</strong>{" "}
       <button
         onClick={() => {
-          answer.current = 'NONE';
+          answer.current = "NONE";
           rerender((n) => n + 1);
         }}
-        style={{ marginLeft: '0.5rem', cursor: 'pointer' }}
+        style={{ marginLeft: "0.5rem", cursor: "pointer" }}
       >
         Reset
       </button>
@@ -141,7 +141,7 @@ export function* ConfirmDialog() {
   return (
     <div>
       <h2>$render / $resume</h2>
-      <p style={{ color: '#555', marginBottom: '1rem' }}>
+      <p style={{ color: "#555", marginBottom: "1rem" }}>
         Generator components can pause and wait for user interaction using <code>$render</code>. The
         resume callback unblocks the generator and returns the value to the caller.
       </p>

--- a/examples/src/components/ContextDemo.tsx
+++ b/examples/src/components/ContextDemo.tsx
@@ -8,36 +8,36 @@
  *  4. Cross-subtree isolation: two sibling Providers for the same context
  *     must not interfere with each other.
  */
-import { createContext, $context, $state } from 'yielderact';
+import { $context, $state, createContext } from "yielderact";
 
 // ── Context definitions ────────────────────────────────────────────────────
 
-type Theme = 'light' | 'dark';
-type Locale = 'en' | 'fi';
+type Theme = "light" | "dark";
+type Locale = "en" | "fi";
 
-const ThemeCtx = createContext<Theme>('light');
-const LocaleCtx = createContext<Locale>('en');
+const ThemeCtx = createContext<Theme>("light");
+const LocaleCtx = createContext<Locale>("en");
 
 // ── Shared style helpers ───────────────────────────────────────────────────
 
 const themeStyles: Record<Theme, { background: string; color: string; border: string }> = {
-  light: { background: '#f9f9f9', color: '#111', border: '1px solid #ccc' },
-  dark: { background: '#222', color: '#eee', border: '1px solid #555' },
+  light: { background: "#f9f9f9", color: "#111", border: "1px solid #ccc" },
+  dark: { background: "#222", color: "#eee", border: "1px solid #555" },
 };
 
 // ── Small leaf components ─────────────────────────────────────────────────
 
 /** Reads ThemeCtx and displays the current value. */
-function* ThemeBadge(props: { 'data-testid'?: string }) {
+function* ThemeBadge(props: { "data-testid"?: string }) {
   const theme = yield* $context(ThemeCtx);
   const s = themeStyles[theme];
   return (
     <span
-      data-testid={props['data-testid'] ?? 'theme-badge'}
+      data-testid={props["data-testid"] ?? "theme-badge"}
       style={{
-        padding: '0.2rem 0.5rem',
-        borderRadius: '4px',
-        fontSize: '0.85rem',
+        padding: "0.2rem 0.5rem",
+        borderRadius: "4px",
+        fontSize: "0.85rem",
         background: s.background,
         color: s.color,
         border: s.border,
@@ -52,7 +52,7 @@ function* ThemeBadge(props: { 'data-testid'?: string }) {
 function* LocaleBadge() {
   const locale = yield* $context(LocaleCtx);
   return (
-    <span data-testid="locale-badge" style={{ padding: '0.2rem 0.5rem', fontSize: '0.85rem' }}>
+    <span data-testid="locale-badge" style={{ padding: "0.2rem 0.5rem", fontSize: "0.85rem" }}>
       {locale}
     </span>
   );
@@ -79,7 +79,7 @@ function* StatefulConsumer() {
   const theme = yield* $context(ThemeCtx);
   const [count, setCount] = yield* $state(0);
   return (
-    <div data-testid="stateful-consumer" style={{ display: 'flex', gap: '0.5rem' }}>
+    <div data-testid="stateful-consumer" style={{ display: "flex", gap: "0.5rem" }}>
       <span data-testid="stateful-theme">{theme}</span>
       <span data-testid="stateful-count">{count}</span>
       <button data-testid="stateful-inc" onClick={() => setCount((c) => c + 1)}>
@@ -110,34 +110,34 @@ function* SiblingConsumerB() {
 }
 
 function* SiblingProvidersDemo() {
-  const [valA, setValA] = yield* $state<Theme>('light');
-  const [valB, setValB] = yield* $state<Theme>('dark');
+  const [valA, setValA] = yield* $state<Theme>("light");
+  const [valB, setValB] = yield* $state<Theme>("dark");
 
   return (
     <div>
       <h3>4 · Sibling providers are isolated</h3>
-      <p style={{ fontSize: '0.9rem', color: '#555', marginBottom: '0.5rem' }}>
+      <p style={{ fontSize: "0.9rem", color: "#555", marginBottom: "0.5rem" }}>
         Two sibling subtrees provide different values for the same context. They must not interfere.
       </p>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.5rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.5rem" }}>
         <button
           data-testid="toggle-sibling-a"
-          onClick={() => setValA((v) => (v === 'light' ? 'dark' : 'light'))}
+          onClick={() => setValA((v) => (v === "light" ? "dark" : "light"))}
         >
           Toggle A (currently: {valA})
         </button>
         <button
           data-testid="toggle-sibling-b"
-          onClick={() => setValB((v) => (v === 'light' ? 'dark' : 'light'))}
+          onClick={() => setValB((v) => (v === "light" ? "dark" : "light"))}
         >
           Toggle B (currently: {valB})
         </button>
       </div>
-      <div style={{ display: 'flex', gap: '1rem' }}>
+      <div style={{ display: "flex", gap: "1rem" }}>
         <ThemeCtx.Provider value={valA}>
           <div
             data-testid="sibling-panel-a"
-            style={{ padding: '0.5rem', border: '1px solid #ccc' }}
+            style={{ padding: "0.5rem", border: "1px solid #ccc" }}
           >
             Subtree A: <SiblingConsumerA />
           </div>
@@ -145,7 +145,7 @@ function* SiblingProvidersDemo() {
         <ThemeCtx.Provider value={valB}>
           <div
             data-testid="sibling-panel-b"
-            style={{ padding: '0.5rem', border: '1px solid #ccc' }}
+            style={{ padding: "0.5rem", border: "1px solid #ccc" }}
           >
             Subtree B: <SiblingConsumerB />
           </div>
@@ -158,24 +158,24 @@ function* SiblingProvidersDemo() {
 // ── Root demo component ────────────────────────────────────────────────────
 
 export function* ContextDemo() {
-  const [theme, setTheme] = yield* $state<Theme>('light');
-  const [locale, setLocale] = yield* $state<Locale>('en');
+  const [theme, setTheme] = yield* $state<Theme>("light");
+  const [locale, setLocale] = yield* $state<Locale>("en");
 
   return (
     <section aria-label="Context demo">
       <h2>Context Demo</h2>
 
       {/* ── Controls (shared for parts 1–3) ──────────────────────── */}
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
         <button
           data-testid="toggle-theme-btn"
-          onClick={() => setTheme((t) => (t === 'light' ? 'dark' : 'light'))}
+          onClick={() => setTheme((t) => (t === "light" ? "dark" : "light"))}
         >
           Toggle theme
         </button>
         <button
           data-testid="toggle-locale-btn"
-          onClick={() => setLocale((l) => (l === 'en' ? 'fi' : 'en'))}
+          onClick={() => setLocale((l) => (l === "en" ? "fi" : "en"))}
         >
           Toggle locale
         </button>
@@ -183,7 +183,7 @@ export function* ContextDemo() {
 
       {/* ── Part 1: two independent contexts ─────────────────────── */}
       <h3>1 · Two independent contexts</h3>
-      <p style={{ fontSize: '0.9rem', color: '#555', marginBottom: '0.5rem' }}>
+      <p style={{ fontSize: "0.9rem", color: "#555", marginBottom: "0.5rem" }}>
         Theme and Locale are separate contexts. Toggling one must not affect the other.
       </p>
       <ThemeCtx.Provider value={theme}>
@@ -191,10 +191,10 @@ export function* ContextDemo() {
           <div
             data-testid="independent-panel"
             style={{
-              padding: '0.75rem',
-              borderRadius: '6px',
+              padding: "0.75rem",
+              borderRadius: "6px",
               ...themeStyles[theme],
-              marginBottom: '1rem',
+              marginBottom: "1rem",
             }}
           >
             Theme: <ThemeBadge data-testid="theme-badge" /> &nbsp; Locale: <LocaleBadge /> &nbsp;
@@ -205,18 +205,18 @@ export function* ContextDemo() {
 
       {/* ── Part 2: inner Provider shadows outer ──────────────────── */}
       <h3>2 · Nested Provider override</h3>
-      <p style={{ fontSize: '0.9rem', color: '#555', marginBottom: '0.5rem' }}>
+      <p style={{ fontSize: "0.9rem", color: "#555", marginBottom: "0.5rem" }}>
         The outer theme is <em>{theme}</em>. An inner Provider hard-codes the theme to <em>dark</em>
         . The inner card must always display <em>dark</em>.
       </p>
       <ThemeCtx.Provider value={theme}>
-        <div data-testid="outer-card" style={{ padding: '0.5rem', ...themeStyles[theme] }}>
+        <div data-testid="outer-card" style={{ padding: "0.5rem", ...themeStyles[theme] }}>
           <span>Outer card – theme: </span>
           <ThemeBadge data-testid="outer-theme-badge" />
           <ThemeCtx.Provider value="dark">
             <div
               data-testid="inner-card"
-              style={{ marginTop: '0.5rem', padding: '0.5rem', ...themeStyles['dark'] }}
+              style={{ marginTop: "0.5rem", padding: "0.5rem", ...themeStyles["dark"] }}
             >
               <span>Inner card (always dark) – theme: </span>
               <ThemeBadge data-testid="inner-theme-badge" />
@@ -227,7 +227,7 @@ export function* ContextDemo() {
 
       {/* ── Part 3: state preserved across context updates ────────── */}
       <h3>3 · State preserved across context updates</h3>
-      <p style={{ fontSize: '0.9rem', color: '#555', marginBottom: '0.5rem' }}>
+      <p style={{ fontSize: "0.9rem", color: "#555", marginBottom: "0.5rem" }}>
         Increment the counter, then toggle the outer theme. The counter must keep its value.
       </p>
       <ThemeCtx.Provider value={theme}>

--- a/examples/src/components/Counter.tsx
+++ b/examples/src/components/Counter.tsx
@@ -2,7 +2,7 @@
  * Counter – a generator component demonstrating stateful rendering with
  * `yield* $state` and returning JSX.
  */
-import { render, $state, $id } from 'yielderact';
+import { $id, $state, render } from "yielderact";
 
 export function* Counter() {
   const decrementId = yield* $id();
@@ -19,7 +19,7 @@ export function* Counter() {
         A generator component keeps state via <code>yield* $state</code>. Each call to the setter
         re-runs the component body and reconciles the DOM.
       </p>
-      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+      <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
         <button id={decrementId} data-testid="decrement-btn" onClick={() => setCount(count - 1)}>
           −
         </button>
@@ -33,7 +33,7 @@ export function* Counter() {
           id={resetId}
           data-testid="reset-btn"
           onClick={() => setCount(0)}
-          style={{ marginLeft: '0.5rem' }}
+          style={{ marginLeft: "0.5rem" }}
         >
           Reset
         </button>

--- a/examples/src/components/DataFetcher.tsx
+++ b/examples/src/components/DataFetcher.tsx
@@ -6,7 +6,7 @@
  * if it rejects).  Once resolved, execution continues and the component
  * returns its final JSX.
  */
-import { render, $resolve, $resolveRaw, $memo, $id, $state } from 'yielderact';
+import { $id, $memo, $resolve, $resolveRaw, $state, render } from "yielderact";
 
 interface User {
   id: number;
@@ -18,18 +18,18 @@ interface User {
 async function fetchUser(signal: AbortSignal): Promise<User> {
   await new Promise((resolve, reject) => {
     const t = setTimeout(resolve, 1500);
-    signal.addEventListener('abort', () => {
+    signal.addEventListener("abort", () => {
       clearTimeout(t);
-      reject(new DOMException('Aborted', 'AbortError'));
+      reject(new DOMException("Aborted", "AbortError"));
     });
   });
-  return { id: 1, name: 'Jane Doe', email: 'jane@example.com' };
+  return { id: 1, name: "Jane Doe", email: "jane@example.com" };
 }
 
 function* Spinner() {
   const id = yield* $id();
   return (
-    <p id={id} data-testid="loading-message" style={{ color: '#888', fontStyle: 'italic' }}>
+    <p id={id} data-testid="loading-message" style={{ color: "#888", fontStyle: "italic" }}>
       Loading user data…
     </p>
   );
@@ -38,7 +38,7 @@ function* Spinner() {
 function* ErrorMessage() {
   const id = yield* $id();
   return (
-    <p id={id} data-testid="error-message" style={{ color: '#c00' }}>
+    <p id={id} data-testid="error-message" style={{ color: "#c00" }}>
       Failed to load data. Please try again.
     </p>
   );
@@ -67,10 +67,10 @@ export function* DataFetcher() {
         id={userDataId}
         data-testid="user-data"
         style={{
-          padding: '0.75rem',
-          background: '#f5f5f5',
-          borderRadius: '4px',
-          fontFamily: 'monospace',
+          padding: "0.75rem",
+          background: "#f5f5f5",
+          borderRadius: "4px",
+          fontFamily: "monospace",
         }}
       >
         <div>
@@ -90,7 +90,7 @@ export function* DataFetcher() {
 
 async function fetchPost(id: number): Promise<{ id: number; title: string; body: string }> {
   await new Promise((resolve) => setTimeout(resolve, 800));
-  if (id === 0) throw new Error('Invalid post ID');
+  if (id === 0) throw new Error("Invalid post ID");
   return { id, title: `Post #${id}`, body: `This is the content of post number ${id}.` };
 }
 
@@ -103,7 +103,7 @@ export function* ResolveRawDemo() {
   >(promise);
 
   return (
-    <section aria-label="$resolveRaw demo" style={{ marginTop: '2rem' }}>
+    <section aria-label="$resolveRaw demo" style={{ marginTop: "2rem" }}>
       <h2>
         <code>$resolveRaw</code>
       </h2>
@@ -111,31 +111,31 @@ export function* ResolveRawDemo() {
         Low-level async hook — returns <code>{`{ data, loading, error }`}</code> directly so the
         component controls rendering at each stage.
       </p>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
         {[1, 2, 3, 0].map((id) => (
           <button
             $key={id}
             data-testid={`post-btn-${id}`}
             onClick={() => setPostId(id)}
-            style={{ fontWeight: postId === id ? 'bold' : 'normal' }}
+            style={{ fontWeight: postId === id ? "bold" : "normal" }}
           >
-            {id === 0 ? 'Error' : `Post ${id}`}
+            {id === 0 ? "Error" : `Post ${id}`}
           </button>
         ))}
       </div>
-      <p $shown={loading} data-testid="raw-loading" style={{ color: '#888', fontStyle: 'italic' }}>
+      <p $shown={loading} data-testid="raw-loading" style={{ color: "#888", fontStyle: "italic" }}>
         Loading…
       </p>
-      <p $shown={!!error} data-testid="raw-error" style={{ color: '#c00' }}>
+      <p $shown={!!error} data-testid="raw-error" style={{ color: "#c00" }}>
         Error: {error?.message}
       </p>
       <div
         $shown={!!data}
         data-testid="raw-data"
-        style={{ padding: '0.75rem', background: '#f5f5f5', borderRadius: '4px' }}
+        style={{ padding: "0.75rem", background: "#f5f5f5", borderRadius: "4px" }}
       >
         <strong>{data?.title}</strong>
-        <p style={{ margin: '0.4rem 0 0' }}>{data?.body}</p>
+        <p style={{ margin: "0.4rem 0 0" }}>{data?.body}</p>
       </div>
     </section>
   );

--- a/examples/src/components/EffectDemo.tsx
+++ b/examples/src/components/EffectDemo.tsx
@@ -6,7 +6,7 @@
  *   2. A log of effect / cleanup calls to make the lifecycle visible.
  *   3. Toggling the component on/off to observe cleanup on unmount.
  */
-import { $state, $effect } from 'yielderact';
+import { $effect, $state } from "yielderact";
 
 function* Timer() {
   const [tick, setTick] = yield* $state(0);
@@ -32,7 +32,7 @@ function* LifecycleLog({ id }: { id: number }) {
   }, [id]);
 
   return (
-    <ul data-testid="lifecycle-log" style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
+    <ul data-testid="lifecycle-log" style={{ fontFamily: "monospace", fontSize: "0.85rem" }}>
       {log.map((entry, i) => (
         <li $key={i}>{entry}</li>
       ))}
@@ -52,31 +52,31 @@ export function* EffectDemo() {
 
       <h3>1. Interval timer (effect with cleanup)</h3>
       <p>
-        The timer starts an <code>setInterval</code> in a <code>$effect</code> with <code>[]</code>{' '}
+        The timer starts an <code>setInterval</code> in a <code>$effect</code> with <code>[]</code>{" "}
         deps. The interval is cleared when the component unmounts.
       </p>
       <label
-        style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.5rem' }}
+        style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.5rem" }}
       >
         <input type="checkbox" checked={showTimer} onChange={() => setShowTimer((v) => !v)} />
         Show timer
       </label>
       <Timer $shown={showTimer} />
 
-      <hr style={{ margin: '1.5rem 0' }} />
+      <hr style={{ margin: "1.5rem 0" }} />
 
       <h3>2. Lifecycle log (effect re-runs when deps change)</h3>
       <p>
         Each button changes <code>id</code>. The effect logs ▶ on run and ■ cleanup before the next
         run.
       </p>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
         {[1, 2, 3].map((n) => (
           <button
             $key={n}
             data-testid={`id-btn-${n}`}
             onClick={() => setLogId(n)}
-            style={{ fontWeight: logId === n ? 'bold' : 'normal' }}
+            style={{ fontWeight: logId === n ? "bold" : "normal" }}
           >
             id = {n}
           </button>

--- a/examples/src/components/HooksShowcase.tsx
+++ b/examples/src/components/HooksShowcase.tsx
@@ -6,28 +6,28 @@
  *  • $ref  – tracks how many times the component has rendered without
  *            triggering a re-render on mutation.
  */
-import { $id, $memo, $ref, $state } from 'yielderact';
+import { $id, $memo, $ref, $state } from "yielderact";
 
 const FRUITS = [
-  'Apple',
-  'Banana',
-  'Cherry',
-  'Date',
-  'Elderberry',
-  'Fig',
-  'Grape',
-  'Honeydew',
-  'Kiwi',
-  'Lemon',
-  'Mango',
-  'Nectarine',
+  "Apple",
+  "Banana",
+  "Cherry",
+  "Date",
+  "Elderberry",
+  "Fig",
+  "Grape",
+  "Honeydew",
+  "Kiwi",
+  "Lemon",
+  "Mango",
+  "Nectarine",
 ];
 
 export function* HooksShowcase() {
   // $id: stable unique ID used to associate the <label> with the <input>
   const inputId = yield* $id();
 
-  const [query, setQuery] = yield* $state('');
+  const [query, setQuery] = yield* $state("");
 
   // $ref: mutable counter that persists across renders without causing them
   const renderCount = yield* $ref(0);
@@ -51,8 +51,8 @@ export function* HooksShowcase() {
       </p>
 
       {/* $id: the generated id wires the <label> to the <input> */}
-      <div style={{ marginBottom: '0.75rem' }}>
-        <label data-testid="hooks-search-label" htmlFor={inputId} style={{ marginRight: '0.5rem' }}>
+      <div style={{ marginBottom: "0.75rem" }}>
+        <label data-testid="hooks-search-label" htmlFor={inputId} style={{ marginRight: "0.5rem" }}>
           Search fruits:
         </label>
         <input
@@ -61,14 +61,14 @@ export function* HooksShowcase() {
           type="text"
           value={query}
           placeholder="Type to filter…"
-          onInput={(e) => setQuery(e.currentTarget?.value ?? '')}
+          onInput={(e) => setQuery(e.currentTarget?.value ?? "")}
         />
       </div>
 
       {/* $memo: filtered list, only recomputed when query changes */}
       <ul
         data-testid="hooks-fruit-list"
-        style={{ listStyle: 'disc', paddingLeft: '1.25rem', margin: '0 0 0.5rem' }}
+        style={{ listStyle: "disc", paddingLeft: "1.25rem", margin: "0 0 0.5rem" }}
       >
         {filtered.map((fruit) => (
           <li $key={fruit} data-testid={`fruit-${fruit.toLowerCase()}`}>
@@ -76,16 +76,16 @@ export function* HooksShowcase() {
           </li>
         ))}
       </ul>
-      <p $shown={filtered.length === 0} data-testid="hooks-no-results" style={{ color: '#888' }}>
+      <p $shown={filtered.length === 0} data-testid="hooks-no-results" style={{ color: "#888" }}>
         No fruits match "{query}".
       </p>
 
       {/* $ref: render count is tracked without triggering a re-render */}
       <p
         data-testid="hooks-render-count"
-        style={{ marginTop: '0.75rem', color: '#666', fontSize: '0.85rem' }}
+        style={{ marginTop: "0.75rem", color: "#666", fontSize: "0.85rem" }}
       >
-        Component has rendered {renderCount.current} time(s) — tracked with <code>$ref</code>{' '}
+        Component has rendered {renderCount.current} time(s) — tracked with <code>$ref</code>{" "}
         (mutations do not cause a re-render).
       </p>
     </section>

--- a/examples/src/components/KeyShuffleDemo.tsx
+++ b/examples/src/components/KeyShuffleDemo.tsx
@@ -5,7 +5,7 @@
  * recreating them, and that generator component state is preserved
  * across reorders.
  */
-import { $state, $ref } from 'yielderact';
+import { $ref, $state } from "yielderact";
 
 /* ── Stateful counter item (generator component) ── */
 
@@ -19,17 +19,17 @@ function* CounterItem({ id, color }: { id: string; color: string }) {
       data-testid={`item-${id}`}
       data-id={id}
       style={{
-        display: 'flex',
-        gap: '0.5rem',
-        alignItems: 'center',
-        padding: '0.4rem 0.75rem',
-        marginBottom: '0.35rem',
-        borderRadius: '4px',
+        display: "flex",
+        gap: "0.5rem",
+        alignItems: "center",
+        padding: "0.4rem 0.75rem",
+        marginBottom: "0.35rem",
+        borderRadius: "4px",
         border: `2px solid ${color}`,
-        background: '#fafafa',
+        background: "#fafafa",
       }}
     >
-      <strong style={{ minWidth: '1.5rem' }}>{id}</strong>
+      <strong style={{ minWidth: "1.5rem" }}>{id}</strong>
       <span data-testid={`count-${id}`}>{count}</span>
       <button data-testid={`inc-${id}`} onClick={() => setCount(count + 1)}>
         +
@@ -45,13 +45,13 @@ function PlainTag({ label }: { label: string }) {
     <span
       data-testid={`tag-${label}`}
       style={{
-        display: 'inline-block',
-        padding: '0.25rem 0.6rem',
-        marginRight: '0.35rem',
-        marginBottom: '0.35rem',
-        borderRadius: '12px',
-        background: '#e0e7ff',
-        fontSize: '0.85rem',
+        display: "inline-block",
+        padding: "0.25rem 0.6rem",
+        marginRight: "0.35rem",
+        marginBottom: "0.35rem",
+        borderRadius: "12px",
+        background: "#e0e7ff",
+        fontSize: "0.85rem",
       }}
     >
       {label}
@@ -62,14 +62,14 @@ function PlainTag({ label }: { label: string }) {
 /* ── Helpers ── */
 
 const COLORS: Record<string, string> = {
-  A: '#e74c3c',
-  B: '#2ecc71',
-  C: '#3498db',
-  D: '#f39c12',
-  E: '#9b59b6',
+  A: "#e74c3c",
+  B: "#2ecc71",
+  C: "#3498db",
+  D: "#f39c12",
+  E: "#9b59b6",
 };
 
-const ALL_IDS = ['A', 'B', 'C', 'D', 'E'];
+const ALL_IDS = ["A", "B", "C", "D", "E"];
 
 function shuffle<T>(arr: T[]): T[] {
   const copy = [...arr];
@@ -83,9 +83,9 @@ function shuffle<T>(arr: T[]): T[] {
 /* ── Main demo ── */
 
 export function* KeyShuffleDemo() {
-  const [order, setOrder] = yield* $state(['A', 'B', 'C']);
-  const [tagOrder, setTagOrder] = yield* $state(['red', 'green', 'blue']);
-  const [elemOrder, setElemOrder] = yield* $state(['first', 'second', 'third']);
+  const [order, setOrder] = yield* $state(["A", "B", "C"]);
+  const [tagOrder, setTagOrder] = yield* $state(["red", "green", "blue"]);
+  const [elemOrder, setElemOrder] = yield* $state(["first", "second", "third"]);
 
   return (
     <section aria-label="Key shuffle example">
@@ -97,7 +97,7 @@ export function* KeyShuffleDemo() {
 
       {/* ── Generator component list ── */}
       <h3>Generator components (stateful)</h3>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem', flexWrap: 'wrap' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem", flexWrap: "wrap" }}>
         <button data-testid="shuffle-btn" onClick={() => setOrder(shuffle(order))}>
           Shuffle
         </button>
@@ -123,19 +123,19 @@ export function* KeyShuffleDemo() {
         </button>
       </div>
       <div data-testid="generator-list">
-        <CounterItem id={'a'} color={'blue'} />
+        <CounterItem id={"a"} color={"blue"} />
         {order.map((id) => (
-          <CounterItem $key={id} id={id} color={COLORS[id] ?? '#999'} />
+          <CounterItem $key={id} id={id} color={COLORS[id] ?? "#999"} />
         ))}
-        <CounterItem id={'b'} color={'green'} />
+        <CounterItem id={"b"} color={"green"} />
       </div>
-      <p data-testid="generator-order" style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
-        Order: {order.join(', ')}
+      <p data-testid="generator-order" style={{ fontFamily: "monospace", fontSize: "0.85rem" }}>
+        Order: {order.join(", ")}
       </p>
 
       {/* ── Plain function component list ── */}
       <h3>Plain function components</h3>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
         <button data-testid="tag-reverse-btn" onClick={() => setTagOrder([...tagOrder].reverse())}>
           Reverse tags
         </button>
@@ -145,13 +145,13 @@ export function* KeyShuffleDemo() {
           <PlainTag $key={label} label={label} />
         ))}
       </div>
-      <p data-testid="tag-order" style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
-        Order: {tagOrder.join(', ')}
+      <p data-testid="tag-order" style={{ fontFamily: "monospace", fontSize: "0.85rem" }}>
+        Order: {tagOrder.join(", ")}
       </p>
 
       {/* ── Keyed HTML elements ── */}
       <h3>Keyed HTML elements</h3>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
         <button
           data-testid="elem-reverse-btn"
           onClick={() => setElemOrder([...elemOrder].reverse())}
@@ -166,8 +166,8 @@ export function* KeyShuffleDemo() {
           </li>
         ))}
       </ul>
-      <p data-testid="elem-order" style={{ fontFamily: 'monospace', fontSize: '0.85rem' }}>
-        Order: {elemOrder.join(', ')}
+      <p data-testid="elem-order" style={{ fontFamily: "monospace", fontSize: "0.85rem" }}>
+        Order: {elemOrder.join(", ")}
       </p>
     </section>
   );

--- a/examples/src/components/LazyContextDemo.tsx
+++ b/examples/src/components/LazyContextDemo.tsx
@@ -9,7 +9,7 @@
  * Playwright tests) that consumers 2 and 3 do NOT rerender when only an
  * unsubscribed field changes.
  */
-import { createContext, $context, $state, $ref } from 'yielderact';
+import { $context, $ref, $state, createContext } from "yielderact";
 
 // ---------------------------------------------------------------------------
 // Context shape & context object
@@ -21,7 +21,7 @@ type AppState = {
 };
 
 const AppCtx = createContext<AppState>({
-  user: { name: 'Alice', role: 'admin' },
+  user: { name: "Alice", role: "admin" },
   count: 0,
 });
 
@@ -33,13 +33,13 @@ function RenderBadge({ count }: { count: number }) {
   return (
     <span
       style={{
-        display: 'inline-block',
-        padding: '1px 6px',
-        borderRadius: '9999px',
-        background: '#0070f3',
-        color: '#fff',
-        fontSize: '0.75rem',
-        marginLeft: '0.4rem',
+        display: "inline-block",
+        padding: "1px 6px",
+        borderRadius: "9999px",
+        background: "#0070f3",
+        color: "#fff",
+        fontSize: "0.75rem",
+        marginLeft: "0.4rem",
       }}
     >
       {count}
@@ -61,17 +61,17 @@ function* NoSelectorConsumer() {
   return (
     <div
       data-testid="lazy-ctx-no-selector"
-      style={{ padding: '0.5rem', background: '#f9f9f9', borderRadius: '4px' }}
+      style={{ padding: "0.5rem", background: "#f9f9f9", borderRadius: "4px" }}
     >
       <strong>
         Overload 1 — no selector
         <RenderBadge count={renderCount.current} />
       </strong>
-      <p style={{ margin: '0.25rem 0 0', fontSize: '0.875rem' }}>
+      <p style={{ margin: "0.25rem 0 0", fontSize: "0.875rem" }}>
         name: <code data-testid="lazy-ctx-no-selector-name">{ctx.user.name}</code>
-        {'  '}count: <code data-testid="lazy-ctx-no-selector-count-val">{ctx.count}</code>
+        {"  "}count: <code data-testid="lazy-ctx-no-selector-count-val">{ctx.count}</code>
       </p>
-      <p style={{ margin: '0.25rem 0 0', fontSize: '0.75rem', color: '#666' }}>
+      <p style={{ margin: "0.25rem 0 0", fontSize: "0.75rem", color: "#666" }}>
         Render count: <span data-testid="lazy-ctx-no-selector-renders">{renderCount.current}</span>
       </p>
     </div>
@@ -92,17 +92,17 @@ function* SelectorConsumer() {
   return (
     <div
       data-testid="lazy-ctx-selector"
-      style={{ padding: '0.5rem', background: '#f0f7ff', borderRadius: '4px' }}
+      style={{ padding: "0.5rem", background: "#f0f7ff", borderRadius: "4px" }}
     >
       <strong>
         Overload 2 — selector (tracks user.name)
         <RenderBadge count={renderCount.current} />
       </strong>
-      <p style={{ margin: '0.25rem 0 0', fontSize: '0.875rem' }}>
+      <p style={{ margin: "0.25rem 0 0", fontSize: "0.875rem" }}>
         name: <code data-testid="lazy-ctx-selector-name">{ctx.user.name}</code>
-        {'  '}count: <code data-testid="lazy-ctx-selector-count-val">{ctx.count}</code>
+        {"  "}count: <code data-testid="lazy-ctx-selector-count-val">{ctx.count}</code>
       </p>
-      <p style={{ margin: '0.25rem 0 0', fontSize: '0.75rem', color: '#666' }}>
+      <p style={{ margin: "0.25rem 0 0", fontSize: "0.75rem", color: "#666" }}>
         Render count: <span data-testid="lazy-ctx-selector-renders">{renderCount.current}</span>
       </p>
     </div>
@@ -129,16 +129,16 @@ function* TransformConsumer() {
   return (
     <div
       data-testid="lazy-ctx-transform"
-      style={{ padding: '0.5rem', background: '#f0fff4', borderRadius: '4px' }}
+      style={{ padding: "0.5rem", background: "#f0fff4", borderRadius: "4px" }}
     >
       <strong>
         Overload 3 — selector + transform (tracks user.name, returns uppercased)
         <RenderBadge count={renderCount.current} />
       </strong>
-      <p style={{ margin: '0.25rem 0 0', fontSize: '0.875rem' }}>
+      <p style={{ margin: "0.25rem 0 0", fontSize: "0.875rem" }}>
         UPPER_NAME: <code data-testid="lazy-ctx-transform-value">{upperName}</code>
       </p>
-      <p style={{ margin: '0.25rem 0 0', fontSize: '0.75rem', color: '#666' }}>
+      <p style={{ margin: "0.25rem 0 0", fontSize: "0.75rem", color: "#666" }}>
         Render count: <span data-testid="lazy-ctx-transform-renders">{renderCount.current}</span>
       </p>
     </div>
@@ -151,20 +151,20 @@ function* TransformConsumer() {
 
 export function* LazyContextDemo() {
   const [state, setState] = yield* $state<AppState>({
-    user: { name: 'Alice', role: 'admin' },
+    user: { name: "Alice", role: "admin" },
     count: 0,
   });
 
   return (
     <section aria-label="Lazy context demo" data-testid="lazy-ctx-demo">
       <h2>Lazy $context (selector &amp; transform)</h2>
-      <p style={{ fontSize: '0.875rem', color: '#555', marginBottom: '0.75rem' }}>
+      <p style={{ fontSize: "0.875rem", color: "#555", marginBottom: "0.75rem" }}>
         The <strong>render count badge</strong> on each consumer shows how many times it has
-        rendered. Use the buttons to change only <code>count</code> or only <code>user.name</code>{' '}
+        rendered. Use the buttons to change only <code>count</code> or only <code>user.name</code>{" "}
         and observe which consumers rerender.
       </p>
 
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem', flexWrap: 'wrap' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem", flexWrap: "wrap" }}>
         <button
           data-testid="lazy-ctx-bump-count"
           onClick={() =>
@@ -173,7 +173,7 @@ export function* LazyContextDemo() {
               count: state.count + 1,
             })
           }
-          style={{ padding: '0.4rem 0.8rem' }}
+          style={{ padding: "0.4rem 0.8rem" }}
         >
           Bump count (+1)
         </button>
@@ -185,11 +185,11 @@ export function* LazyContextDemo() {
               ...state,
               user: {
                 ...state.user,
-                name: state.user.name === 'Alice' ? 'Bob' : 'Alice',
+                name: state.user.name === "Alice" ? "Bob" : "Alice",
               },
             })
           }
-          style={{ padding: '0.4rem 0.8rem' }}
+          style={{ padding: "0.4rem 0.8rem" }}
         >
           Toggle name (Alice ↔ Bob)
         </button>
@@ -201,30 +201,30 @@ export function* LazyContextDemo() {
               ...state,
               user: {
                 ...state.user,
-                role: state.user.role === 'admin' ? 'viewer' : 'admin',
+                role: state.user.role === "admin" ? "viewer" : "admin",
               },
             })
           }
-          style={{ padding: '0.4rem 0.8rem' }}
+          style={{ padding: "0.4rem 0.8rem" }}
         >
           Toggle role (admin ↔ viewer)
         </button>
       </div>
 
-      <p style={{ fontSize: '0.8rem', color: '#888', marginBottom: '0.75rem' }}>
-        Current state — name: <strong>{state.user.name}</strong> | role:{' '}
+      <p style={{ fontSize: "0.8rem", color: "#888", marginBottom: "0.75rem" }}>
+        Current state — name: <strong>{state.user.name}</strong> | role:{" "}
         <strong>{state.user.role}</strong> | count: <strong>{state.count}</strong>
       </p>
 
       <AppCtx.Provider value={state}>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
           <NoSelectorConsumer />
           <SelectorConsumer />
           <TransformConsumer />
         </div>
       </AppCtx.Provider>
 
-      <details style={{ marginTop: '1rem', fontSize: '0.8rem', color: '#555' }}>
+      <details style={{ marginTop: "1rem", fontSize: "0.8rem", color: "#555" }}>
         <summary>Expected behavior</summary>
         <ul>
           <li>

--- a/examples/src/components/ShownDemo.tsx
+++ b/examples/src/components/ShownDemo.tsx
@@ -8,7 +8,7 @@
  *  3. Generator component – a stateful counter toggled via `$shown`; the
  *     counter resets to zero each time it is re-mounted.
  */
-import { $state } from 'yielderact';
+import { $state } from "yielderact";
 
 // ---------------------------------------------------------------------------
 // Sub-components used in the demo
@@ -19,13 +19,13 @@ function InfoPanel() {
     <div
       data-testid="info-panel"
       style={{
-        padding: '0.75rem 1rem',
-        background: '#f0f4ff',
-        border: '1px solid #c0cff8',
-        borderRadius: '6px',
+        padding: "0.75rem 1rem",
+        background: "#f0f4ff",
+        border: "1px solid #c0cff8",
+        borderRadius: "6px",
       }}
     >
-      I am a <strong>function component</strong> – I mount and unmount based on the{' '}
+      I am a <strong>function component</strong> – I mount and unmount based on the{" "}
       <code>$shown</code> prop.
     </div>
   );
@@ -38,13 +38,13 @@ function* StatefulCounter() {
     <div
       data-testid="stateful-counter"
       style={{
-        display: 'flex',
-        gap: '0.5rem',
-        alignItems: 'center',
-        padding: '0.75rem 1rem',
-        background: '#f0fff4',
-        border: '1px solid #b0e8c0',
-        borderRadius: '6px',
+        display: "flex",
+        gap: "0.5rem",
+        alignItems: "center",
+        padding: "0.75rem 1rem",
+        background: "#f0fff4",
+        border: "1px solid #b0e8c0",
+        borderRadius: "6px",
       }}
     >
       <strong>Stateful counter (resets on re-mount):</strong>
@@ -81,9 +81,9 @@ export function* ShownDemo() {
       </p>
 
       {/* ── Row 1: HTML element ── */}
-      <div style={{ marginBottom: '1rem' }}>
+      <div style={{ marginBottom: "1rem" }}>
         <label
-          style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}
+          style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.4rem" }}
         >
           <input
             type="checkbox"
@@ -97,21 +97,21 @@ export function* ShownDemo() {
           $shown={showElement}
           data-testid="shown-element"
           style={{
-            padding: '0.75rem 1rem',
-            background: '#fff8e1',
-            border: '1px solid #ffe082',
-            borderRadius: '6px',
+            padding: "0.75rem 1rem",
+            background: "#fff8e1",
+            border: "1px solid #ffe082",
+            borderRadius: "6px",
           }}
         >
-          I am a plain <strong>&lt;div&gt;</strong> element — toggled with the <code>$shown</code>{' '}
+          I am a plain <strong>&lt;div&gt;</strong> element — toggled with the <code>$shown</code>{" "}
           prop.
         </div>
       </div>
 
       {/* ── Row 2: function component ── */}
-      <div style={{ marginBottom: '1rem' }}>
+      <div style={{ marginBottom: "1rem" }}>
         <label
-          style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}
+          style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.4rem" }}
         >
           <input
             type="checkbox"
@@ -127,7 +127,7 @@ export function* ShownDemo() {
       {/* ── Row 3: generator component ── */}
       <div>
         <label
-          style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '0.4rem' }}
+          style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.4rem" }}
         >
           <input
             type="checkbox"

--- a/examples/src/components/ThemeDemo.tsx
+++ b/examples/src/components/ThemeDemo.tsx
@@ -1,15 +1,15 @@
 /**
  * ThemeDemo – demonstrates createContext / $context with `yield* $state`.
  */
-import { createContext, $context, render, $state, $id } from 'yielderact';
+import { $context, $id, $state, createContext, render } from "yielderact";
 
-type Theme = 'light' | 'dark';
+type Theme = "light" | "dark";
 
-const ThemeContext = createContext<Theme>('light');
+const ThemeContext = createContext<Theme>("light");
 
 const styles: Record<Theme, { background: string; color: string; border: string }> = {
-  light: { background: '#ffffff', color: '#1a1a1a', border: '1px solid #ddd' },
-  dark: { background: '#1a1a1a', color: '#f0f0f0', border: '1px solid #444' },
+  light: { background: "#ffffff", color: "#1a1a1a", border: "1px solid #ddd" },
+  dark: { background: "#1a1a1a", color: "#f0f0f0", border: "1px solid #444" },
 };
 
 function* ThemedCard() {
@@ -23,16 +23,16 @@ function* ThemedCard() {
       id={cardId}
       data-testid="themed-card"
       style={{
-        padding: '1rem',
-        borderRadius: '6px',
+        padding: "1rem",
+        borderRadius: "6px",
         background: s.background,
         color: s.color,
         border: s.border,
       }}
     >
       <strong>Themed Card</strong>
-      <p style={{ margin: '0.4rem 0 0' }}>
-        Current theme:{' '}
+      <p style={{ margin: "0.4rem 0 0" }}>
+        Current theme:{" "}
         <span id={themeValueId} data-testid="theme-value">
           {theme}
         </span>
@@ -44,7 +44,7 @@ function* ThemedCard() {
 export function* ThemeDemo() {
   const toggleBtnId = yield* $id();
 
-  const [theme, setTheme] = yield* $state<Theme>('light');
+  const [theme, setTheme] = yield* $state<Theme>("light");
 
   return (
     <section aria-label="Theme context example">
@@ -56,8 +56,8 @@ export function* ThemeDemo() {
       <button
         id={toggleBtnId}
         data-testid="toggle-theme-btn"
-        onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-        style={{ marginBottom: '0.75rem' }}
+        onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+        style={{ marginBottom: "0.75rem" }}
       >
         Toggle theme (current: {theme})
       </button>

--- a/examples/src/components/TodoList.tsx
+++ b/examples/src/components/TodoList.tsx
@@ -2,7 +2,7 @@
  * TodoList – a generator component demonstrating array state management
  * with `yield* $state`.
  */
-import { render, $state, $id } from 'yielderact';
+import { $id, $state, render } from "yielderact";
 
 interface Todo {
   id: number;
@@ -24,11 +24,11 @@ export function* TodoList() {
 
   const [state, setState] = yield* $state<TodoState>({
     todos: [
-      { id: 1, text: 'Learn yielderact', done: false },
-      { id: 2, text: 'Build something with generators', done: false },
+      { id: 1, text: "Learn yielderact", done: false },
+      { id: 2, text: "Build something with generators", done: false },
     ],
     nextId: 3,
-    inputValue: '',
+    inputValue: "",
   });
 
   const { todos, nextId, inputValue } = state;
@@ -39,7 +39,7 @@ export function* TodoList() {
     setState({
       todos: [...todos, { id: nextId, text, done: false }],
       nextId: nextId + 1,
-      inputValue: '',
+      inputValue: "",
     });
   }
 
@@ -58,7 +58,7 @@ export function* TodoList() {
         Array state lives in <code>yield* $state</code> — no special reactive primitives needed,
         just plain objects and setters.
       </p>
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "0.75rem" }}>
         <label htmlFor={inputId}>New todo:</label>
         <input
           id={inputId}
@@ -67,31 +67,31 @@ export function* TodoList() {
           value={inputValue}
           placeholder="New todo…"
           onInput={(e) => {
-            setState({ ...state, inputValue: e.currentTarget?.value ?? '' });
+            setState({ ...state, inputValue: e.currentTarget?.value ?? "" });
           }}
           onKeydown={(e) => {
-            if (e.nativeEvent.key === 'Enter') addTodo();
+            if (e.nativeEvent.key === "Enter") addTodo();
           }}
         />
         <button id={addBtnId} data-testid="add-todo-btn" onClick={addTodo}>
           Add
         </button>
       </div>
-      <ul id={listId} data-testid="todo-list" style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+      <ul id={listId} data-testid="todo-list" style={{ listStyle: "none", padding: 0, margin: 0 }}>
         {todos.map((todo) => (
           <li
             $key={todo.id}
             data-testid={`todo-item-${todo.id}`}
             data-id={todo.id}
             style={{
-              display: 'flex',
-              gap: '0.5rem',
-              alignItems: 'center',
-              marginBottom: '0.35rem',
+              display: "flex",
+              gap: "0.5rem",
+              alignItems: "center",
+              marginBottom: "0.35rem",
             }}
           >
             <input type="checkbox" checked={todo.done} onChange={() => toggleTodo(todo.id)} />
-            <span style={{ textDecoration: todo.done ? 'line-through' : 'none', flex: 1 }}>
+            <span style={{ textDecoration: todo.done ? "line-through" : "none", flex: 1 }}>
               {todo.text}
             </span>
             <button
@@ -109,7 +109,7 @@ export function* TodoList() {
         $shown={todos.length === 0}
         id={emptyMsgId}
         data-testid="empty-message"
-        style={{ color: '#888' }}
+        style={{ color: "#888" }}
       >
         No todos yet. Add one above!
       </p>

--- a/examples/src/components/TransitionDemo.tsx
+++ b/examples/src/components/TransitionDemo.tsx
@@ -1,4 +1,4 @@
-import { $state, $ref, $uiPatch, startUIPatch, commitUIPatch, $effect } from 'yielderact';
+import { $effect, $ref, $state, $uiPatch, commitUIPatch, startUIPatch } from "yielderact";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -22,24 +22,24 @@ function* Navigation({
   return (
     <nav
       data-testid={`${scope}-nav`}
-      style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}
+      style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}
     >
-      {(['home', 'about', 'contact'] as Page[]).map((p) => (
+      {(["home", "about", "contact"] as Page[]).map((p) => (
         <button
           $key={p}
           data-testid={`${scope}-nav-${p}`}
           onClick={() => navigate(p)}
           disabled={isPending}
           style={{
-            padding: '0.3rem 0.7rem',
-            background: page === p ? '#0070f3' : '#fff',
-            color: page === p ? '#fff' : '#333',
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-            cursor: isPending ? 'wait' : 'pointer',
+            padding: "0.3rem 0.7rem",
+            background: page === p ? "#0070f3" : "#fff",
+            color: page === p ? "#fff" : "#333",
+            border: "1px solid #ccc",
+            borderRadius: "4px",
+            cursor: isPending ? "wait" : "pointer",
           }}
         >
-          {isPending && page !== p ? '…' : p}
+          {isPending && page !== p ? "…" : p}
         </button>
       ))}
     </nav>
@@ -51,7 +51,7 @@ function* Navigation({
 // ---------------------------------------------------------------------------
 
 function* LiveClock({ tick }: { tick: number }) {
-  return <b data-testid="clock-time">{new Date(tick).toLocaleTimeString('en-US')}</b>;
+  return <b data-testid="clock-time">{new Date(tick).toLocaleTimeString("en-US")}</b>;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,33 +95,33 @@ function* Clocks() {
   }, []);
   const seconds = new Date().getSeconds();
   return (
-    <div className={'grid gap-4 grid-cols-3'}>
-      <div style={{ marginBottom: '0.75rem' }} $patch="default" data-testid="clock-default">
+    <div className={"grid gap-4 grid-cols-3"}>
+      <div style={{ marginBottom: "0.75rem" }} $patch="default" data-testid="clock-default">
         Clock (<code>$patch="default"</code>): <LiveClock tick={tick} />
       </div>
-      <div style={{ marginBottom: '0.75rem' }} $patch="live" data-testid="clock-live">
+      <div style={{ marginBottom: "0.75rem" }} $patch="live" data-testid="clock-live">
         Clock (<code>$patch="live"</code>, always live): <LiveClock tick={tick} />
       </div>
       <div
-        style={{ marginBottom: '0.75rem' }}
-        $patch={seconds % 3 === 0 ? 'live' : 'default'}
+        style={{ marginBottom: "0.75rem" }}
+        $patch={seconds % 3 === 0 ? "live" : "default"}
         data-testid="clock-alternating"
       >
-        Clock (<code>$patch={`{seconds % 3 === 0 ? 'live' : 'default'}`}'</code>:{' '}
+        Clock (<code>$patch={`{seconds % 3 === 0 ? 'live' : 'default'}`}'</code>:{" "}
         <LiveClock tick={tick} />
       </div>
     </div>
   );
 }
 
-type Page = 'home' | 'about' | 'contact';
+type Page = "home" | "about" | "contact";
 
 // ---------------------------------------------------------------------------
 // Global patch demo
 // ---------------------------------------------------------------------------
 
 function* GlobalPatchDemo() {
-  const [page, setPage] = yield* $state<Page>('home');
+  const [page, setPage] = yield* $state<Page>("home");
   const [isPending, setIsPending] = yield* $state(false);
   const [log, setLog] = yield* $state<string[]>([]);
 
@@ -142,12 +142,12 @@ function* GlobalPatchDemo() {
   return (
     <div
       data-testid="global-patch-demo"
-      style={{ border: '1px solid #ddd', borderRadius: '6px', padding: '1rem' }}
+      style={{ border: "1px solid #ddd", borderRadius: "6px", padding: "1rem" }}
     >
       <h4 data-testid="global-patch-heading" style={{ marginTop: 0 }}>
         Global patch — entire tree frozen
       </h4>
-      <p style={{ color: '#555', fontSize: '0.9rem' }}>
+      <p style={{ color: "#555", fontSize: "0.9rem" }}>
         During navigation the <strong>entire page area</strong> is frozen (including the clock
         below). State changes are computed but DOM stays unchanged until commit.
       </p>
@@ -159,31 +159,31 @@ function* GlobalPatchDemo() {
 
       <div
         style={{
-          padding: '0.75rem',
-          background: '#f5f5f5',
-          borderRadius: '4px',
-          minHeight: '80px',
+          padding: "0.75rem",
+          background: "#f5f5f5",
+          borderRadius: "4px",
+          minHeight: "80px",
         }}
       >
-        <HomePage $shown={page === 'home'} />
-        <AboutPage $shown={page === 'about'} />
-        <ContactPage $shown={page === 'contact'} />
+        <HomePage $shown={page === "home"} />
+        <AboutPage $shown={page === "about"} />
+        <ContactPage $shown={page === "contact"} />
       </div>
 
       <pre
         data-testid="global-patch-log"
         $shown={!!log.length}
         style={{
-          marginTop: '0.75rem',
-          fontSize: '0.78rem',
-          background: '#1a1a1a',
-          color: '#cfc',
-          padding: '0.5rem',
-          borderRadius: '4px',
-          overflowX: 'auto',
+          marginTop: "0.75rem",
+          fontSize: "0.78rem",
+          background: "#1a1a1a",
+          color: "#cfc",
+          padding: "0.5rem",
+          borderRadius: "4px",
+          overflowX: "auto",
         }}
       >
-        {log.join('\n')}
+        {log.join("\n")}
       </pre>
     </div>
   );
@@ -195,7 +195,7 @@ function* GlobalPatchDemo() {
 
 function* LocalPatchDemo() {
   const startPatch = yield* $uiPatch();
-  const [page, setPage] = yield* $state<Page>('home');
+  const [page, setPage] = yield* $state<Page>("home");
   const [isPending, setIsPending] = yield* $state(false);
   const [log, setLog] = yield* $state<string[]>([]);
 
@@ -216,12 +216,12 @@ function* LocalPatchDemo() {
   return (
     <div
       data-testid="local-patch-demo"
-      style={{ border: '1px solid #ddd', borderRadius: '6px', padding: '1rem' }}
+      style={{ border: "1px solid #ddd", borderRadius: "6px", padding: "1rem" }}
     >
       <h4 data-testid="local-patch-heading" style={{ marginTop: 0 }}>
         Local patch — only this subtree frozen
       </h4>
-      <p style={{ color: '#555', fontSize: '0.9rem' }}>
+      <p style={{ color: "#555", fontSize: "0.9rem" }}>
         During navigation only <strong>this component's subtree</strong> is frozen. The live clock
         marked <code>$patch="live"</code> continues to tick — click it while navigating.
       </p>
@@ -230,31 +230,31 @@ function* LocalPatchDemo() {
       <Clocks />
       <div
         style={{
-          padding: '0.75rem',
-          background: '#f5f5f5',
-          borderRadius: '4px',
-          minHeight: '80px',
+          padding: "0.75rem",
+          background: "#f5f5f5",
+          borderRadius: "4px",
+          minHeight: "80px",
         }}
       >
-        <HomePage $shown={page === 'home'} />
-        <AboutPage $shown={page === 'about'} />
-        <ContactPage $shown={page === 'contact'} />
+        <HomePage $shown={page === "home"} />
+        <AboutPage $shown={page === "about"} />
+        <ContactPage $shown={page === "contact"} />
       </div>
 
       <pre
         data-testid="local-patch-log"
         $shown={!!log.length}
         style={{
-          marginTop: '0.75rem',
-          fontSize: '0.78rem',
-          background: '#1a1a1a',
-          color: '#cfc',
-          padding: '0.5rem',
-          borderRadius: '4px',
-          overflowX: 'auto',
+          marginTop: "0.75rem",
+          fontSize: "0.78rem",
+          background: "#1a1a1a",
+          color: "#cfc",
+          padding: "0.5rem",
+          borderRadius: "4px",
+          overflowX: "auto",
         }}
       >
-        {log.join('\n')}
+        {log.join("\n")}
       </pre>
     </div>
   );
@@ -266,7 +266,7 @@ function* LocalPatchDemo() {
 
 function* VisibilityTarget({ id }: { id: string }) {
   return (
-    <span data-testid={id} style={{ padding: '0.2rem 0.5rem', background: '#d4edda' }}>
+    <span data-testid={id} style={{ padding: "0.2rem 0.5rem", background: "#d4edda" }}>
       visible
     </span>
   );
@@ -290,15 +290,15 @@ function* GlobalVisibilityDemo() {
   return (
     <div
       data-testid="global-visibility-demo"
-      style={{ border: '1px solid #ddd', borderRadius: '6px', padding: '1rem' }}
+      style={{ border: "1px solid #ddd", borderRadius: "6px", padding: "1rem" }}
     >
       <h4 style={{ marginTop: 0 }}>Global patch — visibility</h4>
-      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "0.75rem" }}>
         <button
           data-testid="gv-start-patch"
           disabled={patchActive}
           onClick={beginPatch}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Start patch
         </button>
@@ -306,26 +306,26 @@ function* GlobalVisibilityDemo() {
           data-testid="gv-commit-patch"
           disabled={!patchActive}
           onClick={commitPatch}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Commit patch
         </button>
         <button
           data-testid="gv-toggle-default"
           onClick={() => setShowDefault((v) => !v)}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Toggle default
         </button>
         <button
           data-testid="gv-toggle-live"
           onClick={() => setShowLive((v) => !v)}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Toggle live
         </button>
       </div>
-      <div style={{ display: 'flex', gap: '1rem', minHeight: '2rem', alignItems: 'center' }}>
+      <div style={{ display: "flex", gap: "1rem", minHeight: "2rem", alignItems: "center" }}>
         <span>
           default: <VisibilityTarget $shown={showDefault} $patch="default" id="gv-target-default" />
         </span>
@@ -359,40 +359,40 @@ function* LocalVisibilityDemo() {
   return (
     <div
       data-testid="local-visibility-demo"
-      style={{ border: '1px solid #ddd', borderRadius: '6px', padding: '1rem' }}
+      style={{ border: "1px solid #ddd", borderRadius: "6px", padding: "1rem" }}
     >
       <h4 style={{ marginTop: 0 }}>Local patch — visibility</h4>
-      <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '0.75rem' }}>
+      <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap", marginBottom: "0.75rem" }}>
         <button
           data-testid="lv-start-patch"
           onClick={beginPatch}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Start patch
         </button>
         <button
           data-testid="lv-commit-patch"
           onClick={endPatch}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Commit patch
         </button>
         <button
           data-testid="lv-toggle-default"
           onClick={() => setShowDefault((v) => !v)}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Toggle default
         </button>
         <button
           data-testid="lv-toggle-live"
           onClick={() => setShowLive((v) => !v)}
-          style={{ padding: '0.3rem 0.6rem' }}
+          style={{ padding: "0.3rem 0.6rem" }}
         >
           Toggle live
         </button>
       </div>
-      <div style={{ display: 'flex', gap: '1rem', minHeight: '2rem', alignItems: 'center' }}>
+      <div style={{ display: "flex", gap: "1rem", minHeight: "2rem", alignItems: "center" }}>
         <span>
           default: <VisibilityTarget $shown={showDefault} $patch="default" id="lv-target-default" />
         </span>
@@ -421,7 +421,7 @@ export function* TransitionDemo() {
         Mark a subtree <code>$patch="live"</code> to let it update normally even during a patch.
       </p>
 
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
         <GlobalPatchDemo />
         <LocalPatchDemo />
         <GlobalVisibilityDemo />

--- a/examples/src/main.tsx
+++ b/examples/src/main.tsx
@@ -3,71 +3,70 @@
  *
  * Provides a simple tab-based navigation between the five example demos.
  */
-import { createRoot, $effect, $memo, $state } from 'yielderact';
-import { Counter } from './components/Counter';
-import { TodoList } from './components/TodoList';
-import { ThemeDemo } from './components/ThemeDemo';
-import { DataFetcher, ResolveRawDemo } from './components/DataFetcher';
-import { HooksShowcase } from './components/HooksShowcase';
-import { ShownDemo } from './components/ShownDemo';
-import { ConfirmDialog } from './components/ConfirmDialog';
-import { EffectDemo } from './components/EffectDemo';
-import { TransitionDemo } from './components/TransitionDemo';
-import { ContextDemo } from './components/ContextDemo';
-import { LazyContextDemo } from './components/LazyContextDemo';
-import { AbortSignalEffectDemo } from './components/AbortSignalEffectDemo';
-import { KeyShuffleDemo } from './components/KeyShuffleDemo';
+import { $state, createRoot } from "yielderact";
+import { AbortSignalEffectDemo } from "./components/AbortSignalEffectDemo";
+import { ConfirmDialog } from "./components/ConfirmDialog";
+import { ContextDemo } from "./components/ContextDemo";
+import { Counter } from "./components/Counter";
+import { DataFetcher, ResolveRawDemo } from "./components/DataFetcher";
+import { EffectDemo } from "./components/EffectDemo";
+import { HooksShowcase } from "./components/HooksShowcase";
+import { KeyShuffleDemo } from "./components/KeyShuffleDemo";
+import { LazyContextDemo } from "./components/LazyContextDemo";
+import { ShownDemo } from "./components/ShownDemo";
+import { ThemeDemo } from "./components/ThemeDemo";
+import { TodoList } from "./components/TodoList";
+import { TransitionDemo } from "./components/TransitionDemo";
 
 type Tab =
-  | 'counter'
-  | 'todos'
-  | 'theme'
-  | 'data'
-  | 'raw'
-  | 'hooks'
-  | 'shown'
-  | 'confirm'
-  | 'effect'
-  | 'transition'
-  | 'context'
-  | 'lazy-ctx'
-  | 'abort-signal'
-  | 'key-shuffle';
+  | "counter"
+  | "todos"
+  | "theme"
+  | "data"
+  | "raw"
+  | "hooks"
+  | "shown"
+  | "confirm"
+  | "effect"
+  | "transition"
+  | "context"
+  | "lazy-ctx"
+  | "abort-signal"
+  | "key-shuffle";
 
 const tabs: { id: Tab; label: string }[] = [
-  { id: 'counter', label: 'Counter' },
-  { id: 'todos', label: 'Todo List' },
-  { id: 'theme', label: 'Context / Theme' },
-  { id: 'data', label: 'Data Fetcher' },
-  { id: 'raw', label: '$resolveRaw' },
-  { id: 'hooks', label: 'Hooks Showcase' },
-  { id: 'shown', label: '$shown prop' },
-  { id: 'confirm', label: '$render' },
-  { id: 'effect', label: '$effect' },
-  { id: 'transition', label: 'UI Patch' },
-  { id: 'context', label: 'Context Scoping' },
-  { id: 'lazy-ctx', label: 'Lazy Context' },
-  { id: 'abort-signal', label: 'AbortSignal Effect' },
-  { id: 'key-shuffle', label: 'Key Shuffle' },
+  { id: "counter", label: "Counter" },
+  { id: "todos", label: "Todo List" },
+  { id: "theme", label: "Context / Theme" },
+  { id: "data", label: "Data Fetcher" },
+  { id: "raw", label: "$resolveRaw" },
+  { id: "hooks", label: "Hooks Showcase" },
+  { id: "shown", label: "$shown prop" },
+  { id: "confirm", label: "$render" },
+  { id: "effect", label: "$effect" },
+  { id: "transition", label: "UI Patch" },
+  { id: "context", label: "Context Scoping" },
+  { id: "lazy-ctx", label: "Lazy Context" },
+  { id: "abort-signal", label: "AbortSignal Effect" },
+  { id: "key-shuffle", label: "Key Shuffle" },
 ];
 
 function* App() {
-  const [activeTab, setActiveTab] = yield* $state<Tab>('counter');
+  const [activeTab, setActiveTab] = yield* $state<Tab>("counter");
 
   return (
-    <div style={{ maxWidth: '640px', margin: '0 auto' }}>
-      <h1 data-testid="app-heading" style={{ marginBottom: '0.25rem' }}>
+    <div style={{ maxWidth: "640px", margin: "0 auto" }}>
+      <h1 data-testid="app-heading" style={{ marginBottom: "0.25rem" }}>
         yielderact examples
       </h1>
-      <p style={{ color: '#555', marginBottom: '1.25rem' }}>
+      <p style={{ color: "#555", marginBottom: "1.25rem" }}>
         Generator-powered JSX components — no magic, just plain JavaScript.
       </p>
 
       {/* Tab bar — ids derived from data so $id() is not applicable here */}
       <nav
         data-testid="app-tablist"
-        role="tablist"
-        style={{ display: 'flex', gap: '0.5rem', marginBottom: '1.5rem', flexWrap: 'wrap' }}
+        style={{ display: "flex", gap: "0.5rem", marginBottom: "1.5rem", flexWrap: "wrap" }}
       >
         {tabs.map((tab) => (
           <button
@@ -78,12 +77,12 @@ function* App() {
             aria-selected={activeTab === tab.id}
             onClick={() => setActiveTab(tab.id)}
             style={{
-              padding: '0.4rem 0.9rem',
-              borderRadius: '4px',
-              border: '1px solid #ccc',
-              background: activeTab === tab.id ? '#0070f3' : '#fff',
-              color: activeTab === tab.id ? '#fff' : '#333',
-              cursor: 'pointer',
+              padding: "0.4rem 0.9rem",
+              borderRadius: "4px",
+              border: "1px solid #ccc",
+              background: activeTab === tab.id ? "#0070f3" : "#fff",
+              color: activeTab === tab.id ? "#fff" : "#333",
+              cursor: "pointer",
             }}
           >
             {tab.label}
@@ -93,24 +92,24 @@ function* App() {
 
       {/* Active panel */}
       <div id="example-panel">
-        <Counter $shown={activeTab === 'counter'} />
-        <TodoList $shown={activeTab === 'todos'} />
-        <ThemeDemo $shown={activeTab === 'theme'} />
-        <DataFetcher $shown={activeTab === 'data'} />
-        <ResolveRawDemo $shown={activeTab === 'raw'} />
-        <HooksShowcase $shown={activeTab === 'hooks'} />
-        <ShownDemo $shown={activeTab === 'shown'} />
-        <ConfirmDialog $shown={activeTab === 'confirm'} />
-        <EffectDemo $shown={activeTab === 'effect'} />
-        <TransitionDemo $shown={activeTab === 'transition'} />
-        <ContextDemo $shown={activeTab === 'context'} />
-        <LazyContextDemo $shown={activeTab === 'lazy-ctx'} />
-        <AbortSignalEffectDemo $shown={activeTab === 'abort-signal'} />
-        <KeyShuffleDemo $shown={activeTab === 'key-shuffle'} />
+        <Counter $shown={activeTab === "counter"} />
+        <TodoList $shown={activeTab === "todos"} />
+        <ThemeDemo $shown={activeTab === "theme"} />
+        <DataFetcher $shown={activeTab === "data"} />
+        <ResolveRawDemo $shown={activeTab === "raw"} />
+        <HooksShowcase $shown={activeTab === "hooks"} />
+        <ShownDemo $shown={activeTab === "shown"} />
+        <ConfirmDialog $shown={activeTab === "confirm"} />
+        <EffectDemo $shown={activeTab === "effect"} />
+        <TransitionDemo $shown={activeTab === "transition"} />
+        <ContextDemo $shown={activeTab === "context"} />
+        <LazyContextDemo $shown={activeTab === "lazy-ctx"} />
+        <AbortSignalEffectDemo $shown={activeTab === "abort-signal"} />
+        <KeyShuffleDemo $shown={activeTab === "key-shuffle"} />
       </div>
     </div>
   );
 }
 
-const root = createRoot(document.getElementById('root')!);
+const root = createRoot(document.getElementById("root")!);
 root.render(<App />);

--- a/examples/tests/abort-signal.spec.ts
+++ b/examples/tests/abort-signal.spec.ts
@@ -1,106 +1,106 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('AbortSignal Effect example', () => {
+test.describe("AbortSignal Effect example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'AbortSignal Effect');
+    await clickTab(page, "AbortSignal Effect");
     await page.waitForSelector('[data-testid="abort-signal-demo"]');
   });
 
-  test('renders all three signal rows on mount', async ({ page }) => {
-    await expect(page.getByTestId('signal-row-1')).toBeVisible();
-    await expect(page.getByTestId('signal-row-2')).toBeVisible();
-    await expect(page.getByTestId('signal-row-3')).toBeVisible();
-    await page.screenshot({ path: 'test-results/abort-signal-initial.png' });
+  test("renders all three signal rows on mount", async ({ page }) => {
+    await expect(page.getByTestId("signal-row-1")).toBeVisible();
+    await expect(page.getByTestId("signal-row-2")).toBeVisible();
+    await expect(page.getByTestId("signal-row-3")).toBeVisible();
+    await page.screenshot({ path: "test-results/abort-signal-initial.png" });
   });
 
-  test('user 1 is active and polling by default', async ({ page }) => {
+  test("user 1 is active and polling by default", async ({ page }) => {
     await page.waitForTimeout(500);
-    await expect(page.getByTestId('row-status-1')).toContainText('fetched');
+    await expect(page.getByTestId("row-status-1")).toContainText("fetched");
     // Users 2 and 3 should be inactive
-    await expect(page.getByTestId('row-status-2')).toHaveText('inactive');
-    await expect(page.getByTestId('row-status-3')).toHaveText('inactive');
-    await page.screenshot({ path: 'test-results/abort-signal-polling.png' });
+    await expect(page.getByTestId("row-status-2")).toHaveText("inactive");
+    await expect(page.getByTestId("row-status-3")).toHaveText("inactive");
+    await page.screenshot({ path: "test-results/abort-signal-polling.png" });
   });
 
-  test('switching to user 2 increments user 1 abort count and starts polling user 2', async ({
+  test("switching to user 2 increments user 1 abort count and starts polling user 2", async ({
     page,
   }) => {
     // Let user 1 poll a bit
     await page.waitForTimeout(500);
 
     // Switch to user 2
-    await page.getByTestId('user-btn-2').click();
+    await page.getByTestId("user-btn-2").click();
 
     // Wait for the effect to fire and the abort to propagate
     await page.waitForTimeout(600);
 
     // User 1's abort count should have increased
-    await expect(page.getByTestId('row-abort-count-1')).toHaveText('1');
+    await expect(page.getByTestId("row-abort-count-1")).toHaveText("1");
     // status is "inactive" because the effect re-runs with new activeId
-    await expect(page.getByTestId('row-status-1')).toHaveText('inactive');
+    await expect(page.getByTestId("row-status-1")).toHaveText("inactive");
 
     // User 2 should be polling with 0 aborts
-    await expect(page.getByTestId('row-status-2')).toContainText('fetched');
-    await expect(page.getByTestId('row-abort-count-2')).toHaveText('0');
+    await expect(page.getByTestId("row-status-2")).toContainText("fetched");
+    await expect(page.getByTestId("row-abort-count-2")).toHaveText("0");
 
-    await page.screenshot({ path: 'test-results/abort-signal-user-change.png' });
+    await page.screenshot({ path: "test-results/abort-signal-user-change.png" });
   });
 
-  test('switching from user 2 to user 3 increments user 2 abort count', async ({ page }) => {
-    await page.getByTestId('user-btn-2').click();
+  test("switching from user 2 to user 3 increments user 2 abort count", async ({ page }) => {
+    await page.getByTestId("user-btn-2").click();
     await page.waitForTimeout(500);
 
-    await page.getByTestId('user-btn-3').click();
+    await page.getByTestId("user-btn-3").click();
     await page.waitForTimeout(600);
 
     // User 2's abort count should have increased
-    await expect(page.getByTestId('row-abort-count-2')).toHaveText('1');
+    await expect(page.getByTestId("row-abort-count-2")).toHaveText("1");
     // status is "inactive" because the effect re-runs with new activeId
-    await expect(page.getByTestId('row-status-2')).toHaveText('inactive');
+    await expect(page.getByTestId("row-status-2")).toHaveText("inactive");
 
     // User 3 should be polling
-    await expect(page.getByTestId('row-status-3')).toContainText('fetched');
-    await expect(page.getByTestId('row-abort-count-3')).toHaveText('0');
+    await expect(page.getByTestId("row-status-3")).toContainText("fetched");
+    await expect(page.getByTestId("row-abort-count-3")).toHaveText("0");
 
-    await page.screenshot({ path: 'test-results/abort-signal-switch-2-to-3.png' });
+    await page.screenshot({ path: "test-results/abort-signal-switch-2-to-3.png" });
   });
 
-  test('unmounting the panel aborts all active signals', async ({ page }) => {
+  test("unmounting the panel aborts all active signals", async ({ page }) => {
     await page.waitForTimeout(500);
 
     // Unmount the panel
-    await page.getByTestId('toggle-panel').uncheck();
-    await expect(page.getByTestId('signal-table')).not.toBeAttached();
-    await page.screenshot({ path: 'test-results/abort-signal-unmounted.png' });
+    await page.getByTestId("toggle-panel").uncheck();
+    await expect(page.getByTestId("signal-table")).not.toBeAttached();
+    await page.screenshot({ path: "test-results/abort-signal-unmounted.png" });
   });
 
-  test('remounting the panel starts fresh with user 1 polling', async ({ page }) => {
+  test("remounting the panel starts fresh with user 1 polling", async ({ page }) => {
     // Unmount
-    await page.getByTestId('toggle-panel').uncheck();
-    await expect(page.getByTestId('signal-table')).not.toBeAttached();
+    await page.getByTestId("toggle-panel").uncheck();
+    await expect(page.getByTestId("signal-table")).not.toBeAttached();
 
     // Remount
-    await page.getByTestId('toggle-panel').check();
-    await expect(page.getByTestId('signal-table')).toBeVisible();
+    await page.getByTestId("toggle-panel").check();
+    await expect(page.getByTestId("signal-table")).toBeVisible();
 
     await page.waitForTimeout(500);
-    await expect(page.getByTestId('row-status-1')).toContainText('fetched');
-    await page.screenshot({ path: 'test-results/abort-signal-remounted.png' });
+    await expect(page.getByTestId("row-status-1")).toContainText("fetched");
+    await page.screenshot({ path: "test-results/abort-signal-remounted.png" });
   });
 
-  test('rapid switches: only the final user polls, others show aborted', async ({ page }) => {
-    await page.getByTestId('user-btn-2').click();
-    await page.getByTestId('user-btn-3').click();
-    await page.getByTestId('user-btn-1').click();
+  test("rapid switches: only the final user polls, others show aborted", async ({ page }) => {
+    await page.getByTestId("user-btn-2").click();
+    await page.getByTestId("user-btn-3").click();
+    await page.getByTestId("user-btn-1").click();
 
     await page.waitForTimeout(600);
 
     // User 1 should be polling again (abort count accumulated from previous switches)
-    await expect(page.getByTestId('row-status-1')).toContainText('fetched');
-    await expect(page.getByTestId('row-abort-count-1')).toHaveText('1');
+    await expect(page.getByTestId("row-status-1")).toContainText("fetched");
+    await expect(page.getByTestId("row-abort-count-1")).toHaveText("1");
 
-    await page.screenshot({ path: 'test-results/abort-signal-rapid-change.png' });
+    await page.screenshot({ path: "test-results/abort-signal-rapid-change.png" });
   });
 });

--- a/examples/tests/app.spec.ts
+++ b/examples/tests/app.spec.ts
@@ -1,19 +1,19 @@
-import { test, expect } from '@playwright/test';
-import { goToApp } from './helpers';
+import { expect, test } from "@playwright/test";
+import { goToApp } from "./helpers";
 
-test.describe('App shell', () => {
-  test('loads and shows the heading', async ({ page }) => {
+test.describe("App shell", () => {
+  test("loads and shows the heading", async ({ page }) => {
     await goToApp(page);
-    await expect(page.getByTestId('app-heading')).toHaveText('yielderact examples');
-    await page.screenshot({ path: 'test-results/app-loaded.png' });
+    await expect(page.getByTestId("app-heading")).toHaveText("yielderact examples");
+    await page.screenshot({ path: "test-results/app-loaded.png" });
   });
 
-  test('shows all five tabs', async ({ page }) => {
+  test("shows all five tabs", async ({ page }) => {
     await goToApp(page);
-    await expect(page.getByTestId('tab-counter')).toBeVisible();
-    await expect(page.getByTestId('tab-todos')).toBeVisible();
-    await expect(page.getByTestId('tab-theme')).toBeVisible();
-    await expect(page.getByTestId('tab-data')).toBeVisible();
-    await expect(page.getByTestId('tab-hooks')).toBeVisible();
+    await expect(page.getByTestId("tab-counter")).toBeVisible();
+    await expect(page.getByTestId("tab-todos")).toBeVisible();
+    await expect(page.getByTestId("tab-theme")).toBeVisible();
+    await expect(page.getByTestId("tab-data")).toBeVisible();
+    await expect(page.getByTestId("tab-hooks")).toBeVisible();
   });
 });

--- a/examples/tests/context-scoping.spec.ts
+++ b/examples/tests/context-scoping.spec.ts
@@ -1,112 +1,112 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('Context Scoping demo', () => {
+test.describe("Context Scoping demo", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'Context Scoping');
+    await clickTab(page, "Context Scoping");
     await page.waitForSelector('[data-testid="independent-panel"]');
   });
 
   // ── 1. Two independent contexts ─────────────────────────────────────────
 
-  test('shows initial theme and locale in independent panel', async ({ page }) => {
-    await expect(page.getByTestId('theme-badge')).toHaveText('light');
-    await expect(page.getByTestId('locale-badge')).toHaveText('en');
-    await expect(page.getByTestId('both-badge')).toHaveText('light/en');
-    await page.screenshot({ path: 'test-results/context-initial.png' });
+  test("shows initial theme and locale in independent panel", async ({ page }) => {
+    await expect(page.getByTestId("theme-badge")).toHaveText("light");
+    await expect(page.getByTestId("locale-badge")).toHaveText("en");
+    await expect(page.getByTestId("both-badge")).toHaveText("light/en");
+    await page.screenshot({ path: "test-results/context-initial.png" });
   });
 
-  test('toggling theme does not change locale', async ({ page }) => {
-    await page.getByTestId('toggle-theme-btn').click();
-    await expect(page.getByTestId('theme-badge')).toHaveText('dark');
-    await expect(page.getByTestId('locale-badge')).toHaveText('en');
-    await expect(page.getByTestId('both-badge')).toHaveText('dark/en');
-    await page.screenshot({ path: 'test-results/context-theme-toggled.png' });
+  test("toggling theme does not change locale", async ({ page }) => {
+    await page.getByTestId("toggle-theme-btn").click();
+    await expect(page.getByTestId("theme-badge")).toHaveText("dark");
+    await expect(page.getByTestId("locale-badge")).toHaveText("en");
+    await expect(page.getByTestId("both-badge")).toHaveText("dark/en");
+    await page.screenshot({ path: "test-results/context-theme-toggled.png" });
   });
 
-  test('toggling locale does not change theme', async ({ page }) => {
-    await page.getByTestId('toggle-locale-btn').click();
-    await expect(page.getByTestId('locale-badge')).toHaveText('fi');
-    await expect(page.getByTestId('theme-badge')).toHaveText('light');
-    await expect(page.getByTestId('both-badge')).toHaveText('light/fi');
-    await page.screenshot({ path: 'test-results/context-locale-toggled.png' });
+  test("toggling locale does not change theme", async ({ page }) => {
+    await page.getByTestId("toggle-locale-btn").click();
+    await expect(page.getByTestId("locale-badge")).toHaveText("fi");
+    await expect(page.getByTestId("theme-badge")).toHaveText("light");
+    await expect(page.getByTestId("both-badge")).toHaveText("light/fi");
+    await page.screenshot({ path: "test-results/context-locale-toggled.png" });
   });
 
-  test('toggling both contexts updates the combined badge', async ({ page }) => {
-    await page.getByTestId('toggle-theme-btn').click();
-    await page.getByTestId('toggle-locale-btn').click();
-    await expect(page.getByTestId('both-badge')).toHaveText('dark/fi');
-    await page.screenshot({ path: 'test-results/context-both-toggled.png' });
+  test("toggling both contexts updates the combined badge", async ({ page }) => {
+    await page.getByTestId("toggle-theme-btn").click();
+    await page.getByTestId("toggle-locale-btn").click();
+    await expect(page.getByTestId("both-badge")).toHaveText("dark/fi");
+    await page.screenshot({ path: "test-results/context-both-toggled.png" });
   });
 
   // ── 2. Nested Provider override ─────────────────────────────────────────
 
-  test('inner card always shows dark even when outer theme is light', async ({ page }) => {
-    await expect(page.getByTestId('outer-theme-badge')).toHaveText('light');
-    await expect(page.getByTestId('inner-theme-badge')).toHaveText('dark');
-    await page.screenshot({ path: 'test-results/context-nested-initial.png' });
+  test("inner card always shows dark even when outer theme is light", async ({ page }) => {
+    await expect(page.getByTestId("outer-theme-badge")).toHaveText("light");
+    await expect(page.getByTestId("inner-theme-badge")).toHaveText("dark");
+    await page.screenshot({ path: "test-results/context-nested-initial.png" });
   });
 
-  test('inner card stays dark after outer theme toggles to dark', async ({ page }) => {
-    await page.getByTestId('toggle-theme-btn').click();
-    await expect(page.getByTestId('outer-theme-badge')).toHaveText('dark');
-    await expect(page.getByTestId('inner-theme-badge')).toHaveText('dark');
-    await page.screenshot({ path: 'test-results/context-nested-outer-dark.png' });
+  test("inner card stays dark after outer theme toggles to dark", async ({ page }) => {
+    await page.getByTestId("toggle-theme-btn").click();
+    await expect(page.getByTestId("outer-theme-badge")).toHaveText("dark");
+    await expect(page.getByTestId("inner-theme-badge")).toHaveText("dark");
+    await page.screenshot({ path: "test-results/context-nested-outer-dark.png" });
   });
 
-  test('inner card stays dark after outer theme toggles back to light', async ({ page }) => {
-    await page.getByTestId('toggle-theme-btn').click(); // → dark
-    await page.getByTestId('toggle-theme-btn').click(); // → light again
-    await expect(page.getByTestId('inner-theme-badge')).toHaveText('dark');
+  test("inner card stays dark after outer theme toggles back to light", async ({ page }) => {
+    await page.getByTestId("toggle-theme-btn").click(); // → dark
+    await page.getByTestId("toggle-theme-btn").click(); // → light again
+    await expect(page.getByTestId("inner-theme-badge")).toHaveText("dark");
   });
 
   // ── 3. State preserved across context updates ───────────────────────────
 
-  test('consumer state is preserved when context value changes', async ({ page }) => {
+  test("consumer state is preserved when context value changes", async ({ page }) => {
     // Increment the counter three times
-    await page.getByTestId('stateful-inc').click();
-    await page.getByTestId('stateful-inc').click();
-    await page.getByTestId('stateful-inc').click();
-    await expect(page.getByTestId('stateful-count')).toHaveText('3');
+    await page.getByTestId("stateful-inc").click();
+    await page.getByTestId("stateful-inc").click();
+    await page.getByTestId("stateful-inc").click();
+    await expect(page.getByTestId("stateful-count")).toHaveText("3");
 
     // Toggle the outer theme – this changes the context value flowing into the consumer
-    await page.getByTestId('toggle-theme-btn').click();
+    await page.getByTestId("toggle-theme-btn").click();
 
     // Consumer must reflect the new theme…
-    await expect(page.getByTestId('stateful-theme')).toHaveText('dark');
+    await expect(page.getByTestId("stateful-theme")).toHaveText("dark");
     // …but the counter state must be preserved (not reset to 0)
-    await expect(page.getByTestId('stateful-count')).toHaveText('3');
-    await page.screenshot({ path: 'test-results/context-state-preserved.png' });
+    await expect(page.getByTestId("stateful-count")).toHaveText("3");
+    await page.screenshot({ path: "test-results/context-state-preserved.png" });
   });
 
   // ── 4. Sibling providers are isolated ───────────────────────────────────
 
-  test('sibling providers start with independent values', async ({ page }) => {
-    await expect(page.getByTestId('sibling-a')).toHaveText('light');
-    await expect(page.getByTestId('sibling-b')).toHaveText('dark');
-    await page.screenshot({ path: 'test-results/context-siblings-initial.png' });
+  test("sibling providers start with independent values", async ({ page }) => {
+    await expect(page.getByTestId("sibling-a")).toHaveText("light");
+    await expect(page.getByTestId("sibling-b")).toHaveText("dark");
+    await page.screenshot({ path: "test-results/context-siblings-initial.png" });
   });
 
-  test('toggling sibling A does not affect sibling B', async ({ page }) => {
-    await page.getByTestId('toggle-sibling-a').click();
-    await expect(page.getByTestId('sibling-a')).toHaveText('dark');
-    await expect(page.getByTestId('sibling-b')).toHaveText('dark');
-    await page.screenshot({ path: 'test-results/context-sibling-a-toggled.png' });
+  test("toggling sibling A does not affect sibling B", async ({ page }) => {
+    await page.getByTestId("toggle-sibling-a").click();
+    await expect(page.getByTestId("sibling-a")).toHaveText("dark");
+    await expect(page.getByTestId("sibling-b")).toHaveText("dark");
+    await page.screenshot({ path: "test-results/context-sibling-a-toggled.png" });
   });
 
-  test('toggling sibling B does not affect sibling A', async ({ page }) => {
-    await page.getByTestId('toggle-sibling-b').click();
-    await expect(page.getByTestId('sibling-a')).toHaveText('light');
-    await expect(page.getByTestId('sibling-b')).toHaveText('light');
-    await page.screenshot({ path: 'test-results/context-sibling-b-toggled.png' });
+  test("toggling sibling B does not affect sibling A", async ({ page }) => {
+    await page.getByTestId("toggle-sibling-b").click();
+    await expect(page.getByTestId("sibling-a")).toHaveText("light");
+    await expect(page.getByTestId("sibling-b")).toHaveText("light");
+    await page.screenshot({ path: "test-results/context-sibling-b-toggled.png" });
   });
 
-  test('both sibling providers can be toggled independently', async ({ page }) => {
-    await page.getByTestId('toggle-sibling-a').click();
-    await page.getByTestId('toggle-sibling-b').click();
-    await expect(page.getByTestId('sibling-a')).toHaveText('dark');
-    await expect(page.getByTestId('sibling-b')).toHaveText('light');
-    await page.screenshot({ path: 'test-results/context-siblings-both-toggled.png' });
+  test("both sibling providers can be toggled independently", async ({ page }) => {
+    await page.getByTestId("toggle-sibling-a").click();
+    await page.getByTestId("toggle-sibling-b").click();
+    await expect(page.getByTestId("sibling-a")).toHaveText("dark");
+    await expect(page.getByTestId("sibling-b")).toHaveText("light");
+    await page.screenshot({ path: "test-results/context-siblings-both-toggled.png" });
   });
 });

--- a/examples/tests/counter.spec.ts
+++ b/examples/tests/counter.spec.ts
@@ -1,40 +1,40 @@
-import { test, expect } from '@playwright/test';
-import { goToApp } from './helpers';
+import { expect, test } from "@playwright/test";
+import { goToApp } from "./helpers";
 
-test.describe('Counter example', () => {
+test.describe("Counter example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
     // Counter tab is active by default
   });
 
-  test('renders the counter with initial value 0', async ({ page }) => {
-    await expect(page.getByTestId('counter-value')).toHaveText('0');
-    await page.screenshot({ path: 'test-results/counter-initial.png' });
+  test("renders the counter with initial value 0", async ({ page }) => {
+    await expect(page.getByTestId("counter-value")).toHaveText("0");
+    await page.screenshot({ path: "test-results/counter-initial.png" });
   });
 
-  test('increments the counter', async ({ page }) => {
-    await page.getByTestId('increment-btn').click();
-    await expect(page.getByTestId('counter-value')).toHaveText('1');
+  test("increments the counter", async ({ page }) => {
+    await page.getByTestId("increment-btn").click();
+    await expect(page.getByTestId("counter-value")).toHaveText("1");
 
-    await page.getByTestId('increment-btn').click();
-    await page.getByTestId('increment-btn').click();
-    await expect(page.getByTestId('counter-value')).toHaveText('3');
-    await page.screenshot({ path: 'test-results/counter-incremented.png' });
+    await page.getByTestId("increment-btn").click();
+    await page.getByTestId("increment-btn").click();
+    await expect(page.getByTestId("counter-value")).toHaveText("3");
+    await page.screenshot({ path: "test-results/counter-incremented.png" });
   });
 
-  test('decrements the counter', async ({ page }) => {
-    await page.getByTestId('decrement-btn').click();
-    await expect(page.getByTestId('counter-value')).toHaveText('-1');
-    await page.screenshot({ path: 'test-results/counter-decremented.png' });
+  test("decrements the counter", async ({ page }) => {
+    await page.getByTestId("decrement-btn").click();
+    await expect(page.getByTestId("counter-value")).toHaveText("-1");
+    await page.screenshot({ path: "test-results/counter-decremented.png" });
   });
 
-  test('resets the counter', async ({ page }) => {
-    await page.getByTestId('increment-btn').click();
-    await page.getByTestId('increment-btn').click();
-    await expect(page.getByTestId('counter-value')).toHaveText('2');
+  test("resets the counter", async ({ page }) => {
+    await page.getByTestId("increment-btn").click();
+    await page.getByTestId("increment-btn").click();
+    await expect(page.getByTestId("counter-value")).toHaveText("2");
 
-    await page.getByTestId('reset-btn').click();
-    await expect(page.getByTestId('counter-value')).toHaveText('0');
-    await page.screenshot({ path: 'test-results/counter-reset.png' });
+    await page.getByTestId("reset-btn").click();
+    await expect(page.getByTestId("counter-value")).toHaveText("0");
+    await page.screenshot({ path: "test-results/counter-reset.png" });
   });
 });

--- a/examples/tests/data-fetcher.spec.ts
+++ b/examples/tests/data-fetcher.spec.ts
@@ -1,21 +1,21 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('Data Fetcher example', () => {
+test.describe("Data Fetcher example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'Data Fetcher');
+    await clickTab(page, "Data Fetcher");
   });
 
-  test('shows loading state initially', async ({ page }) => {
-    await expect(page.getByTestId('loading-message')).toBeVisible();
-    await page.screenshot({ path: 'test-results/data-loading.png' });
+  test("shows loading state initially", async ({ page }) => {
+    await expect(page.getByTestId("loading-message")).toBeVisible();
+    await page.screenshot({ path: "test-results/data-loading.png" });
   });
 
-  test('shows user data after promise resolves', async ({ page }) => {
+  test("shows user data after promise resolves", async ({ page }) => {
     // Wait up to 5 s for the simulated 1.5 s fetch to complete
-    await expect(page.getByTestId('user-data')).toBeVisible({ timeout: 5000 });
-    await expect(page.getByTestId('user-data')).toContainText('Jane Doe');
-    await page.screenshot({ path: 'test-results/data-loaded.png' });
+    await expect(page.getByTestId("user-data")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId("user-data")).toContainText("Jane Doe");
+    await page.screenshot({ path: "test-results/data-loaded.png" });
   });
 });

--- a/examples/tests/helpers.ts
+++ b/examples/tests/helpers.ts
@@ -1,27 +1,27 @@
-import { type Page } from '@playwright/test';
+import type { Page } from "@playwright/test";
 
 /** Navigate to the app and wait for it to be ready. */
 export async function goToApp(page: Page) {
-  await page.goto('/');
+  await page.goto("/");
   await page.waitForSelector('[data-testid="app-heading"]');
 }
 
 /** Map of tab labels used in tests → their data-testid values. */
 const tabIds: Record<string, string> = {
-  Counter: 'tab-counter',
-  'Todo List': 'tab-todos',
-  'Context / Theme': 'tab-theme',
-  'Data Fetcher': 'tab-data',
-  $resolveRaw: 'tab-raw',
-  'Hooks Showcase': 'tab-hooks',
-  '$shown prop': 'tab-shown',
-  $render: 'tab-confirm',
-  $effect: 'tab-effect',
-  'UI Patch': 'tab-transition',
-  'Context Scoping': 'tab-context',
-  'Lazy Context': 'tab-lazy-ctx',
-  'AbortSignal Effect': 'tab-abort-signal',
-  'Key Shuffle': 'tab-key-shuffle',
+  Counter: "tab-counter",
+  "Todo List": "tab-todos",
+  "Context / Theme": "tab-theme",
+  "Data Fetcher": "tab-data",
+  $resolveRaw: "tab-raw",
+  "Hooks Showcase": "tab-hooks",
+  "$shown prop": "tab-shown",
+  $render: "tab-confirm",
+  $effect: "tab-effect",
+  "UI Patch": "tab-transition",
+  "Context Scoping": "tab-context",
+  "Lazy Context": "tab-lazy-ctx",
+  "AbortSignal Effect": "tab-abort-signal",
+  "Key Shuffle": "tab-key-shuffle",
 };
 
 /** Click the tab with the given label. */

--- a/examples/tests/hooks-showcase.spec.ts
+++ b/examples/tests/hooks-showcase.spec.ts
@@ -1,46 +1,46 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('Hooks Showcase example', () => {
+test.describe("Hooks Showcase example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'Hooks Showcase');
+    await clickTab(page, "Hooks Showcase");
     await page.waitForSelector('[data-testid="hooks-search-input"]');
   });
 
-  test('renders the full fruit list initially', async ({ page }) => {
+  test("renders the full fruit list initially", async ({ page }) => {
     const items = page.locator('[data-testid^="fruit-"]');
     await expect(items).toHaveCount(12);
-    await page.screenshot({ path: 'test-results/hooks-initial.png' });
+    await page.screenshot({ path: "test-results/hooks-initial.png" });
   });
 
-  test('filters the list via useMemo when the search input changes', async ({ page }) => {
-    await page.getByTestId('hooks-search-input').fill('an');
+  test("filters the list via useMemo when the search input changes", async ({ page }) => {
+    await page.getByTestId("hooks-search-input").fill("an");
     const items = page.locator('[data-testid^="fruit-"]');
     // 'Banana', 'Mango' contain 'an' (Nectarine does not)
     await expect(items).toHaveCount(2);
-    await page.screenshot({ path: 'test-results/hooks-filtered.png' });
+    await page.screenshot({ path: "test-results/hooks-filtered.png" });
   });
 
-  test('shows no-results message when no fruits match', async ({ page }) => {
-    await page.getByTestId('hooks-search-input').fill('zzz');
-    await expect(page.getByTestId('hooks-no-results')).toBeVisible();
-    await page.screenshot({ path: 'test-results/hooks-no-results.png' });
+  test("shows no-results message when no fruits match", async ({ page }) => {
+    await page.getByTestId("hooks-search-input").fill("zzz");
+    await expect(page.getByTestId("hooks-no-results")).toBeVisible();
+    await page.screenshot({ path: "test-results/hooks-no-results.png" });
   });
 
-  test('shows render count tracked by useRef', async ({ page }) => {
-    await expect(page.getByTestId('hooks-render-count')).toContainText('rendered');
-    await page.screenshot({ path: 'test-results/hooks-render-count.png' });
+  test("shows render count tracked by useRef", async ({ page }) => {
+    await expect(page.getByTestId("hooks-render-count")).toContainText("rendered");
+    await page.screenshot({ path: "test-results/hooks-render-count.png" });
   });
 
-  test('search input label is associated via useId', async ({ page }) => {
-    const input = page.getByTestId('hooks-search-input');
-    const inputId = await input.getAttribute('id');
+  test("search input label is associated via useId", async ({ page }) => {
+    const input = page.getByTestId("hooks-search-input");
+    const inputId = await input.getAttribute("id");
     expect(inputId).toBeTruthy();
     // The label's htmlFor must match the input's id
-    const label = page.getByTestId('hooks-search-label');
+    const label = page.getByTestId("hooks-search-label");
     await expect(label).toBeVisible();
-    const labelFor = await label.getAttribute('for');
+    const labelFor = await label.getAttribute("for");
     expect(labelFor).toBe(inputId);
   });
 });

--- a/examples/tests/key-shuffle.spec.ts
+++ b/examples/tests/key-shuffle.spec.ts
@@ -1,156 +1,156 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('Key Shuffle example', () => {
+test.describe("Key Shuffle example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'Key Shuffle');
+    await clickTab(page, "Key Shuffle");
   });
 
   // ── Generator components (stateful) ──
 
-  test('renders initial generator component list A, B, C', async ({ page }) => {
-    await expect(page.getByTestId('generator-order')).toHaveText('Order: A, B, C');
-    await expect(page.getByTestId('item-A')).toBeVisible();
-    await expect(page.getByTestId('item-B')).toBeVisible();
-    await expect(page.getByTestId('item-C')).toBeVisible();
-    await page.screenshot({ path: 'test-results/key-shuffle-initial.png' });
+  test("renders initial generator component list A, B, C", async ({ page }) => {
+    await expect(page.getByTestId("generator-order")).toHaveText("Order: A, B, C");
+    await expect(page.getByTestId("item-A")).toBeVisible();
+    await expect(page.getByTestId("item-B")).toBeVisible();
+    await expect(page.getByTestId("item-C")).toBeVisible();
+    await page.screenshot({ path: "test-results/key-shuffle-initial.png" });
   });
 
-  test('reverse preserves generator component state', async ({ page }) => {
+  test("reverse preserves generator component state", async ({ page }) => {
     // Increment A twice and B once to give them recognizable state
-    await page.getByTestId('inc-A').click();
-    await page.getByTestId('inc-A').click();
-    await expect(page.getByTestId('count-A')).toHaveText('2');
+    await page.getByTestId("inc-A").click();
+    await page.getByTestId("inc-A").click();
+    await expect(page.getByTestId("count-A")).toHaveText("2");
 
-    await page.getByTestId('inc-B').click();
-    await expect(page.getByTestId('count-B')).toHaveText('1');
+    await page.getByTestId("inc-B").click();
+    await expect(page.getByTestId("count-B")).toHaveText("1");
 
     // Reverse: C, B, A
-    await page.getByTestId('reverse-btn').click();
-    await expect(page.getByTestId('generator-order')).toHaveText('Order: C, B, A');
+    await page.getByTestId("reverse-btn").click();
+    await expect(page.getByTestId("generator-order")).toHaveText("Order: C, B, A");
 
     // State must be preserved after reorder
-    await expect(page.getByTestId('count-A')).toHaveText('2');
-    await expect(page.getByTestId('count-B')).toHaveText('1');
-    await expect(page.getByTestId('count-C')).toHaveText('0');
-    await page.screenshot({ path: 'test-results/key-shuffle-reversed.png' });
+    await expect(page.getByTestId("count-A")).toHaveText("2");
+    await expect(page.getByTestId("count-B")).toHaveText("1");
+    await expect(page.getByTestId("count-C")).toHaveText("0");
+    await page.screenshot({ path: "test-results/key-shuffle-reversed.png" });
   });
 
-  test('DOM nodes are moved, not recreated, on reverse', async ({ page }) => {
+  test("DOM nodes are moved, not recreated, on reverse", async ({ page }) => {
     // Capture initial DOM node identity via a data attribute written by JS
-    await page.getByTestId('item-A').evaluate((el) => el.setAttribute('data-marker', 'original-A'));
-    await page.getByTestId('item-B').evaluate((el) => el.setAttribute('data-marker', 'original-B'));
-    await page.getByTestId('item-C').evaluate((el) => el.setAttribute('data-marker', 'original-C'));
+    await page.getByTestId("item-A").evaluate((el) => el.setAttribute("data-marker", "original-A"));
+    await page.getByTestId("item-B").evaluate((el) => el.setAttribute("data-marker", "original-B"));
+    await page.getByTestId("item-C").evaluate((el) => el.setAttribute("data-marker", "original-C"));
 
-    await page.getByTestId('reverse-btn').click();
-    await expect(page.getByTestId('generator-order')).toHaveText('Order: C, B, A');
+    await page.getByTestId("reverse-btn").click();
+    await expect(page.getByTestId("generator-order")).toHaveText("Order: C, B, A");
 
     // The marker attributes survive only if the DOM node was moved, not recreated
-    await expect(page.getByTestId('item-A')).toHaveAttribute('data-marker', 'original-A');
-    await expect(page.getByTestId('item-B')).toHaveAttribute('data-marker', 'original-B');
-    await expect(page.getByTestId('item-C')).toHaveAttribute('data-marker', 'original-C');
-    await page.screenshot({ path: 'test-results/key-shuffle-dom-identity.png' });
+    await expect(page.getByTestId("item-A")).toHaveAttribute("data-marker", "original-A");
+    await expect(page.getByTestId("item-B")).toHaveAttribute("data-marker", "original-B");
+    await expect(page.getByTestId("item-C")).toHaveAttribute("data-marker", "original-C");
+    await page.screenshot({ path: "test-results/key-shuffle-dom-identity.png" });
   });
 
-  test('components keep working after reorder', async ({ page }) => {
-    await page.getByTestId('reverse-btn').click();
-    await expect(page.getByTestId('generator-order')).toHaveText('Order: C, B, A');
+  test("components keep working after reorder", async ({ page }) => {
+    await page.getByTestId("reverse-btn").click();
+    await expect(page.getByTestId("generator-order")).toHaveText("Order: C, B, A");
 
     // Increment C after reorder
-    await page.getByTestId('inc-C').click();
-    await page.getByTestId('inc-C').click();
-    await expect(page.getByTestId('count-C')).toHaveText('2');
+    await page.getByTestId("inc-C").click();
+    await page.getByTestId("inc-C").click();
+    await expect(page.getByTestId("count-C")).toHaveText("2");
 
     // Increment A after reorder
-    await page.getByTestId('inc-A').click();
-    await expect(page.getByTestId('count-A')).toHaveText('1');
+    await page.getByTestId("inc-A").click();
+    await expect(page.getByTestId("count-A")).toHaveText("1");
 
-    await page.screenshot({ path: 'test-results/key-shuffle-post-reorder-increment.png' });
+    await page.screenshot({ path: "test-results/key-shuffle-post-reorder-increment.png" });
   });
 
-  test('add and remove items', async ({ page }) => {
+  test("add and remove items", async ({ page }) => {
     // Add D
-    await page.getByTestId('add-btn').click();
-    await expect(page.getByTestId('generator-order')).toHaveText('Order: A, B, C, D');
-    await expect(page.getByTestId('item-D')).toBeVisible();
+    await page.getByTestId("add-btn").click();
+    await expect(page.getByTestId("generator-order")).toHaveText("Order: A, B, C, D");
+    await expect(page.getByTestId("item-D")).toBeVisible();
 
     // Remove last (D)
-    await page.getByTestId('remove-last-btn').click();
-    await expect(page.getByTestId('generator-order')).toHaveText('Order: A, B, C');
-    await expect(page.getByTestId('item-D')).not.toBeVisible();
+    await page.getByTestId("remove-last-btn").click();
+    await expect(page.getByTestId("generator-order")).toHaveText("Order: A, B, C");
+    await expect(page.getByTestId("item-D")).not.toBeVisible();
 
-    await page.screenshot({ path: 'test-results/key-shuffle-add-remove.png' });
+    await page.screenshot({ path: "test-results/key-shuffle-add-remove.png" });
   });
 
-  test('shuffle then reverse preserves state', async ({ page }) => {
+  test("shuffle then reverse preserves state", async ({ page }) => {
     // Build up some state
-    await page.getByTestId('inc-A').click();
-    await page.getByTestId('inc-A').click();
-    await page.getByTestId('inc-A').click();
-    await expect(page.getByTestId('count-A')).toHaveText('3');
+    await page.getByTestId("inc-A").click();
+    await page.getByTestId("inc-A").click();
+    await page.getByTestId("inc-A").click();
+    await expect(page.getByTestId("count-A")).toHaveText("3");
 
     // Shuffle (deterministic check: state values survive)
-    await page.getByTestId('shuffle-btn').click();
-    await expect(page.getByTestId('count-A')).toHaveText('3');
+    await page.getByTestId("shuffle-btn").click();
+    await expect(page.getByTestId("count-A")).toHaveText("3");
 
     // Reverse again
-    await page.getByTestId('reverse-btn').click();
-    await expect(page.getByTestId('count-A')).toHaveText('3');
-    await expect(page.getByTestId('count-B')).toHaveText('0');
-    await expect(page.getByTestId('count-C')).toHaveText('0');
+    await page.getByTestId("reverse-btn").click();
+    await expect(page.getByTestId("count-A")).toHaveText("3");
+    await expect(page.getByTestId("count-B")).toHaveText("0");
+    await expect(page.getByTestId("count-C")).toHaveText("0");
 
-    await page.screenshot({ path: 'test-results/key-shuffle-shuffle-reverse.png' });
+    await page.screenshot({ path: "test-results/key-shuffle-shuffle-reverse.png" });
   });
 
   // ── Plain function components ──
 
-  test('renders initial tag list', async ({ page }) => {
-    await expect(page.getByTestId('tag-order')).toHaveText('Order: red, green, blue');
-    await expect(page.getByTestId('tag-red')).toBeVisible();
-    await expect(page.getByTestId('tag-green')).toBeVisible();
-    await expect(page.getByTestId('tag-blue')).toBeVisible();
+  test("renders initial tag list", async ({ page }) => {
+    await expect(page.getByTestId("tag-order")).toHaveText("Order: red, green, blue");
+    await expect(page.getByTestId("tag-red")).toBeVisible();
+    await expect(page.getByTestId("tag-green")).toBeVisible();
+    await expect(page.getByTestId("tag-blue")).toBeVisible();
   });
 
-  test('reverse tags moves DOM nodes', async ({ page }) => {
-    await page.getByTestId('tag-red').evaluate((el) => el.setAttribute('data-marker', 'orig-red'));
+  test("reverse tags moves DOM nodes", async ({ page }) => {
+    await page.getByTestId("tag-red").evaluate((el) => el.setAttribute("data-marker", "orig-red"));
     await page
-      .getByTestId('tag-blue')
-      .evaluate((el) => el.setAttribute('data-marker', 'orig-blue'));
+      .getByTestId("tag-blue")
+      .evaluate((el) => el.setAttribute("data-marker", "orig-blue"));
 
-    await page.getByTestId('tag-reverse-btn').click();
-    await expect(page.getByTestId('tag-order')).toHaveText('Order: blue, green, red');
+    await page.getByTestId("tag-reverse-btn").click();
+    await expect(page.getByTestId("tag-order")).toHaveText("Order: blue, green, red");
 
     // DOM identity preserved
-    await expect(page.getByTestId('tag-red')).toHaveAttribute('data-marker', 'orig-red');
-    await expect(page.getByTestId('tag-blue')).toHaveAttribute('data-marker', 'orig-blue');
-    await page.screenshot({ path: 'test-results/key-shuffle-tags-reversed.png' });
+    await expect(page.getByTestId("tag-red")).toHaveAttribute("data-marker", "orig-red");
+    await expect(page.getByTestId("tag-blue")).toHaveAttribute("data-marker", "orig-blue");
+    await page.screenshot({ path: "test-results/key-shuffle-tags-reversed.png" });
   });
 
   // ── Keyed HTML elements ──
 
-  test('renders initial element list', async ({ page }) => {
-    await expect(page.getByTestId('elem-order')).toHaveText('Order: first, second, third');
-    await expect(page.getByTestId('elem-first')).toHaveText('first');
-    await expect(page.getByTestId('elem-second')).toHaveText('second');
-    await expect(page.getByTestId('elem-third')).toHaveText('third');
+  test("renders initial element list", async ({ page }) => {
+    await expect(page.getByTestId("elem-order")).toHaveText("Order: first, second, third");
+    await expect(page.getByTestId("elem-first")).toHaveText("first");
+    await expect(page.getByTestId("elem-second")).toHaveText("second");
+    await expect(page.getByTestId("elem-third")).toHaveText("third");
   });
 
-  test('reverse elements moves DOM nodes', async ({ page }) => {
-    await page.getByTestId('elem-first').evaluate((el) => el.setAttribute('data-marker', 'orig-1'));
-    await page.getByTestId('elem-third').evaluate((el) => el.setAttribute('data-marker', 'orig-3'));
+  test("reverse elements moves DOM nodes", async ({ page }) => {
+    await page.getByTestId("elem-first").evaluate((el) => el.setAttribute("data-marker", "orig-1"));
+    await page.getByTestId("elem-third").evaluate((el) => el.setAttribute("data-marker", "orig-3"));
 
-    await page.getByTestId('elem-reverse-btn').click();
-    await expect(page.getByTestId('elem-order')).toHaveText('Order: third, second, first');
+    await page.getByTestId("elem-reverse-btn").click();
+    await expect(page.getByTestId("elem-order")).toHaveText("Order: third, second, first");
 
     // DOM identity preserved
-    await expect(page.getByTestId('elem-first')).toHaveAttribute('data-marker', 'orig-1');
-    await expect(page.getByTestId('elem-third')).toHaveAttribute('data-marker', 'orig-3');
+    await expect(page.getByTestId("elem-first")).toHaveAttribute("data-marker", "orig-1");
+    await expect(page.getByTestId("elem-third")).toHaveAttribute("data-marker", "orig-3");
 
     // Verify visual order in the DOM
-    const texts = await page.getByTestId('elem-list').locator('li').allTextContents();
-    expect(texts).toEqual(['third', 'second', 'first']);
+    const texts = await page.getByTestId("elem-list").locator("li").allTextContents();
+    expect(texts).toEqual(["third", "second", "first"]);
 
-    await page.screenshot({ path: 'test-results/key-shuffle-elems-reversed.png' });
+    await page.screenshot({ path: "test-results/key-shuffle-elems-reversed.png" });
   });
 });

--- a/examples/tests/lazy-context.spec.ts
+++ b/examples/tests/lazy-context.spec.ts
@@ -1,144 +1,144 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('Lazy context example', () => {
+test.describe("Lazy context example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'Lazy Context');
+    await clickTab(page, "Lazy Context");
     await page.waitForSelector('[data-testid="lazy-ctx-demo"]');
   });
 
   // ── initial render ────────────────────────────────────────────────────────
 
-  test('all three consumers render once on mount', async ({ page }) => {
-    await expect(page.getByTestId('lazy-ctx-no-selector-renders')).toHaveText('1');
-    await expect(page.getByTestId('lazy-ctx-selector-renders')).toHaveText('1');
-    await expect(page.getByTestId('lazy-ctx-transform-renders')).toHaveText('1');
-    await page.screenshot({ path: 'test-results/lazy-ctx-initial.png' });
+  test("all three consumers render once on mount", async ({ page }) => {
+    await expect(page.getByTestId("lazy-ctx-no-selector-renders")).toHaveText("1");
+    await expect(page.getByTestId("lazy-ctx-selector-renders")).toHaveText("1");
+    await expect(page.getByTestId("lazy-ctx-transform-renders")).toHaveText("1");
+    await page.screenshot({ path: "test-results/lazy-ctx-initial.png" });
   });
 
-  test('initial name is Alice for overloads 1 and 2', async ({ page }) => {
-    await expect(page.getByTestId('lazy-ctx-no-selector-name')).toHaveText('Alice');
-    await expect(page.getByTestId('lazy-ctx-selector-name')).toHaveText('Alice');
+  test("initial name is Alice for overloads 1 and 2", async ({ page }) => {
+    await expect(page.getByTestId("lazy-ctx-no-selector-name")).toHaveText("Alice");
+    await expect(page.getByTestId("lazy-ctx-selector-name")).toHaveText("Alice");
   });
 
-  test('initial transform value is ALICE (uppercased)', async ({ page }) => {
-    await expect(page.getByTestId('lazy-ctx-transform-value')).toHaveText('ALICE');
+  test("initial transform value is ALICE (uppercased)", async ({ page }) => {
+    await expect(page.getByTestId("lazy-ctx-transform-value")).toHaveText("ALICE");
   });
 
   // ── Bump count — only overload 1 should rerender ─────────────────────────
 
-  test('bump count: only overload-1 consumer rerenders', async ({ page }) => {
-    await page.getByTestId('lazy-ctx-bump-count').click();
+  test("bump count: only overload-1 consumer rerenders", async ({ page }) => {
+    await page.getByTestId("lazy-ctx-bump-count").click();
 
     // Overload 1 must have rerendered (render count increased to 2)
-    await expect(page.getByTestId('lazy-ctx-no-selector-renders')).toHaveText('2');
+    await expect(page.getByTestId("lazy-ctx-no-selector-renders")).toHaveText("2");
 
     // Overloads 2 and 3 must NOT have rerendered (still at 1)
-    await expect(page.getByTestId('lazy-ctx-selector-renders')).toHaveText('1');
-    await expect(page.getByTestId('lazy-ctx-transform-renders')).toHaveText('1');
+    await expect(page.getByTestId("lazy-ctx-selector-renders")).toHaveText("1");
+    await expect(page.getByTestId("lazy-ctx-transform-renders")).toHaveText("1");
 
-    await page.screenshot({ path: 'test-results/lazy-ctx-bump-count.png' });
+    await page.screenshot({ path: "test-results/lazy-ctx-bump-count.png" });
   });
 
-  test('bump count multiple times: overload-2 and overload-3 stay at 1', async ({ page }) => {
-    await page.getByTestId('lazy-ctx-bump-count').click();
-    await page.getByTestId('lazy-ctx-bump-count').click();
-    await page.getByTestId('lazy-ctx-bump-count').click();
+  test("bump count multiple times: overload-2 and overload-3 stay at 1", async ({ page }) => {
+    await page.getByTestId("lazy-ctx-bump-count").click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-renders')).toHaveText('4');
-    await expect(page.getByTestId('lazy-ctx-selector-renders')).toHaveText('1');
-    await expect(page.getByTestId('lazy-ctx-transform-renders')).toHaveText('1');
+    await expect(page.getByTestId("lazy-ctx-no-selector-renders")).toHaveText("4");
+    await expect(page.getByTestId("lazy-ctx-selector-renders")).toHaveText("1");
+    await expect(page.getByTestId("lazy-ctx-transform-renders")).toHaveText("1");
   });
 
-  test('bump count: overload-1 shows updated count value', async ({ page }) => {
-    await page.getByTestId('lazy-ctx-bump-count').click();
-    await page.getByTestId('lazy-ctx-bump-count').click();
+  test("bump count: overload-1 shows updated count value", async ({ page }) => {
+    await page.getByTestId("lazy-ctx-bump-count").click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-count-val')).toHaveText('2');
+    await expect(page.getByTestId("lazy-ctx-no-selector-count-val")).toHaveText("2");
   });
 
   // ── Toggle role — only overload 1 should rerender ────────────────────────
 
-  test('toggle role: only overload-1 consumer rerenders', async ({ page }) => {
-    await page.getByTestId('lazy-ctx-change-role').click();
+  test("toggle role: only overload-1 consumer rerenders", async ({ page }) => {
+    await page.getByTestId("lazy-ctx-change-role").click();
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-renders')).toHaveText('2');
-    await expect(page.getByTestId('lazy-ctx-selector-renders')).toHaveText('1');
-    await expect(page.getByTestId('lazy-ctx-transform-renders')).toHaveText('1');
+    await expect(page.getByTestId("lazy-ctx-no-selector-renders")).toHaveText("2");
+    await expect(page.getByTestId("lazy-ctx-selector-renders")).toHaveText("1");
+    await expect(page.getByTestId("lazy-ctx-transform-renders")).toHaveText("1");
 
-    await page.screenshot({ path: 'test-results/lazy-ctx-toggle-role.png' });
+    await page.screenshot({ path: "test-results/lazy-ctx-toggle-role.png" });
   });
 
   // ── Toggle name — all three consumers should rerender ────────────────────
 
-  test('toggle name: all three consumers rerender', async ({ page }) => {
-    await page.getByTestId('lazy-ctx-change-name').click();
+  test("toggle name: all three consumers rerender", async ({ page }) => {
+    await page.getByTestId("lazy-ctx-change-name").click();
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-renders')).toHaveText('2');
-    await expect(page.getByTestId('lazy-ctx-selector-renders')).toHaveText('2');
-    await expect(page.getByTestId('lazy-ctx-transform-renders')).toHaveText('2');
+    await expect(page.getByTestId("lazy-ctx-no-selector-renders")).toHaveText("2");
+    await expect(page.getByTestId("lazy-ctx-selector-renders")).toHaveText("2");
+    await expect(page.getByTestId("lazy-ctx-transform-renders")).toHaveText("2");
 
-    await page.screenshot({ path: 'test-results/lazy-ctx-toggle-name.png' });
+    await page.screenshot({ path: "test-results/lazy-ctx-toggle-name.png" });
   });
 
-  test('toggle name: overload-1 and overload-2 show updated name', async ({ page }) => {
-    await page.getByTestId('lazy-ctx-change-name').click();
+  test("toggle name: overload-1 and overload-2 show updated name", async ({ page }) => {
+    await page.getByTestId("lazy-ctx-change-name").click();
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-name')).toHaveText('Bob');
-    await expect(page.getByTestId('lazy-ctx-selector-name')).toHaveText('Bob');
+    await expect(page.getByTestId("lazy-ctx-no-selector-name")).toHaveText("Bob");
+    await expect(page.getByTestId("lazy-ctx-selector-name")).toHaveText("Bob");
   });
 
-  test('toggle name: overload-3 transform value updates to BOB', async ({ page }) => {
-    await page.getByTestId('lazy-ctx-change-name').click();
+  test("toggle name: overload-3 transform value updates to BOB", async ({ page }) => {
+    await page.getByTestId("lazy-ctx-change-name").click();
 
-    await expect(page.getByTestId('lazy-ctx-transform-value')).toHaveText('BOB');
+    await expect(page.getByTestId("lazy-ctx-transform-value")).toHaveText("BOB");
   });
 
-  test('toggle name twice: all consumers back to render count 3, name Alice, transform ALICE', async ({
+  test("toggle name twice: all consumers back to render count 3, name Alice, transform ALICE", async ({
     page,
   }) => {
-    await page.getByTestId('lazy-ctx-change-name').click();
-    await page.getByTestId('lazy-ctx-change-name').click();
+    await page.getByTestId("lazy-ctx-change-name").click();
+    await page.getByTestId("lazy-ctx-change-name").click();
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-renders')).toHaveText('3');
-    await expect(page.getByTestId('lazy-ctx-selector-renders')).toHaveText('3');
-    await expect(page.getByTestId('lazy-ctx-transform-renders')).toHaveText('3');
+    await expect(page.getByTestId("lazy-ctx-no-selector-renders")).toHaveText("3");
+    await expect(page.getByTestId("lazy-ctx-selector-renders")).toHaveText("3");
+    await expect(page.getByTestId("lazy-ctx-transform-renders")).toHaveText("3");
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-name')).toHaveText('Alice');
-    await expect(page.getByTestId('lazy-ctx-transform-value')).toHaveText('ALICE');
+    await expect(page.getByTestId("lazy-ctx-no-selector-name")).toHaveText("Alice");
+    await expect(page.getByTestId("lazy-ctx-transform-value")).toHaveText("ALICE");
   });
 
   // ── Mixed sequence ────────────────────────────────────────────────────────
 
-  test('mixed: bump then toggle name — correct render counts', async ({ page }) => {
+  test("mixed: bump then toggle name — correct render counts", async ({ page }) => {
     // bump: +1 to overload-1 only → [2, 1, 1]
-    await page.getByTestId('lazy-ctx-bump-count').click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
     // toggle name: +1 to all → [3, 2, 2]
-    await page.getByTestId('lazy-ctx-change-name').click();
+    await page.getByTestId("lazy-ctx-change-name").click();
     // bump again: +1 to overload-1 only → [4, 2, 2]
-    await page.getByTestId('lazy-ctx-bump-count').click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
 
-    await expect(page.getByTestId('lazy-ctx-no-selector-renders')).toHaveText('4');
-    await expect(page.getByTestId('lazy-ctx-selector-renders')).toHaveText('2');
-    await expect(page.getByTestId('lazy-ctx-transform-renders')).toHaveText('2');
+    await expect(page.getByTestId("lazy-ctx-no-selector-renders")).toHaveText("4");
+    await expect(page.getByTestId("lazy-ctx-selector-renders")).toHaveText("2");
+    await expect(page.getByTestId("lazy-ctx-transform-renders")).toHaveText("2");
 
-    await page.screenshot({ path: 'test-results/lazy-ctx-mixed.png' });
+    await page.screenshot({ path: "test-results/lazy-ctx-mixed.png" });
   });
 
-  test('overload-2 selector hook state preserved: count shown by selector consumer matches overload-1', async ({
+  test("overload-2 selector hook state preserved: count shown by selector consumer matches overload-1", async ({
     page,
   }) => {
     // bump count 3 times — overload-2 does NOT rerender, so it shows stale count.
     // This is expected: selector consumer skips rerender, thus its displayed
     // count value is from the last time it rendered (mount = 0).
-    await page.getByTestId('lazy-ctx-bump-count').click();
-    await page.getByTestId('lazy-ctx-bump-count').click();
-    await page.getByTestId('lazy-ctx-bump-count').click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
+    await page.getByTestId("lazy-ctx-bump-count").click();
 
     // Overload 1 sees the latest count (3)
-    await expect(page.getByTestId('lazy-ctx-no-selector-count-val')).toHaveText('3');
+    await expect(page.getByTestId("lazy-ctx-no-selector-count-val")).toHaveText("3");
     // Overload 2 last rendered at mount (count was 0) and has not rerendered
-    await expect(page.getByTestId('lazy-ctx-selector-count-val')).toHaveText('0');
+    await expect(page.getByTestId("lazy-ctx-selector-count-val")).toHaveText("0");
   });
 });

--- a/examples/tests/shown.spec.ts
+++ b/examples/tests/shown.spec.ts
@@ -1,60 +1,60 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('shown prop example', () => {
+test.describe("shown prop example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, '$shown prop');
+    await clickTab(page, "$shown prop");
     await page.waitForSelector('[data-testid="toggle-element"]');
   });
 
-  test('all three items are visible by default', async ({ page }) => {
-    await expect(page.getByTestId('shown-element')).toBeVisible();
-    await expect(page.getByTestId('info-panel')).toBeVisible();
-    await expect(page.getByTestId('stateful-counter')).toBeVisible();
-    await page.screenshot({ path: 'test-results/shown-all-visible.png' });
+  test("all three items are visible by default", async ({ page }) => {
+    await expect(page.getByTestId("shown-element")).toBeVisible();
+    await expect(page.getByTestId("info-panel")).toBeVisible();
+    await expect(page.getByTestId("stateful-counter")).toBeVisible();
+    await page.screenshot({ path: "test-results/shown-all-visible.png" });
   });
 
-  test('hides and shows the HTML element', async ({ page }) => {
-    await page.getByTestId('toggle-element').uncheck();
-    await expect(page.getByTestId('shown-element')).not.toBeAttached();
-    await page.screenshot({ path: 'test-results/shown-element-hidden.png' });
+  test("hides and shows the HTML element", async ({ page }) => {
+    await page.getByTestId("toggle-element").uncheck();
+    await expect(page.getByTestId("shown-element")).not.toBeAttached();
+    await page.screenshot({ path: "test-results/shown-element-hidden.png" });
 
-    await page.getByTestId('toggle-element').check();
-    await expect(page.getByTestId('shown-element')).toBeVisible();
-    await page.screenshot({ path: 'test-results/shown-element-shown.png' });
+    await page.getByTestId("toggle-element").check();
+    await expect(page.getByTestId("shown-element")).toBeVisible();
+    await page.screenshot({ path: "test-results/shown-element-shown.png" });
   });
 
-  test('hides and shows the function component', async ({ page }) => {
-    await page.getByTestId('toggle-function').uncheck();
-    await expect(page.getByTestId('info-panel')).not.toBeAttached();
-    await page.screenshot({ path: 'test-results/shown-function-hidden.png' });
+  test("hides and shows the function component", async ({ page }) => {
+    await page.getByTestId("toggle-function").uncheck();
+    await expect(page.getByTestId("info-panel")).not.toBeAttached();
+    await page.screenshot({ path: "test-results/shown-function-hidden.png" });
 
-    await page.getByTestId('toggle-function').check();
-    await expect(page.getByTestId('info-panel')).toBeVisible();
-    await page.screenshot({ path: 'test-results/shown-function-shown.png' });
+    await page.getByTestId("toggle-function").check();
+    await expect(page.getByTestId("info-panel")).toBeVisible();
+    await page.screenshot({ path: "test-results/shown-function-shown.png" });
   });
 
-  test('hides and shows the generator component', async ({ page }) => {
-    await page.getByTestId('toggle-generator').uncheck();
-    await expect(page.getByTestId('stateful-counter')).not.toBeAttached();
-    await page.screenshot({ path: 'test-results/shown-generator-hidden.png' });
+  test("hides and shows the generator component", async ({ page }) => {
+    await page.getByTestId("toggle-generator").uncheck();
+    await expect(page.getByTestId("stateful-counter")).not.toBeAttached();
+    await page.screenshot({ path: "test-results/shown-generator-hidden.png" });
 
-    await page.getByTestId('toggle-generator').check();
-    await expect(page.getByTestId('stateful-counter')).toBeVisible();
-    await page.screenshot({ path: 'test-results/shown-generator-shown.png' });
+    await page.getByTestId("toggle-generator").check();
+    await expect(page.getByTestId("stateful-counter")).toBeVisible();
+    await page.screenshot({ path: "test-results/shown-generator-shown.png" });
   });
 
-  test('generator component state resets after re-mount', async ({ page }) => {
+  test("generator component state resets after re-mount", async ({ page }) => {
     // Increment the counter inside the generator component
-    await page.getByTestId('counter-inc').click();
-    await page.getByTestId('counter-inc').click();
-    await expect(page.getByTestId('counter-val')).toHaveText('2');
+    await page.getByTestId("counter-inc").click();
+    await page.getByTestId("counter-inc").click();
+    await expect(page.getByTestId("counter-val")).toHaveText("2");
 
     // Hide then re-show — state should reset to 0
-    await page.getByTestId('toggle-generator').uncheck();
-    await page.getByTestId('toggle-generator').check();
-    await expect(page.getByTestId('counter-val')).toHaveText('0');
-    await page.screenshot({ path: 'test-results/shown-generator-reset.png' });
+    await page.getByTestId("toggle-generator").uncheck();
+    await page.getByTestId("toggle-generator").check();
+    await expect(page.getByTestId("counter-val")).toHaveText("0");
+    await page.screenshot({ path: "test-results/shown-generator-reset.png" });
   });
 });

--- a/examples/tests/theme.spec.ts
+++ b/examples/tests/theme.spec.ts
@@ -1,33 +1,33 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('Context / Theme example', () => {
+test.describe("Context / Theme example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'Context / Theme');
+    await clickTab(page, "Context / Theme");
     await page.waitForSelector('[data-testid="toggle-theme-btn"]');
   });
 
-  test('renders with the light theme by default', async ({ page }) => {
-    await expect(page.getByTestId('theme-value')).toHaveText('light');
-    await page.screenshot({ path: 'test-results/theme-light.png' });
+  test("renders with the light theme by default", async ({ page }) => {
+    await expect(page.getByTestId("theme-value")).toHaveText("light");
+    await page.screenshot({ path: "test-results/theme-light.png" });
   });
 
-  test('toggles to dark theme', async ({ page }) => {
-    await page.getByTestId('toggle-theme-btn').click();
-    await expect(page.getByTestId('theme-value')).toHaveText('dark');
-    await page.screenshot({ path: 'test-results/theme-dark.png' });
+  test("toggles to dark theme", async ({ page }) => {
+    await page.getByTestId("toggle-theme-btn").click();
+    await expect(page.getByTestId("theme-value")).toHaveText("dark");
+    await page.screenshot({ path: "test-results/theme-dark.png" });
   });
 
-  test('toggles back to light theme', async ({ page }) => {
-    await page.getByTestId('toggle-theme-btn').click();
-    await page.getByTestId('toggle-theme-btn').click();
-    await expect(page.getByTestId('theme-value')).toHaveText('light');
-    await page.screenshot({ path: 'test-results/theme-light-again.png' });
+  test("toggles back to light theme", async ({ page }) => {
+    await page.getByTestId("toggle-theme-btn").click();
+    await page.getByTestId("toggle-theme-btn").click();
+    await expect(page.getByTestId("theme-value")).toHaveText("light");
+    await page.screenshot({ path: "test-results/theme-light-again.png" });
   });
 
-  test('themed card is visible', async ({ page }) => {
-    await expect(page.getByTestId('themed-card')).toBeVisible();
-    await page.screenshot({ path: 'test-results/theme-card.png' });
+  test("themed card is visible", async ({ page }) => {
+    await expect(page.getByTestId("themed-card")).toBeVisible();
+    await page.screenshot({ path: "test-results/theme-card.png" });
   });
 });

--- a/examples/tests/todos.spec.ts
+++ b/examples/tests/todos.spec.ts
@@ -1,56 +1,56 @@
-import { test, expect } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
-test.describe('Todo List example', () => {
+test.describe("Todo List example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'Todo List');
+    await clickTab(page, "Todo List");
     await page.waitForSelector('[data-testid="todo-input"]');
   });
 
-  test('renders the initial todos', async ({ page }) => {
-    await expect(page.getByTestId('todo-item-1')).toBeVisible();
-    await expect(page.getByTestId('todo-item-2')).toBeVisible();
-    await page.screenshot({ path: 'test-results/todos-initial.png' });
+  test("renders the initial todos", async ({ page }) => {
+    await expect(page.getByTestId("todo-item-1")).toBeVisible();
+    await expect(page.getByTestId("todo-item-2")).toBeVisible();
+    await page.screenshot({ path: "test-results/todos-initial.png" });
   });
 
-  test('adds a new todo', async ({ page }) => {
-    await page.getByTestId('todo-input').fill('Write Playwright tests');
-    await page.getByTestId('add-todo-btn').click();
+  test("adds a new todo", async ({ page }) => {
+    await page.getByTestId("todo-input").fill("Write Playwright tests");
+    await page.getByTestId("add-todo-btn").click();
 
-    await expect(page.getByTestId('todo-item-3')).toBeVisible();
-    await expect(page.getByTestId('todo-item-3')).toContainText('Write Playwright tests');
-    await page.screenshot({ path: 'test-results/todos-added.png' });
+    await expect(page.getByTestId("todo-item-3")).toBeVisible();
+    await expect(page.getByTestId("todo-item-3")).toContainText("Write Playwright tests");
+    await page.screenshot({ path: "test-results/todos-added.png" });
   });
 
-  test('adds a todo by pressing Enter', async ({ page }) => {
-    await page.getByTestId('todo-input').fill('Press Enter to add');
-    await page.getByTestId('todo-input').press('Enter');
+  test("adds a todo by pressing Enter", async ({ page }) => {
+    await page.getByTestId("todo-input").fill("Press Enter to add");
+    await page.getByTestId("todo-input").press("Enter");
 
-    await expect(page.getByTestId('todo-item-3')).toBeVisible();
-    await expect(page.getByTestId('todo-item-3')).toContainText('Press Enter to add');
+    await expect(page.getByTestId("todo-item-3")).toBeVisible();
+    await expect(page.getByTestId("todo-item-3")).toContainText("Press Enter to add");
   });
 
-  test('removes a todo', async ({ page }) => {
+  test("removes a todo", async ({ page }) => {
     // Remove the first todo
-    await page.getByTestId('todo-remove-1').click();
-    await expect(page.getByTestId('todo-item-1')).not.toBeAttached();
-    await expect(page.getByTestId('todo-item-2')).toBeVisible();
-    await page.screenshot({ path: 'test-results/todos-removed.png' });
+    await page.getByTestId("todo-remove-1").click();
+    await expect(page.getByTestId("todo-item-1")).not.toBeAttached();
+    await expect(page.getByTestId("todo-item-2")).toBeVisible();
+    await page.screenshot({ path: "test-results/todos-removed.png" });
   });
 
-  test('shows the empty message when all todos are removed', async ({ page }) => {
-    await page.getByTestId('todo-remove-1').click();
-    await page.getByTestId('todo-remove-2').click();
-    await expect(page.getByTestId('empty-message')).toBeVisible();
-    await page.screenshot({ path: 'test-results/todos-empty.png' });
+  test("shows the empty message when all todos are removed", async ({ page }) => {
+    await page.getByTestId("todo-remove-1").click();
+    await page.getByTestId("todo-remove-2").click();
+    await expect(page.getByTestId("empty-message")).toBeVisible();
+    await page.screenshot({ path: "test-results/todos-empty.png" });
   });
 
-  test('does not add an empty todo', async ({ page }) => {
-    await page.getByTestId('add-todo-btn').click();
+  test("does not add an empty todo", async ({ page }) => {
+    await page.getByTestId("add-todo-btn").click();
     // Still only the original 2 items
-    await expect(page.getByTestId('todo-item-1')).toBeVisible();
-    await expect(page.getByTestId('todo-item-2')).toBeVisible();
-    await expect(page.getByTestId('todo-item-3')).not.toBeAttached();
+    await expect(page.getByTestId("todo-item-1")).toBeVisible();
+    await expect(page.getByTestId("todo-item-2")).toBeVisible();
+    await expect(page.getByTestId("todo-item-3")).not.toBeAttached();
   });
 });

--- a/examples/tests/ui-patch.spec.ts
+++ b/examples/tests/ui-patch.spec.ts
@@ -1,10 +1,10 @@
-import { test, expect, type Page } from '@playwright/test';
-import { goToApp, clickTab } from './helpers';
+import { expect, type Page, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
 
 /** Helpers scoped to one of the two visibility demos. */
-async function visibilitySetup(page: Page, scope: 'gv' | 'lv') {
+async function visibilitySetup(page: Page, scope: "gv" | "lv") {
   const panel = page.locator(
-    `[data-testid="${scope === 'gv' ? 'global' : 'local'}-visibility-demo"]`,
+    `[data-testid="${scope === "gv" ? "global" : "local"}-visibility-demo"]`,
   );
   const startBtn = panel.locator(`[data-testid="${scope}-start-patch"]`);
   const commitBtn = panel.locator(`[data-testid="${scope}-commit-patch"]`);
@@ -15,23 +15,23 @@ async function visibilitySetup(page: Page, scope: 'gv' | 'lv') {
   return { panel, startBtn, commitBtn, toggleDefault, toggleLive, targetDefault, targetLive };
 }
 
-test.describe('UI Patch example', () => {
+test.describe("UI Patch example", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'UI Patch');
+    await clickTab(page, "UI Patch");
     // Wait for the Global patch section to appear
     await page.waitForSelector('[data-testid="global-patch-demo"]');
   });
 
-  test('renders both global and local patch sections', async ({ page }) => {
-    await expect(page.getByTestId('global-patch-heading')).toBeVisible();
-    await expect(page.getByTestId('local-patch-heading')).toBeVisible();
-    await page.screenshot({ path: 'test-results/ui-patch-initial.png' });
+  test("renders both global and local patch sections", async ({ page }) => {
+    await expect(page.getByTestId("global-patch-heading")).toBeVisible();
+    await expect(page.getByTestId("local-patch-heading")).toBeVisible();
+    await page.screenshot({ path: "test-results/ui-patch-initial.png" });
   });
 
-  test('global patch: home page is shown by default', async ({ page }) => {
-    await expect(page.getByTestId('page-home').first()).toBeVisible();
-    await page.screenshot({ path: 'test-results/ui-patch-home.png' });
+  test("global patch: home page is shown by default", async ({ page }) => {
+    await expect(page.getByTestId("page-home").first()).toBeVisible();
+    await page.screenshot({ path: "test-results/ui-patch-home.png" });
   });
 
   // ── Navigation button state regression ──────────────────────────────────
@@ -40,110 +40,110 @@ test.describe('UI Patch example', () => {
   // updated during the live-only pass, causing shallowEqual to skip the
   // Navigation component at commit time.
 
-  test('global patch: navigation buttons are re-enabled after patch commits', async ({ page }) => {
-    await page.getByTestId('global-nav-about').click();
+  test("global patch: navigation buttons are re-enabled after patch commits", async ({ page }) => {
+    await page.getByTestId("global-nav-about").click();
 
     // Wait for navigation to complete and the about page to appear
-    await expect(page.getByTestId('page-about').first()).toBeVisible({ timeout: 7000 });
+    await expect(page.getByTestId("page-about").first()).toBeVisible({ timeout: 7000 });
 
     // All navigation buttons must be re-enabled after the patch commits
-    await expect(page.getByTestId('global-nav-home')).not.toBeDisabled();
-    await expect(page.getByTestId('global-nav-about')).not.toBeDisabled();
-    await expect(page.getByTestId('global-nav-contact')).not.toBeDisabled();
+    await expect(page.getByTestId("global-nav-home")).not.toBeDisabled();
+    await expect(page.getByTestId("global-nav-about")).not.toBeDisabled();
+    await expect(page.getByTestId("global-nav-contact")).not.toBeDisabled();
 
     // Button labels must be back to plain text (not '…' which shows during isPending)
-    await expect(page.getByTestId('global-nav-home')).toHaveText('home');
-    await expect(page.getByTestId('global-nav-about')).toHaveText('about');
-    await expect(page.getByTestId('global-nav-contact')).toHaveText('contact');
+    await expect(page.getByTestId("global-nav-home")).toHaveText("home");
+    await expect(page.getByTestId("global-nav-about")).toHaveText("about");
+    await expect(page.getByTestId("global-nav-contact")).toHaveText("contact");
 
-    await page.screenshot({ path: 'test-results/ui-patch-global-nav-reenabled.png' });
+    await page.screenshot({ path: "test-results/ui-patch-global-nav-reenabled.png" });
   });
 
-  test('local patch: navigation buttons are re-enabled after patch commits', async ({ page }) => {
-    await page.getByTestId('local-nav-about').click();
+  test("local patch: navigation buttons are re-enabled after patch commits", async ({ page }) => {
+    await page.getByTestId("local-nav-about").click();
 
     // Wait for navigation to complete and the about page to appear
-    await expect(page.getByTestId('page-about').first()).toBeVisible({ timeout: 7000 });
+    await expect(page.getByTestId("page-about").first()).toBeVisible({ timeout: 7000 });
 
     // Navigation buttons in the local patch nav must be re-enabled
-    await expect(page.getByTestId('local-nav-home')).not.toBeDisabled();
-    await expect(page.getByTestId('local-nav-about')).not.toBeDisabled();
-    await expect(page.getByTestId('local-nav-contact')).not.toBeDisabled();
+    await expect(page.getByTestId("local-nav-home")).not.toBeDisabled();
+    await expect(page.getByTestId("local-nav-about")).not.toBeDisabled();
+    await expect(page.getByTestId("local-nav-contact")).not.toBeDisabled();
 
     // Labels back to plain text
-    await expect(page.getByTestId('local-nav-home')).toHaveText('home');
-    await expect(page.getByTestId('local-nav-about')).toHaveText('about');
-    await expect(page.getByTestId('local-nav-contact')).toHaveText('contact');
+    await expect(page.getByTestId("local-nav-home")).toHaveText("home");
+    await expect(page.getByTestId("local-nav-about")).toHaveText("about");
+    await expect(page.getByTestId("local-nav-contact")).toHaveText("contact");
 
-    await page.screenshot({ path: 'test-results/ui-patch-local-nav-reenabled.png' });
+    await page.screenshot({ path: "test-results/ui-patch-local-nav-reenabled.png" });
   });
 
-  test('clocks demo: renders all three clock variants', async ({ page }) => {
-    await expect(page.getByTestId('clock-default').first()).toBeVisible();
-    await expect(page.getByTestId('clock-live').first()).toBeVisible();
-    await expect(page.getByTestId('clock-alternating').first()).toBeVisible();
-    await page.screenshot({ path: 'test-results/ui-patch-clocks.png' });
+  test("clocks demo: renders all three clock variants", async ({ page }) => {
+    await expect(page.getByTestId("clock-default").first()).toBeVisible();
+    await expect(page.getByTestId("clock-live").first()).toBeVisible();
+    await expect(page.getByTestId("clock-alternating").first()).toBeVisible();
+    await page.screenshot({ path: "test-results/ui-patch-clocks.png" });
   });
 
-  test('clocks demo: clocks display a time string', async ({ page }) => {
-    const clockEl = page.getByTestId('clock-default').first();
+  test("clocks demo: clocks display a time string", async ({ page }) => {
+    const clockEl = page.getByTestId("clock-default").first();
     await expect(clockEl).toBeVisible();
     const text = await clockEl.textContent();
     // toLocaleTimeString('en-US') produces e.g. "3:45:11 PM" or "12:34:56 PM"
     expect(text).toMatch(/\d{1,2}:\d{2}:\d{2}/);
-    await page.screenshot({ path: 'test-results/ui-patch-clock-time.png' });
+    await page.screenshot({ path: "test-results/ui-patch-clock-time.png" });
   });
 
-  test('global patch: navigates to about page after async delay', async ({ page }) => {
-    await page.getByTestId('global-nav-about').click();
+  test("global patch: navigates to about page after async delay", async ({ page }) => {
+    await page.getByTestId("global-nav-about").click();
 
     // Navigation takes 5 s — use a generous timeout
-    await expect(page.getByTestId('page-about').first()).toBeVisible({ timeout: 7000 });
-    await page.screenshot({ path: 'test-results/ui-patch-about.png' });
+    await expect(page.getByTestId("page-about").first()).toBeVisible({ timeout: 7000 });
+    await page.screenshot({ path: "test-results/ui-patch-about.png" });
   });
 
-  test('global patch: DOM is frozen until patch commits', async ({ page }) => {
-    await page.getByTestId('global-nav-about').click();
+  test("global patch: DOM is frozen until patch commits", async ({ page }) => {
+    await page.getByTestId("global-nav-about").click();
 
     // Immediately after click the home page must still be visible (DOM is frozen)
-    await expect(page.getByTestId('page-home').first()).toBeVisible();
+    await expect(page.getByTestId("page-home").first()).toBeVisible();
 
     // After the 5 s patch commits the about page replaces it
-    await expect(page.getByTestId('page-about').first()).toBeVisible({ timeout: 7000 });
-    await page.screenshot({ path: 'test-results/ui-patch-frozen-then-committed.png' });
+    await expect(page.getByTestId("page-about").first()).toBeVisible({ timeout: 7000 });
+    await page.screenshot({ path: "test-results/ui-patch-frozen-then-committed.png" });
   });
 
-  test('global patch: shows navigation log entries after commit', async ({ page }) => {
-    await page.getByTestId('global-nav-contact').click();
+  test("global patch: shows navigation log entries after commit", async ({ page }) => {
+    await page.getByTestId("global-nav-contact").click();
 
     // Both log entries are deferred — they appear together after the 5 s commit
-    await expect(page.getByTestId('global-patch-log')).toContainText(
-      '[global] navigating to contact',
+    await expect(page.getByTestId("global-patch-log")).toContainText(
+      "[global] navigating to contact",
       { timeout: 7000 },
     );
-    await expect(page.getByTestId('global-patch-log')).toContainText(
-      '[global] arrived at contact',
+    await expect(page.getByTestId("global-patch-log")).toContainText(
+      "[global] arrived at contact",
       { timeout: 7000 },
     );
-    await page.screenshot({ path: 'test-results/ui-patch-log.png' });
+    await page.screenshot({ path: "test-results/ui-patch-log.png" });
   });
 
-  test('local patch: home page is shown by default', async ({ page }) => {
+  test("local patch: home page is shown by default", async ({ page }) => {
     // The local patch demo also has HomePage/AboutPage/ContactPage
-    await expect(page.getByTestId('page-home').nth(1)).toBeVisible();
+    await expect(page.getByTestId("page-home").nth(1)).toBeVisible();
   });
 
-  test('local patch: navigates to contact page after async delay', async ({ page }) => {
-    await page.getByTestId('local-nav-contact').click();
+  test("local patch: navigates to contact page after async delay", async ({ page }) => {
+    await page.getByTestId("local-nav-contact").click();
 
-    await expect(page.getByTestId('page-contact').first()).toBeVisible({ timeout: 7000 });
-    await page.screenshot({ path: 'test-results/ui-patch-local-contact.png' });
+    await expect(page.getByTestId("page-contact").first()).toBeVisible({ timeout: 7000 });
+    await page.screenshot({ path: "test-results/ui-patch-local-contact.png" });
   });
 
-  test('clocks tick every second and display valid time strings', async ({ page }) => {
+  test("clocks tick every second and display valid time strings", async ({ page }) => {
     // After 1 s the clocks tick — verify all clock containers still show valid times
     await page.waitForTimeout(1100);
-    for (const testId of ['clock-default', 'clock-live', 'clock-alternating']) {
+    for (const testId of ["clock-default", "clock-live", "clock-alternating"]) {
       const text = await page
         .getByTestId(testId)
         .first()
@@ -151,7 +151,7 @@ test.describe('UI Patch example', () => {
         .textContent();
       expect(text).toMatch(/\d{1,2}:\d{2}:\d{2}/);
     }
-    await page.screenshot({ path: 'test-results/ui-patch-clocks-ticked.png' });
+    await page.screenshot({ path: "test-results/ui-patch-clocks-ticked.png" });
   });
 
   // ── $patch="live" correctness tests ─────────────────────────────────────
@@ -160,20 +160,20 @@ test.describe('UI Patch example', () => {
     page,
   }) => {
     // Start the 5 s global-patch navigation
-    await page.getByTestId('global-nav-about').click();
+    await page.getByTestId("global-nav-about").click();
 
     // Wait 1.5 s so a clock tick is guaranteed to have occurred while the patch
     // is still in progress (patch runs for 5 s total).
     await page.waitForTimeout(1500);
 
     // Snapshot both clocks at this mid-patch moment (first instance = global demo)
-    const globalDemo = page.getByTestId('global-patch-demo');
+    const globalDemo = page.getByTestId("global-patch-demo");
     const liveBefore = await globalDemo
-      .getByTestId('clock-live')
+      .getByTestId("clock-live")
       .locator('[data-testid="clock-time"]')
       .textContent();
     const defaultBefore = await globalDemo
-      .getByTestId('clock-default')
+      .getByTestId("clock-default")
       .locator('[data-testid="clock-time"]')
       .textContent();
 
@@ -181,11 +181,11 @@ test.describe('UI Patch example', () => {
     await page.waitForTimeout(1500);
 
     const liveAfter = await globalDemo
-      .getByTestId('clock-live')
+      .getByTestId("clock-live")
       .locator('[data-testid="clock-time"]')
       .textContent();
     const defaultAfter = await globalDemo
-      .getByTestId('clock-default')
+      .getByTestId("clock-default")
       .locator('[data-testid="clock-time"]')
       .textContent();
 
@@ -195,44 +195,44 @@ test.describe('UI Patch example', () => {
     // The default clock MUST remain frozen until the patch commits
     expect(defaultAfter).toBe(defaultBefore);
 
-    await page.screenshot({ path: 'test-results/ui-patch-live-vs-default.png' });
+    await page.screenshot({ path: "test-results/ui-patch-live-vs-default.png" });
   });
 
   test('$patch="live" clock updates during a local patch while $patch="default" stays frozen', async ({
     page,
   }) => {
     // Start the 5 s local-patch navigation
-    await page.getByTestId('local-nav-about').click();
+    await page.getByTestId("local-nav-about").click();
 
     // Wait 1.5 s — patch is still active
     await page.waitForTimeout(1500);
 
     // Use the Clocks instance inside LocalPatchDemo
-    const localDemo = page.getByTestId('local-patch-demo');
+    const localDemo = page.getByTestId("local-patch-demo");
     const liveBefore = await localDemo
-      .getByTestId('clock-live')
+      .getByTestId("clock-live")
       .locator('[data-testid="clock-time"]')
       .textContent();
     const defaultBefore = await localDemo
-      .getByTestId('clock-default')
+      .getByTestId("clock-default")
       .locator('[data-testid="clock-time"]')
       .textContent();
 
     await page.waitForTimeout(1500);
 
     const liveAfter = await localDemo
-      .getByTestId('clock-live')
+      .getByTestId("clock-live")
       .locator('[data-testid="clock-time"]')
       .textContent();
     const defaultAfter = await localDemo
-      .getByTestId('clock-default')
+      .getByTestId("clock-default")
       .locator('[data-testid="clock-time"]')
       .textContent();
 
     expect(liveAfter).not.toBe(liveBefore);
     expect(defaultAfter).toBe(defaultBefore);
 
-    await page.screenshot({ path: 'test-results/ui-patch-local-live-vs-default.png' });
+    await page.screenshot({ path: "test-results/ui-patch-local-live-vs-default.png" });
   });
 });
 
@@ -240,17 +240,17 @@ test.describe('UI Patch example', () => {
 // Visibility during global patch
 // ---------------------------------------------------------------------------
 
-test.describe('Visibility during global patch', () => {
+test.describe("Visibility during global patch", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'UI Patch');
+    await clickTab(page, "UI Patch");
     await page.waitForSelector('[data-testid="global-visibility-demo"]');
   });
 
-  test('default element stays visible when removed during patch, gone after commit', async ({
+  test("default element stays visible when removed during patch, gone after commit", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, 'gv');
+    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, "gv");
 
     await expect(targetDefault).toBeAttached();
 
@@ -261,13 +261,13 @@ test.describe('Visibility during global patch', () => {
     await commitBtn.click();
     await expect(targetDefault).not.toBeAttached(); // gone after commit
 
-    await page.screenshot({ path: 'test-results/gv-default-remove.png' });
+    await page.screenshot({ path: "test-results/gv-default-remove.png" });
   });
 
   test('$patch="live" element disappears immediately when removed during patch', async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, 'gv');
+    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, "gv");
 
     await expect(targetLive).toBeAttached();
 
@@ -278,13 +278,13 @@ test.describe('Visibility during global patch', () => {
     await commitBtn.click();
     await expect(targetLive).not.toBeAttached(); // still gone after commit
 
-    await page.screenshot({ path: 'test-results/gv-live-remove.png' });
+    await page.screenshot({ path: "test-results/gv-live-remove.png" });
   });
 
-  test('default element does not appear when added during patch, appears after commit', async ({
+  test("default element does not appear when added during patch, appears after commit", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, 'gv');
+    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, "gv");
 
     // Start with element hidden
     await toggleDefault.click(); // hide before patch
@@ -297,11 +297,11 @@ test.describe('Visibility during global patch', () => {
     await commitBtn.click();
     await expect(targetDefault).toBeAttached(); // appears after commit
 
-    await page.screenshot({ path: 'test-results/gv-default-add.png' });
+    await page.screenshot({ path: "test-results/gv-default-add.png" });
   });
 
   test('$patch="live" element appears immediately when added during patch', async ({ page }) => {
-    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, 'gv');
+    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, "gv");
 
     await toggleLive.click(); // hide before patch
     await expect(targetLive).not.toBeAttached();
@@ -313,13 +313,13 @@ test.describe('Visibility during global patch', () => {
     await commitBtn.click();
     await expect(targetLive).toBeAttached(); // still present after commit
 
-    await page.screenshot({ path: 'test-results/gv-live-add.png' });
+    await page.screenshot({ path: "test-results/gv-live-add.png" });
   });
 
-  test('live element removed then re-added: disappears immediately and reappears immediately', async ({
+  test("live element removed then re-added: disappears immediately and reappears immediately", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, 'gv');
+    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, "gv");
 
     await startBtn.click();
     await toggleLive.click(); // live-remove
@@ -330,13 +330,13 @@ test.describe('Visibility during global patch', () => {
     await commitBtn.click();
     await expect(targetLive).toBeAttached();
 
-    await page.screenshot({ path: 'test-results/gv-live-remove-readd.png' });
+    await page.screenshot({ path: "test-results/gv-live-remove-readd.png" });
   });
 
-  test('default element removed then re-added: visible throughout, present after commit', async ({
+  test("default element removed then re-added: visible throughout, present after commit", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, 'gv');
+    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, "gv");
 
     await startBtn.click();
     await toggleDefault.click(); // frozen — still visible
@@ -348,10 +348,10 @@ test.describe('Visibility during global patch', () => {
     await expect(targetDefault).toBeAttached();
   });
 
-  test('default element added then removed during patch: absent throughout and after commit', async ({
+  test("default element added then removed during patch: absent throughout and after commit", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, 'gv');
+    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, "gv");
 
     await toggleDefault.click(); // hide before patch
     await expect(targetDefault).not.toBeAttached();
@@ -365,11 +365,11 @@ test.describe('Visibility during global patch', () => {
     await commitBtn.click();
     await expect(targetDefault).not.toBeAttached(); // final state: hidden
 
-    await page.screenshot({ path: 'test-results/gv-default-add-remove.png' });
+    await page.screenshot({ path: "test-results/gv-default-add-remove.png" });
   });
 
-  test('live element added then removed: not present after commit', async ({ page }) => {
-    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, 'gv');
+  test("live element added then removed: not present after commit", async ({ page }) => {
+    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, "gv");
 
     await toggleLive.click(); // hide before patch
     await startBtn.click();
@@ -381,7 +381,7 @@ test.describe('Visibility during global patch', () => {
     await commitBtn.click();
     await expect(targetLive).not.toBeAttached();
 
-    await page.screenshot({ path: 'test-results/gv-live-add-remove.png' });
+    await page.screenshot({ path: "test-results/gv-live-add-remove.png" });
   });
 });
 
@@ -389,17 +389,17 @@ test.describe('Visibility during global patch', () => {
 // Visibility during local patch
 // ---------------------------------------------------------------------------
 
-test.describe('Visibility during local patch', () => {
+test.describe("Visibility during local patch", () => {
   test.beforeEach(async ({ page }) => {
     await goToApp(page);
-    await clickTab(page, 'UI Patch');
+    await clickTab(page, "UI Patch");
     await page.waitForSelector('[data-testid="local-visibility-demo"]');
   });
 
-  test('default element stays visible when removed during local patch, gone after commit', async ({
+  test("default element stays visible when removed during local patch, gone after commit", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, 'lv');
+    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, "lv");
 
     await expect(targetDefault).toBeAttached();
 
@@ -410,11 +410,11 @@ test.describe('Visibility during local patch', () => {
     await commitBtn.click();
     await expect(targetDefault).not.toBeAttached();
 
-    await page.screenshot({ path: 'test-results/lv-default-remove.png' });
+    await page.screenshot({ path: "test-results/lv-default-remove.png" });
   });
 
   test('$patch="live" element disappears immediately during local patch', async ({ page }) => {
-    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, 'lv');
+    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, "lv");
 
     await startBtn.click();
     await toggleLive.click();
@@ -423,13 +423,13 @@ test.describe('Visibility during local patch', () => {
     await commitBtn.click();
     await expect(targetLive).not.toBeAttached();
 
-    await page.screenshot({ path: 'test-results/lv-live-remove.png' });
+    await page.screenshot({ path: "test-results/lv-live-remove.png" });
   });
 
-  test('default element does not appear during local patch, appears after commit', async ({
+  test("default element does not appear during local patch, appears after commit", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, 'lv');
+    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, "lv");
 
     await toggleDefault.click(); // hide before patch
     await startBtn.click();
@@ -439,11 +439,11 @@ test.describe('Visibility during local patch', () => {
     await commitBtn.click();
     await expect(targetDefault).toBeAttached();
 
-    await page.screenshot({ path: 'test-results/lv-default-add.png' });
+    await page.screenshot({ path: "test-results/lv-default-add.png" });
   });
 
   test('$patch="live" element appears immediately during local patch', async ({ page }) => {
-    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, 'lv');
+    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, "lv");
 
     await toggleLive.click(); // hide before patch
     await startBtn.click();
@@ -453,13 +453,13 @@ test.describe('Visibility during local patch', () => {
     await commitBtn.click();
     await expect(targetLive).toBeAttached();
 
-    await page.screenshot({ path: 'test-results/lv-live-add.png' });
+    await page.screenshot({ path: "test-results/lv-live-add.png" });
   });
 
-  test('live element removed then re-added during local patch: correct immediate and final state', async ({
+  test("live element removed then re-added during local patch: correct immediate and final state", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, 'lv');
+    const { startBtn, commitBtn, toggleLive, targetLive } = await visibilitySetup(page, "lv");
 
     await startBtn.click();
     await toggleLive.click(); // live-remove
@@ -471,10 +471,10 @@ test.describe('Visibility during local patch', () => {
     await expect(targetLive).toBeAttached();
   });
 
-  test('default element removed then re-added: visible throughout, present after commit', async ({
+  test("default element removed then re-added: visible throughout, present after commit", async ({
     page,
   }) => {
-    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, 'lv');
+    const { startBtn, commitBtn, toggleDefault, targetDefault } = await visibilitySetup(page, "lv");
 
     await startBtn.click();
     await toggleDefault.click(); // frozen: still visible

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite';
-import path from 'path';
-import { yielderactPlugin } from '../vite-plugin-yielderact';
+import path from "path";
+import { defineConfig } from "vite";
+import { yielderactPlugin } from "../vite-plugin-yielderact";
 
 export default defineConfig({
   plugins: [yielderactPlugin()],
@@ -9,9 +9,9 @@ export default defineConfig({
     // jsx-dev-runtime is an alias for jsx-runtime because yielderact exports
     // jsxDEV from the same module (Vite's dev mode requests the dev runtime path).
     alias: {
-      'yielderact/jsx-dev-runtime': path.resolve(__dirname, '../src/jsx-runtime.ts'),
-      'yielderact/jsx-runtime': path.resolve(__dirname, '../src/jsx-runtime.ts'),
-      yielderact: path.resolve(__dirname, '../src/index.ts'),
+      "yielderact/jsx-dev-runtime": path.resolve(__dirname, "../src/jsx-runtime.ts"),
+      "yielderact/jsx-runtime": path.resolve(__dirname, "../src/jsx-runtime.ts"),
+      yielderact: path.resolve(__dirname, "../src/index.ts"),
     },
   },
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,17 +1,17 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
-  roots: ['<rootDir>/src'],
-  testMatch: ['**/__tests__/**/*.test.ts'],
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/__tests__/**/*.test.ts"],
   transform: {
-    '^.+\\.tsx?$': [
-      'ts-jest',
+    "^.+\\.tsx?$": [
+      "ts-jest",
       {
         tsconfig: {
-          jsx: 'react',
-          jsxFactory: 'createElement',
-          jsxFragmentFactory: 'Fragment',
+          jsx: "react",
+          jsxFactory: "createElement",
+          jsxFragmentFactory: "Fragment",
         },
       },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@biomejs/biome": "^2.4.6",
         "@playwright/test": "^1.58.2",
         "@types/jest": "^30.0.0",
         "esbuild": "^0.27.3",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
-        "prettier": "^3.8.1",
         "ts-jest": "^29.4.6",
         "typescript": "^5.9.3"
       }
@@ -535,6 +535,160 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.6.tgz",
+      "integrity": "sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==",
+      "dev": true,
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.6",
+        "@biomejs/cli-darwin-x64": "2.4.6",
+        "@biomejs/cli-linux-arm64": "2.4.6",
+        "@biomejs/cli-linux-arm64-musl": "2.4.6",
+        "@biomejs/cli-linux-x64": "2.4.6",
+        "@biomejs/cli-linux-x64-musl": "2.4.6",
+        "@biomejs/cli-win32-arm64": "2.4.6",
+        "@biomejs/cli-win32-x64": "2.4.6"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.6.tgz",
+      "integrity": "sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.6.tgz",
+      "integrity": "sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.6.tgz",
+      "integrity": "sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.6.tgz",
+      "integrity": "sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.6.tgz",
+      "integrity": "sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.6.tgz",
+      "integrity": "sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.6.tgz",
+      "integrity": "sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.6.tgz",
+      "integrity": "sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -4595,22 +4749,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "build": "tsc",
     "test": "jest",
     "test:visual": "playwright test",
-    "format": "prettier --write \"**/*.{ts,tsx,js,json,md}\" --ignore-path .gitignore",
-    "format:check": "prettier --check \"**/*.{ts,tsx,js,json,md}\" --ignore-path .gitignore"
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format --write .",
+    "format:check": "biome check --linter-enabled=false ."
   },
   "repository": {
     "type": "git",
@@ -47,12 +49,12 @@
   },
   "homepage": "https://github.com/jEnbuska/yielderact#readme",
   "devDependencies": {
+    "@biomejs/biome": "^2.4.6",
     "@playwright/test": "^1.58.2",
     "@types/jest": "^30.0.0",
     "esbuild": "^0.27.3",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
-    "prettier": "^3.8.1",
     "ts-jest": "^29.4.6",
     "typescript": "^5.9.3"
   }

--- a/playwright-tests/visual.test.ts
+++ b/playwright-tests/visual.test.ts
@@ -9,26 +9,26 @@
  * Screenshots are taken after key interactions so reviewers can see the
  * rendered output.
  */
-import { test, expect, Page } from '@playwright/test';
-import { build } from 'esbuild';
-import * as path from 'path';
+import { expect, type Page, test } from "@playwright/test";
+import { build } from "esbuild";
+import * as path from "path";
 
 // ---------------------------------------------------------------------------
 // Bundle setup
 // ---------------------------------------------------------------------------
 
-let bundleCode = '';
+let bundleCode = "";
 
 test.beforeAll(async () => {
   const result = await build({
-    entryPoints: [path.join(__dirname, '../src/index.ts')],
+    entryPoints: [path.join(__dirname, "../src/index.ts")],
     bundle: true,
-    format: 'iife',
-    globalName: 'Yielderact',
+    format: "iife",
+    globalName: "Yielderact",
     write: false,
-    tsconfig: path.join(__dirname, '../tsconfig.json'),
+    tsconfig: path.join(__dirname, "../tsconfig.json"),
     // Silence any warnings in CI
-    logLevel: 'error',
+    logLevel: "error",
   });
   bundleCode = result.outputFiles[0].text;
 });
@@ -49,162 +49,162 @@ async function setupPage(page: Page): Promise<void> {
 // Element rendering tests
 // ---------------------------------------------------------------------------
 
-test('renders a plain HTML element', async ({ page }) => {
+test("renders a plain HTML element", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
     render(
-      createElement('h1', { id: 'heading', className: 'title' }, 'Hello yielderact'),
-      document.getElementById('root')!,
+      createElement("h1", { id: "heading", className: "title" }, "Hello yielderact"),
+      document.getElementById("root")!,
     );
   });
 
-  await expect(page.locator('#heading')).toHaveText('Hello yielderact');
-  await expect(page.locator('#heading')).toHaveClass('title');
-  await page.screenshot({ path: '/tmp/visual-element.png' });
+  await expect(page.locator("#heading")).toHaveText("Hello yielderact");
+  await expect(page.locator("#heading")).toHaveClass("title");
+  await page.screenshot({ path: "/tmp/visual-element.png" });
 });
 
-test('renders nested elements', async ({ page }) => {
+test("renders nested elements", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
     render(
       createElement(
-        'ul',
-        { id: 'list' },
-        createElement('li', null, 'Item 1'),
-        createElement('li', null, 'Item 2'),
-        createElement('li', null, 'Item 3'),
+        "ul",
+        { id: "list" },
+        createElement("li", null, "Item 1"),
+        createElement("li", null, "Item 2"),
+        createElement("li", null, "Item 3"),
       ),
-      document.getElementById('root')!,
+      document.getElementById("root")!,
     );
   });
 
-  const items = page.locator('#list li');
+  const items = page.locator("#list li");
   await expect(items).toHaveCount(3);
-  await expect(items.nth(0)).toHaveText('Item 1');
-  await expect(items.nth(2)).toHaveText('Item 3');
-  await page.screenshot({ path: '/tmp/visual-nested.png' });
+  await expect(items.nth(0)).toHaveText("Item 1");
+  await expect(items.nth(2)).toHaveText("Item 3");
+  await page.screenshot({ path: "/tmp/visual-nested.png" });
 });
 
 // ---------------------------------------------------------------------------
 // Counter (generator component with internal state)
 // ---------------------------------------------------------------------------
 
-test('generator counter increments on click', async ({ page }) => {
+test("generator counter increments on click", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render, $state } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     function* Counter(_: object) {
       const [count, setCount] = yield* $state(0);
       return createElement(
-        'button',
+        "button",
         {
-          id: 'btn',
+          id: "btn",
           onclick: () => setCount((c: number) => c + 1),
         },
         String(count),
       );
     }
 
-    render(createElement(Counter as never, {}), document.getElementById('root')!);
+    render(createElement(Counter as never, {}), document.getElementById("root")!);
   });
 
-  await expect(page.locator('#btn')).toHaveText('0');
-  await page.screenshot({ path: '/tmp/visual-counter-0.png' });
+  await expect(page.locator("#btn")).toHaveText("0");
+  await page.screenshot({ path: "/tmp/visual-counter-0.png" });
 
-  await page.click('#btn');
-  await expect(page.locator('#btn')).toHaveText('1');
-  await page.screenshot({ path: '/tmp/visual-counter-1.png' });
+  await page.click("#btn");
+  await expect(page.locator("#btn")).toHaveText("1");
+  await page.screenshot({ path: "/tmp/visual-counter-1.png" });
 
-  await page.click('#btn');
-  await page.click('#btn');
-  await expect(page.locator('#btn')).toHaveText('3');
-  await page.screenshot({ path: '/tmp/visual-counter-3.png' });
+  await page.click("#btn");
+  await page.click("#btn");
+  await expect(page.locator("#btn")).toHaveText("3");
+  await page.screenshot({ path: "/tmp/visual-counter-3.png" });
 });
 
 // ---------------------------------------------------------------------------
 // Plain function component
 // ---------------------------------------------------------------------------
 
-test('plain function component renders correctly', async ({ page }) => {
+test("plain function component renders correctly", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     function Greeting({ name }: { name: string }) {
-      return createElement('p', { id: 'greeting' }, `Hello, ${name}!`);
+      return createElement("p", { id: "greeting" }, `Hello, ${name}!`);
     }
 
     render(
-      createElement(Greeting as never, { name: 'Playwright' }),
-      document.getElementById('root')!,
+      createElement(Greeting as never, { name: "Playwright" }),
+      document.getElementById("root")!,
     );
   });
 
-  await expect(page.locator('#greeting')).toHaveText('Hello, Playwright!');
-  await page.screenshot({ path: '/tmp/visual-plain-component.png' });
+  await expect(page.locator("#greeting")).toHaveText("Hello, Playwright!");
+  await page.screenshot({ path: "/tmp/visual-plain-component.png" });
 });
 
 // ---------------------------------------------------------------------------
 // Component renders component (lifecycle managed by parent)
 // ---------------------------------------------------------------------------
 
-test('generator renders child generator component', async ({ page }) => {
+test("generator renders child generator component", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     function* Badge({ label }: { label: string }) {
-      yield createElement('span', { id: 'badge', className: 'badge' }, label);
+      yield createElement("span", { id: "badge", className: "badge" }, label);
     }
 
     function* App() {
       yield createElement(
-        'div',
-        { id: 'app' },
-        createElement('h2', null, 'App'),
-        createElement(Badge as never, { label: 'Active' }),
+        "div",
+        { id: "app" },
+        createElement("h2", null, "App"),
+        createElement(Badge as never, { label: "Active" }),
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
   });
 
-  await expect(page.locator('#app h2')).toHaveText('App');
-  await expect(page.locator('#badge')).toHaveText('Active');
-  await page.screenshot({ path: '/tmp/visual-component-in-component.png' });
+  await expect(page.locator("#app h2")).toHaveText("App");
+  await expect(page.locator("#badge")).toHaveText("Active");
+  await page.screenshot({ path: "/tmp/visual-component-in-component.png" });
 });
 
-test('parent re-render preserves child generator state (memoization)', async ({ page }) => {
+test("parent re-render preserves child generator state (memoization)", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render, $state } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     function* Child(_: object) {
       const [count, setCount] = yield* $state(0);
       (window as unknown as Record<string, () => void>).rerenderChild = () =>
         setCount((c: number) => c + 1);
-      return createElement('span', { id: 'child-count' }, String(count));
+      return createElement("span", { id: "child-count" }, String(count));
     }
 
     function* Parent(_: object) {
@@ -212,107 +212,107 @@ test('parent re-render preserves child generator state (memoization)', async ({ 
       (window as unknown as Record<string, () => void>).rerenderParent = () =>
         setTick((t: number) => t + 1);
       // Child props never change → should be memoized
-      return createElement('div', null, createElement(Child as never, {}));
+      return createElement("div", null, createElement(Child as never, {}));
     }
 
-    render(createElement(Parent as never, {}), document.getElementById('root')!);
+    render(createElement(Parent as never, {}), document.getElementById("root")!);
   });
 
-  await expect(page.locator('#child-count')).toHaveText('0');
+  await expect(page.locator("#child-count")).toHaveText("0");
 
   // Increment child
   await page.evaluate(() => (window as unknown as Record<string, () => void>).rerenderChild());
-  await expect(page.locator('#child-count')).toHaveText('1');
+  await expect(page.locator("#child-count")).toHaveText("1");
 
   // Re-render parent with same child props → child is memoized, stays at 1
   await page.evaluate(() => (window as unknown as Record<string, () => void>).rerenderParent());
-  await expect(page.locator('#child-count')).toHaveText('1');
+  await expect(page.locator("#child-count")).toHaveText("1");
 
-  await page.screenshot({ path: '/tmp/visual-memoization.png' });
+  await page.screenshot({ path: "/tmp/visual-memoization.png" });
 });
 
 // ---------------------------------------------------------------------------
 // Context API visual test
 // ---------------------------------------------------------------------------
 
-test('context Provider supplies value to deeply nested consumer', async ({ page }) => {
+test("context Provider supplies value to deeply nested consumer", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, createContext, $context, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
-    const ThemeCtx = createContext<string>('light');
+    const ThemeCtx = createContext<string>("light");
 
     function* ThemeDisplay() {
       const theme = yield* $context(ThemeCtx);
-      return createElement('p', { id: 'theme' }, theme);
+      return createElement("p", { id: "theme" }, theme);
     }
 
     function* Section() {
-      yield createElement('div', null, createElement(ThemeDisplay as never, {}));
+      yield createElement("div", null, createElement(ThemeDisplay as never, {}));
     }
 
     render(
       createElement(
         ThemeCtx.Provider as never,
-        { value: 'dark' },
+        { value: "dark" },
         createElement(Section as never, {}),
       ),
-      document.getElementById('root')!,
+      document.getElementById("root")!,
     );
   });
 
-  await expect(page.locator('#theme')).toHaveText('dark');
-  await page.screenshot({ path: '/tmp/visual-context.png' });
+  await expect(page.locator("#theme")).toHaveText("dark");
+  await page.screenshot({ path: "/tmp/visual-context.png" });
 });
 
 // ---------------------------------------------------------------------------
 // Fragment
 // ---------------------------------------------------------------------------
 
-test('Fragment renders multiple children without a wrapper', async ({ page }) => {
+test("Fragment renders multiple children without a wrapper", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, Fragment, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     function* App() {
       yield createElement(
         Fragment,
         null,
-        createElement('p', { id: 'p1' }, 'First'),
-        createElement('p', { id: 'p2' }, 'Second'),
+        createElement("p", { id: "p1" }, "First"),
+        createElement("p", { id: "p2" }, "Second"),
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
   });
 
-  await expect(page.locator('#p1')).toHaveText('First');
-  await expect(page.locator('#p2')).toHaveText('Second');
-  await page.screenshot({ path: '/tmp/visual-fragment.png' });
+  await expect(page.locator("#p1")).toHaveText("First");
+  await expect(page.locator("#p2")).toHaveText("Second");
+  await page.screenshot({ path: "/tmp/visual-fragment.png" });
 });
 
 // ---------------------------------------------------------------------------
 // $context — selector and transform overloads
 // ---------------------------------------------------------------------------
 
-test('$context selector: consumer skips rerender when selected dep is unchanged', async ({
+test("$context selector: consumer skips rerender when selected dep is unchanged", async ({
   page,
 }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, createContext, $context, $ref, $state, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     type State = { name: string; count: number };
-    const Ctx = createContext<State>({ name: 'Alice', count: 0 });
+    const Ctx = createContext<State>({ name: "Alice", count: 0 });
 
     let setSt: ((v: State) => void) | null = null;
 
@@ -322,14 +322,14 @@ test('$context selector: consumer skips rerender when selected dep is unchanged'
       renders.current++;
       // Overload 2: selector only — rerender only when name changes
       const ctx = yield* $context(Ctx, (c) => [c.name]);
-      return createElement('div', { id: 'consumer' }, [
-        createElement('span', { id: 'name' }, ctx.name),
-        createElement('span', { id: 'renders' }, String(renders.current)),
+      return createElement("div", { id: "consumer" }, [
+        createElement("span", { id: "name" }, ctx.name),
+        createElement("span", { id: "renders" }, String(renders.current)),
       ]);
     }
 
     function* App() {
-      const [st, set] = yield* $state<State>({ name: 'Alice', count: 0 });
+      const [st, set] = yield* $state<State>({ name: "Alice", count: 0 });
       setSt = set;
       return createElement(
         Ctx.Provider as never,
@@ -338,41 +338,41 @@ test('$context selector: consumer skips rerender when selected dep is unchanged'
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
 
     // Expose setter on window for Playwright to call
     (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
   });
 
   // Initial state
-  await expect(page.locator('#name')).toHaveText('Alice');
-  await expect(page.locator('#renders')).toHaveText('1');
+  await expect(page.locator("#name")).toHaveText("Alice");
+  await expect(page.locator("#renders")).toHaveText("1");
 
   // Change only `count` — selector tracks `name`, so Consumer must NOT rerender.
   await page.evaluate(() => {
     type State = { name: string; count: number };
     const set = (window as unknown as Record<string, (v: State) => void>).__setSt;
-    set({ name: 'Alice', count: 99 });
+    set({ name: "Alice", count: 99 });
   });
 
-  await expect(page.locator('#name')).toHaveText('Alice');
-  await expect(page.locator('#renders')).toHaveText('1');
+  await expect(page.locator("#name")).toHaveText("Alice");
+  await expect(page.locator("#renders")).toHaveText("1");
 
-  await page.screenshot({ path: '/tmp/visual-ctx-selector-stable.png' });
+  await page.screenshot({ path: "/tmp/visual-ctx-selector-stable.png" });
 });
 
-test('$context selector: consumer rerenders in-place ($ref preserved) when selected dep changes', async ({
+test("$context selector: consumer rerenders in-place ($ref preserved) when selected dep changes", async ({
   page,
 }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, createContext, $context, $ref, $state, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     type State = { name: string; count: number };
-    const Ctx = createContext<State>({ name: 'Alice', count: 0 });
+    const Ctx = createContext<State>({ name: "Alice", count: 0 });
 
     let setSt: ((v: State) => void) | null = null;
 
@@ -381,14 +381,14 @@ test('$context selector: consumer rerenders in-place ($ref preserved) when selec
       renders.current++;
       // Selector tracks `name`. Rerender is in-place so $ref survives.
       const ctx = yield* $context(Ctx, (c) => [c.name]);
-      return createElement('div', { id: 'consumer' }, [
-        createElement('span', { id: 'name' }, ctx.name),
-        createElement('span', { id: 'renders' }, String(renders.current)),
+      return createElement("div", { id: "consumer" }, [
+        createElement("span", { id: "name" }, ctx.name),
+        createElement("span", { id: "renders" }, String(renders.current)),
       ]);
     }
 
     function* App() {
-      const [st, set] = yield* $state<State>({ name: 'Alice', count: 0 });
+      const [st, set] = yield* $state<State>({ name: "Alice", count: 0 });
       setSt = set;
       return createElement(
         Ctx.Provider as never,
@@ -397,45 +397,45 @@ test('$context selector: consumer rerenders in-place ($ref preserved) when selec
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
     (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
   });
 
-  await expect(page.locator('#name')).toHaveText('Alice');
-  await expect(page.locator('#renders')).toHaveText('1');
+  await expect(page.locator("#name")).toHaveText("Alice");
+  await expect(page.locator("#renders")).toHaveText("1");
 
   // Change only `count` — selector tracks `name`, so no rerender.
   await page.evaluate(() => {
     type State = { name: string; count: number };
     const set = (window as unknown as Record<string, (v: State) => void>).__setSt;
-    set({ name: 'Alice', count: 5 });
+    set({ name: "Alice", count: 5 });
   });
-  await expect(page.locator('#renders')).toHaveText('1');
+  await expect(page.locator("#renders")).toHaveText("1");
 
   // Change `name` — dep changed → in-place rerender → $ref increments to 2.
   await page.evaluate(() => {
     type State = { name: string; count: number };
     const set = (window as unknown as Record<string, (v: State) => void>).__setSt;
-    set({ name: 'Bob', count: 5 });
+    set({ name: "Bob", count: 5 });
   });
-  await expect(page.locator('#name')).toHaveText('Bob');
-  await expect(page.locator('#renders')).toHaveText('2');
+  await expect(page.locator("#name")).toHaveText("Bob");
+  await expect(page.locator("#renders")).toHaveText("2");
 
-  await page.screenshot({ path: '/tmp/visual-ctx-selector-changed.png' });
+  await page.screenshot({ path: "/tmp/visual-ctx-selector-changed.png" });
 });
 
-test('$context transform: suppresses rerender when dep stable; updates transform when dep changes', async ({
+test("$context transform: suppresses rerender when dep stable; updates transform when dep changes", async ({
   page,
 }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, createContext, $context, $ref, $state, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     type State = { name: string; count: number };
-    const Ctx = createContext<State>({ name: 'Alice', count: 0 });
+    const Ctx = createContext<State>({ name: "Alice", count: 0 });
 
     let setSt: ((v: State) => void) | null = null;
 
@@ -448,14 +448,14 @@ test('$context transform: suppresses rerender when dep stable; updates transform
         (c) => [c.name] as [string],
         (name) => name.toUpperCase(),
       );
-      return createElement('div', { id: 'consumer' }, [
-        createElement('span', { id: 'upper' }, upper),
-        createElement('span', { id: 'renders' }, String(renders.current)),
+      return createElement("div", { id: "consumer" }, [
+        createElement("span", { id: "upper" }, upper),
+        createElement("span", { id: "renders" }, String(renders.current)),
       ]);
     }
 
     function* App() {
-      const [st, set] = yield* $state<State>({ name: 'Alice', count: 0 });
+      const [st, set] = yield* $state<State>({ name: "Alice", count: 0 });
       setSt = set;
       return createElement(
         Ctx.Provider as never,
@@ -464,48 +464,48 @@ test('$context transform: suppresses rerender when dep stable; updates transform
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
     (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
   });
 
   // Initial: ALICE, rendered once
-  await expect(page.locator('#upper')).toHaveText('ALICE');
-  await expect(page.locator('#renders')).toHaveText('1');
+  await expect(page.locator("#upper")).toHaveText("ALICE");
+  await expect(page.locator("#renders")).toHaveText("1");
 
   // Change only count — selector tracks name, so rerender is suppressed.
   await page.evaluate(() => {
     type State = { name: string; count: number };
     const set = (window as unknown as Record<string, (v: State) => void>).__setSt;
-    set({ name: 'Alice', count: 7 });
+    set({ name: "Alice", count: 7 });
   });
   // Consumer skipped — render count stays at 1, value unchanged.
-  await expect(page.locator('#renders')).toHaveText('1');
-  await expect(page.locator('#upper')).toHaveText('ALICE');
+  await expect(page.locator("#renders")).toHaveText("1");
+  await expect(page.locator("#upper")).toHaveText("ALICE");
 
   // Change name — dep changed → in-place rerender → $ref increments to 2, transform produces BOB.
   await page.evaluate(() => {
     type State = { name: string; count: number };
     const set = (window as unknown as Record<string, (v: State) => void>).__setSt;
-    set({ name: 'Bob', count: 7 });
+    set({ name: "Bob", count: 7 });
   });
-  await expect(page.locator('#upper')).toHaveText('BOB');
-  await expect(page.locator('#renders')).toHaveText('2');
+  await expect(page.locator("#upper")).toHaveText("BOB");
+  await expect(page.locator("#renders")).toHaveText("2");
 
-  await page.screenshot({ path: '/tmp/visual-ctx-transform.png' });
+  await page.screenshot({ path: "/tmp/visual-ctx-transform.png" });
 });
 
-test('$context no-selector vs selector: no-selector updates on any field change, selector does not', async ({
+test("$context no-selector vs selector: no-selector updates on any field change, selector does not", async ({
   page,
 }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, createContext, $context, $ref, $state, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     type State = { name: string; count: number };
-    const Ctx = createContext<State>({ name: 'Alice', count: 0 });
+    const Ctx = createContext<State>({ name: "Alice", count: 0 });
 
     let setSt: ((v: State) => void) | null = null;
 
@@ -515,9 +515,9 @@ test('$context no-selector vs selector: no-selector updates on any field change,
       const renders = yield* $ref(0);
       renders.current++;
       const ctx = yield* $context(Ctx);
-      return createElement('div', null, [
-        createElement('span', { id: 'no-sel-count' }, String(ctx.count)),
-        createElement('span', { id: 'no-sel-renders' }, String(renders.current)),
+      return createElement("div", null, [
+        createElement("span", { id: "no-sel-count" }, String(ctx.count)),
+        createElement("span", { id: "no-sel-renders" }, String(renders.current)),
       ]);
     }
 
@@ -526,11 +526,11 @@ test('$context no-selector vs selector: no-selector updates on any field change,
       const renders = yield* $ref(0);
       renders.current++;
       yield* $context(Ctx, (c) => [c.name]);
-      return createElement('span', { id: 'sel-renders' }, String(renders.current));
+      return createElement("span", { id: "sel-renders" }, String(renders.current));
     }
 
     function* App() {
-      const [st, set] = yield* $state<State>({ name: 'Alice', count: 0 });
+      const [st, set] = yield* $state<State>({ name: "Alice", count: 0 });
       setSt = set;
       return createElement(Ctx.Provider as never, { value: st }, [
         createElement(NoSelectorConsumer as never, {}),
@@ -538,39 +538,39 @@ test('$context no-selector vs selector: no-selector updates on any field change,
       ]);
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
     (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
   });
 
-  await expect(page.locator('#no-sel-count')).toHaveText('0');
-  await expect(page.locator('#no-sel-renders')).toHaveText('1');
-  await expect(page.locator('#sel-renders')).toHaveText('1');
+  await expect(page.locator("#no-sel-count")).toHaveText("0");
+  await expect(page.locator("#no-sel-renders")).toHaveText("1");
+  await expect(page.locator("#sel-renders")).toHaveText("1");
 
   // Change only `count` — no-selector consumer rerenders in-place (renders=2,
   // sees new count); selector consumer is suppressed (still at renders=1).
   await page.evaluate(() => {
     type State = { name: string; count: number };
     const set = (window as unknown as Record<string, (v: State) => void>).__setSt;
-    set({ name: 'Alice', count: 5 });
+    set({ name: "Alice", count: 5 });
   });
 
-  await expect(page.locator('#no-sel-count')).toHaveText('5');
-  await expect(page.locator('#no-sel-renders')).toHaveText('2');
-  await expect(page.locator('#sel-renders')).toHaveText('1');
+  await expect(page.locator("#no-sel-count")).toHaveText("5");
+  await expect(page.locator("#no-sel-renders")).toHaveText("2");
+  await expect(page.locator("#sel-renders")).toHaveText("1");
 
-  await page.screenshot({ path: '/tmp/visual-ctx-no-selector.png' });
+  await page.screenshot({ path: "/tmp/visual-ctx-no-selector.png" });
 });
 
-test('$context selector: hook state preserved when rerender suppressed', async ({ page }) => {
+test("$context selector: hook state preserved when rerender suppressed", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
-    const { createElement, createContext, $context, $ref, $state, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+    const { createElement, createContext, $context, $state, render } = (
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     type State = { name: string; count: number };
-    const Ctx = createContext<State>({ name: 'Alice', count: 0 });
+    const Ctx = createContext<State>({ name: "Alice", count: 0 });
 
     let setCtx: ((v: State) => void) | null = null;
     let setLocal: ((v: number) => void) | null = null;
@@ -579,11 +579,11 @@ test('$context selector: hook state preserved when rerender suppressed', async (
       yield* $context(Ctx, (c) => [c.name]);
       const [local, sl] = yield* $state(42);
       setLocal = sl;
-      return createElement('span', { id: 'local' }, String(local));
+      return createElement("span", { id: "local" }, String(local));
     }
 
     function* App() {
-      const [st, set] = yield* $state<State>({ name: 'Alice', count: 0 });
+      const [st, set] = yield* $state<State>({ name: "Alice", count: 0 });
       setCtx = set;
       return createElement(
         Ctx.Provider as never,
@@ -592,7 +592,7 @@ test('$context selector: hook state preserved when rerender suppressed', async (
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
     (window as unknown as Record<string, unknown>).__setCtx = (v: State) => setCtx!(v);
     (window as unknown as Record<string, unknown>).__setLocal = (v: number) => setLocal!(v);
   });
@@ -602,50 +602,50 @@ test('$context selector: hook state preserved when rerender suppressed', async (
     const set = (window as unknown as Record<string, (v: number) => void>).__setLocal;
     set(100);
   });
-  await expect(page.locator('#local')).toHaveText('100');
+  await expect(page.locator("#local")).toHaveText("100");
 
   // Change only count — selector suppresses rerender, local state must survive
   await page.evaluate(() => {
     type State = { name: string; count: number };
     const set = (window as unknown as Record<string, (v: State) => void>).__setCtx;
-    set({ name: 'Alice', count: 99 });
+    set({ name: "Alice", count: 99 });
   });
-  await expect(page.locator('#local')).toHaveText('100');
+  await expect(page.locator("#local")).toHaveText("100");
 
-  await page.screenshot({ path: '/tmp/visual-ctx-hook-state-preserved.png' });
+  await page.screenshot({ path: "/tmp/visual-ctx-hook-state-preserved.png" });
 });
 
 // ---------------------------------------------------------------------------
 // Style application
 // ---------------------------------------------------------------------------
 
-test('inline styles are applied correctly', async ({ page }) => {
+test("inline styles are applied correctly", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     render(
       createElement(
-        'div',
+        "div",
         {
-          id: 'styled',
-          style: { backgroundColor: 'blue', color: 'white', padding: '8px' },
+          id: "styled",
+          style: { backgroundColor: "blue", color: "white", padding: "8px" },
         },
-        'Styled',
+        "Styled",
       ),
-      document.getElementById('root')!,
+      document.getElementById("root")!,
     );
   });
 
-  const el = page.locator('#styled');
-  await expect(el).toHaveText('Styled');
+  const el = page.locator("#styled");
+  await expect(el).toHaveText("Styled");
   // Verify styles are applied
   const bgColor = await el.evaluate((node: HTMLElement) => node.style.backgroundColor);
-  expect(bgColor).toBe('blue');
-  await page.screenshot({ path: '/tmp/visual-styles.png' });
+  expect(bgColor).toBe("blue");
+  await page.screenshot({ path: "/tmp/visual-styles.png" });
 });
 
 // ---------------------------------------------------------------------------
@@ -656,14 +656,14 @@ test('inline styles are applied correctly', async ({ page }) => {
 // skip pass, so at commit time shallowEqual returned true and the component
 // was never re-rendered with the new props (e.g. isPending: false).
 
-test('global patch: child prop change before patch survives to commit (disabled button re-enabled)', async ({
+test("global patch: child prop change before patch survives to commit (disabled button re-enabled)", async ({
   page,
 }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render, $state, startUIPatch, commitUIPatch } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     let setPending: ((v: boolean) => void) | null = null;
@@ -671,16 +671,16 @@ test('global patch: child prop change before patch survives to commit (disabled 
 
     // Child component: renders a button whose disabled state mirrors the prop
     function* Nav(props: { isPending: boolean }) {
-      return createElement('button', { id: 'nav-btn', disabled: props.isPending }, 'click');
+      return createElement("button", { id: "nav-btn", disabled: props.isPending }, "click");
     }
 
     function* App() {
       const [isPending, setP] = yield* $state(false);
       setPending = setP as never;
-      return createElement('div', null, createElement(Nav as never, { isPending }));
+      return createElement("div", null, createElement(Nav as never, { isPending }));
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
 
     // Step 1: set isPending=true BEFORE the patch (immediate DOM update)
     setPending!(true);
@@ -697,7 +697,7 @@ test('global patch: child prop change before patch survives to commit (disabled 
   });
 
   // During the patch the button must still be disabled (DOM is frozen)
-  await expect(page.locator('#nav-btn')).toBeDisabled();
+  await expect(page.locator("#nav-btn")).toBeDisabled();
 
   // Commit the patch
   await page.evaluate(() => {
@@ -705,25 +705,25 @@ test('global patch: child prop change before patch survives to commit (disabled 
   });
 
   // After commit the button must be re-enabled
-  await expect(page.locator('#nav-btn')).not.toBeDisabled();
-  await page.screenshot({ path: '/tmp/visual-patch-prop-update-global.png' });
+  await expect(page.locator("#nav-btn")).not.toBeDisabled();
+  await page.screenshot({ path: "/tmp/visual-patch-prop-update-global.png" });
 });
 
-test('local patch: child prop change before patch survives to commit (disabled button re-enabled)', async ({
+test("local patch: child prop change before patch survives to commit (disabled button re-enabled)", async ({
   page,
 }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render, $state, $uiPatch } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     let setPending: ((v: boolean) => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Nav(props: { isPending: boolean }) {
-      return createElement('button', { id: 'nav-btn', disabled: props.isPending }, 'click');
+      return createElement("button", { id: "nav-btn", disabled: props.isPending }, "click");
     }
 
     function* App() {
@@ -731,10 +731,10 @@ test('local patch: child prop change before patch survives to commit (disabled b
       capturedStartPatch = startPatch;
       const [isPending, setP] = yield* $state(false);
       setPending = setP as never;
-      return createElement('div', null, createElement(Nav as never, { isPending }));
+      return createElement("div", null, createElement(Nav as never, { isPending }));
     }
 
-    render(createElement(App as never, {}), document.getElementById('root')!);
+    render(createElement(App as never, {}), document.getElementById("root")!);
 
     // Step 1: set isPending=true BEFORE the patch (immediate DOM update)
     setPending!(true);
@@ -750,7 +750,7 @@ test('local patch: child prop change before patch survives to commit (disabled b
   });
 
   // DOM must be frozen — button still disabled
-  await expect(page.locator('#nav-btn')).toBeDisabled();
+  await expect(page.locator("#nav-btn")).toBeDisabled();
 
   // Commit
   await page.evaluate(() => {
@@ -758,40 +758,40 @@ test('local patch: child prop change before patch survives to commit (disabled b
   });
 
   // After commit the button must be re-enabled
-  await expect(page.locator('#nav-btn')).not.toBeDisabled();
-  await page.screenshot({ path: '/tmp/visual-patch-prop-update-local.png' });
+  await expect(page.locator("#nav-btn")).not.toBeDisabled();
+  await page.screenshot({ path: "/tmp/visual-patch-prop-update-local.png" });
 });
 
 // ---------------------------------------------------------------------------
 // $effect AbortSignal tests
 // ---------------------------------------------------------------------------
 
-test('$effect: AbortSignal abort count increments when deps change', async ({ page }) => {
+test("$effect: AbortSignal abort count increments when deps change", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render, $state, $effect } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     const win = window as unknown as Record<string, unknown>;
 
     function* SignalRow({ userId, activeId }: { userId: number; activeId: number }) {
-      const [status, setStatus] = yield* $state('idle');
+      const [status, setStatus] = yield* $state("idle");
       const [abortCount, setAbortCount] = yield* $state(0);
 
       yield* $effect(
         (signal: AbortSignal) => {
           if (activeId !== userId) {
-            setStatus('inactive');
+            setStatus("inactive");
             return;
           }
-          setStatus('polling');
+          setStatus("polling");
           signal.addEventListener(
-            'abort',
+            "abort",
             () => {
               setAbortCount((c: number) => c + 1);
-              setStatus('aborted');
+              setStatus("aborted");
             },
             { once: true },
           );
@@ -800,10 +800,10 @@ test('$effect: AbortSignal abort count increments when deps change', async ({ pa
       );
 
       return createElement(
-        'div',
+        "div",
         { id: `row-${userId}` },
-        createElement('span', { id: `status-${userId}` }, status),
-        createElement('span', { id: `aborts-${userId}` }, String(abortCount)),
+        createElement("span", { id: `status-${userId}` }, status),
+        createElement("span", { id: `aborts-${userId}` }, String(abortCount)),
       );
     }
 
@@ -812,7 +812,7 @@ test('$effect: AbortSignal abort count increments when deps change', async ({ pa
       win.setActiveId = setActiveId;
 
       return createElement(
-        'div',
+        "div",
         null,
         createElement(SignalRow, { userId: 1, activeId }),
         createElement(SignalRow, { userId: 2, activeId }),
@@ -820,52 +820,52 @@ test('$effect: AbortSignal abort count increments when deps change', async ({ pa
       );
     }
 
-    render(createElement(App, {}), document.getElementById('root')!);
+    render(createElement(App, {}), document.getElementById("root")!);
   });
 
   // Initial: user 1 is polling, others inactive, all abort counts 0
-  await expect(page.locator('#status-1')).toHaveText('polling');
-  await expect(page.locator('#aborts-1')).toHaveText('0');
-  await expect(page.locator('#status-2')).toHaveText('inactive');
-  await expect(page.locator('#status-3')).toHaveText('inactive');
+  await expect(page.locator("#status-1")).toHaveText("polling");
+  await expect(page.locator("#aborts-1")).toHaveText("0");
+  await expect(page.locator("#status-2")).toHaveText("inactive");
+  await expect(page.locator("#status-3")).toHaveText("inactive");
 
   // Switch to user 2 — user 1's abort count increases to 1
   await page.evaluate(() => {
     (window as unknown as { setActiveId: (v: number) => void }).setActiveId(2);
   });
 
-  await expect(page.locator('#status-2')).toHaveText('polling');
-  await expect(page.locator('#aborts-1')).toHaveText('1');
+  await expect(page.locator("#status-2")).toHaveText("polling");
+  await expect(page.locator("#aborts-1")).toHaveText("1");
   // status-1 is "inactive" because the effect re-runs with the new activeId
-  await expect(page.locator('#status-1')).toHaveText('inactive');
+  await expect(page.locator("#status-1")).toHaveText("inactive");
 
   // Switch to user 3 — user 2's abort count increases to 1
   await page.evaluate(() => {
     (window as unknown as { setActiveId: (v: number) => void }).setActiveId(3);
   });
 
-  await expect(page.locator('#status-3')).toHaveText('polling');
-  await expect(page.locator('#aborts-2')).toHaveText('1');
-  await expect(page.locator('#status-2')).toHaveText('inactive');
+  await expect(page.locator("#status-3")).toHaveText("polling");
+  await expect(page.locator("#aborts-2")).toHaveText("1");
+  await expect(page.locator("#status-2")).toHaveText("inactive");
 
   // Switch back to user 1 — user 3's abort count increases, user 1 still has 1
   await page.evaluate(() => {
     (window as unknown as { setActiveId: (v: number) => void }).setActiveId(1);
   });
 
-  await expect(page.locator('#status-1')).toHaveText('polling');
-  await expect(page.locator('#aborts-3')).toHaveText('1');
-  await expect(page.locator('#aborts-1')).toHaveText('1');
+  await expect(page.locator("#status-1")).toHaveText("polling");
+  await expect(page.locator("#aborts-3")).toHaveText("1");
+  await expect(page.locator("#aborts-1")).toHaveText("1");
 
-  await page.screenshot({ path: '/tmp/visual-abort-signal-deps-change.png' });
+  await page.screenshot({ path: "/tmp/visual-abort-signal-deps-change.png" });
 });
 
-test('$effect: AbortSignal is aborted on component unmount', async ({ page }) => {
+test("$effect: AbortSignal is aborted on component unmount", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render, $state, $effect, $ref } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     function* Ticker() {
@@ -881,7 +881,7 @@ test('$effect: AbortSignal is aborted on component unmount', async ({ page }) =>
         }, 100);
 
         signal.addEventListener(
-          'abort',
+          "abort",
           () => {
             clearInterval(id);
             abortedRef.current = true;
@@ -893,10 +893,10 @@ test('$effect: AbortSignal is aborted on component unmount', async ({ page }) =>
       }, []);
 
       return createElement(
-        'div',
-        { id: 'ticker' },
-        createElement('span', { id: 'tick-count' }, String(count)),
-        createElement('span', { id: 'tick-aborted' }, String(abortedRef.current)),
+        "div",
+        { id: "ticker" },
+        createElement("span", { id: "tick-count" }, String(count)),
+        createElement("span", { id: "tick-aborted" }, String(abortedRef.current)),
       );
     }
 
@@ -905,21 +905,21 @@ test('$effect: AbortSignal is aborted on component unmount', async ({ page }) =>
       (window as unknown as Record<string, unknown>).setShow = setShow;
 
       return createElement(
-        'div',
+        "div",
         null,
-        show ? createElement(Ticker, {}) : createElement('span', { id: 'gone' }, 'unmounted'),
+        show ? createElement(Ticker, {}) : createElement("span", { id: "gone" }, "unmounted"),
       );
     }
 
-    render(createElement(App, {}), document.getElementById('root')!);
+    render(createElement(App, {}), document.getElementById("root")!);
   });
 
   // Ticker should be running
-  await expect(page.locator('#ticker')).toBeAttached();
+  await expect(page.locator("#ticker")).toBeAttached();
 
   // Wait for a couple ticks
   await page.waitForTimeout(350);
-  const countBefore = Number(await page.locator('#tick-count').textContent());
+  const countBefore = Number(await page.locator("#tick-count").textContent());
   expect(countBefore).toBeGreaterThanOrEqual(2);
 
   // Unmount the ticker
@@ -927,28 +927,28 @@ test('$effect: AbortSignal is aborted on component unmount', async ({ page }) =>
     (window as unknown as { setShow: (v: boolean) => void }).setShow(false);
   });
 
-  await expect(page.locator('#gone')).toHaveText('unmounted');
+  await expect(page.locator("#gone")).toHaveText("unmounted");
 
   // The ticker should be gone and the interval stopped (signal aborted)
-  await expect(page.locator('#ticker')).not.toBeAttached();
+  await expect(page.locator("#ticker")).not.toBeAttached();
 
-  await page.screenshot({ path: '/tmp/visual-abort-signal-unmount.png' });
+  await page.screenshot({ path: "/tmp/visual-abort-signal-unmount.png" });
 });
 
-test('$effect: AbortSignal aborts async work (fetch-like) on deps change', async ({ page }) => {
+test("$effect: AbortSignal aborts async work (fetch-like) on deps change", async ({ page }) => {
   await setupPage(page);
 
   await page.evaluate(() => {
     const { createElement, render, $state, $effect } = (
-      window as unknown as { Yielderact: typeof import('../src/index') }
+      window as unknown as { Yielderact: typeof import("../src/index") }
     ).Yielderact;
 
     function* AsyncWorker({ taskId }: { taskId: number }) {
-      const [result, setResult] = yield* $state('pending');
+      const [result, setResult] = yield* $state("pending");
 
       yield* $effect(
         (signal: AbortSignal) => {
-          setResult('pending');
+          setResult("pending");
           // Simulate async work that respects the signal
           const timer = setTimeout(() => {
             if (!signal.aborted) {
@@ -957,7 +957,7 @@ test('$effect: AbortSignal aborts async work (fetch-like) on deps change', async
           }, 300);
 
           signal.addEventListener(
-            'abort',
+            "abort",
             () => {
               clearTimeout(timer);
               setResult(`cancelled-${taskId}`);
@@ -968,7 +968,7 @@ test('$effect: AbortSignal aborts async work (fetch-like) on deps change', async
         [taskId],
       );
 
-      return createElement('span', { id: 'async-result' }, result);
+      return createElement("span", { id: "async-result" }, result);
     }
 
     function* App() {
@@ -976,18 +976,18 @@ test('$effect: AbortSignal aborts async work (fetch-like) on deps change', async
       (window as unknown as Record<string, unknown>).setTaskId = setTaskId;
 
       return createElement(
-        'div',
+        "div",
         null,
-        createElement('span', { id: 'task-id' }, String(taskId)),
+        createElement("span", { id: "task-id" }, String(taskId)),
         createElement(AsyncWorker, { taskId }),
       );
     }
 
-    render(createElement(App, {}), document.getElementById('root')!);
+    render(createElement(App, {}), document.getElementById("root")!);
   });
 
   // Initial: pending then resolves to done-1
-  await expect(page.locator('#async-result')).toHaveText('done-1', { timeout: 2000 });
+  await expect(page.locator("#async-result")).toHaveText("done-1", { timeout: 2000 });
 
   // Change task before it can complete — previous is cancelled, new one starts
   await page.evaluate(() => {
@@ -995,8 +995,8 @@ test('$effect: AbortSignal aborts async work (fetch-like) on deps change', async
   });
 
   // Should quickly show cancelled for task 1, then resolve to done-2
-  await expect(page.locator('#async-result')).toHaveText('done-2', { timeout: 2000 });
-  await expect(page.locator('#task-id')).toHaveText('2');
+  await expect(page.locator("#async-result")).toHaveText("done-2", { timeout: 2000 });
+  await expect(page.locator("#task-id")).toHaveText("2");
 
-  await page.screenshot({ path: '/tmp/visual-abort-signal-async-cancel.png' });
+  await page.screenshot({ path: "/tmp/visual-abort-signal-async-cancel.png" });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,14 +1,14 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './playwright-tests',
+  testDir: "./playwright-tests",
   use: {
     headless: true,
   },
   projects: [
-    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
-    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
-    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+    { name: "firefox", use: { ...devices["Desktop Firefox"] } },
+    { name: "webkit", use: { ...devices["Desktop Safari"] } },
   ],
-  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  reporter: [["list"], ["html", { open: "never", outputFolder: "playwright-report" }]],
 });

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -1,17 +1,17 @@
-import { createElement } from '../jsx';
-import { createContext, $context } from '../context';
-import { render } from '../render';
-import { $state } from '../hooks';
+import { $context, createContext } from "../context";
+import { $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // $context is now a generator – components must call it with yield*
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('createContext / $context', () => {
+describe("createContext / $context", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -19,97 +19,97 @@ describe('createContext / $context', () => {
     document.body.removeChild(container);
   });
 
-  it('provides the default value when no Provider is present', () => {
-    const Ctx = createContext('default');
+  it("provides the default value when no Provider is present", () => {
+    const Ctx = createContext("default");
 
     function* Consumer() {
       const value = yield* $context(Ctx);
-      return createElement('span', null, value);
+      return createElement("span", null, value);
     }
 
     render(createElement(Consumer as never, {}), container);
-    expect(container.querySelector('span')!.textContent).toBe('default');
+    expect(container.querySelector("span")!.textContent).toBe("default");
   });
 
-  it('passes a value through Context.Provider to a consumer component', () => {
-    const Ctx = createContext('default');
+  it("passes a value through Context.Provider to a consumer component", () => {
+    const Ctx = createContext("default");
 
     function* Consumer() {
       const value = yield* $context(Ctx);
-      return createElement('span', null, value);
+      return createElement("span", null, value);
     }
 
     render(
       createElement(
         Ctx.Provider as never,
-        { value: 'provided' },
+        { value: "provided" },
         createElement(Consumer as never, {}),
       ),
       container,
     );
-    expect(container.querySelector('span')!.textContent).toBe('provided');
+    expect(container.querySelector("span")!.textContent).toBe("provided");
   });
 
-  it('nested Providers shadow the outer value', () => {
-    const Ctx = createContext('outer');
+  it("nested Providers shadow the outer value", () => {
+    const Ctx = createContext("outer");
 
     function* Consumer() {
       const value = yield* $context(Ctx);
-      return createElement('span', null, value);
+      return createElement("span", null, value);
     }
 
     render(
       createElement(
         Ctx.Provider as never,
-        { value: 'outer' },
+        { value: "outer" },
         createElement(
-          'div',
+          "div",
           null,
           createElement(
             Ctx.Provider as never,
-            { value: 'inner' },
+            { value: "inner" },
             createElement(Consumer as never, {}),
           ),
         ),
       ),
       container,
     );
-    expect(container.querySelector('span')!.textContent).toBe('inner');
+    expect(container.querySelector("span")!.textContent).toBe("inner");
   });
 
-  it('consumer outside Provider still gets default value', () => {
+  it("consumer outside Provider still gets default value", () => {
     const Ctx = createContext(42);
 
     function* Consumer() {
       const val = yield* $context(Ctx);
-      return createElement('span', null, String(val));
+      return createElement("span", null, String(val));
     }
 
     render(
       createElement(
-        'div',
+        "div",
         null,
         createElement(
           Ctx.Provider as never,
           { value: 99 },
-          createElement('span', { id: 'inside' }, 'ignored'),
+          createElement("span", { id: "inside" }, "ignored"),
         ),
         createElement(Consumer as never, {}),
       ),
       container,
     );
-    const spans = container.querySelectorAll('span');
-    const consumerSpan = Array.from(spans).find((s) => s.textContent === '42');
+    const spans = container.querySelectorAll("span");
+    const consumerSpan = Array.from(spans).find((s) => s.textContent === "42");
     expect(consumerSpan).toBeTruthy();
   });
 
-  it('generator component reads context on every re-render', () => {
+  it("generator component reads context on every re-render", () => {
     const Ctx = createContext(0);
     let setTheme: ((v: number) => void) | null = null;
 
     function* Consumer() {
       const val = yield* $context(Ctx);
-      return createElement('span', null, String(val));
+      return createElement("span", null, String(val));
     }
 
     function* Parent() {
@@ -123,18 +123,18 @@ describe('createContext / $context', () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('span')!.textContent).toBe('7');
+    expect(container.querySelector("span")!.textContent).toBe("7");
 
     setTheme!(99);
-    expect(container.querySelector('span')!.textContent).toBe('99');
+    expect(container.querySelector("span")!.textContent).toBe("99");
   });
 
   // ── Scoping correctness tests (expose the "global ctxMap" bug) ──────────────
 
-  it('context Provider value change preserves descendant component state', () => {
+  it("context Provider value change preserves descendant component state", () => {
     // When the provider value changes the child component must NOT be remounted –
     // any local state it holds should survive the context update.
-    const Ctx = createContext('initial');
+    const Ctx = createContext("initial");
     let setCtxValue: ((v: string) => void) | null = null;
     let setChildCount: ((v: number) => void) | null = null;
 
@@ -142,11 +142,11 @@ describe('createContext / $context', () => {
       const [count, setCount] = yield* $state(0);
       setChildCount = setCount;
       const ctxVal = yield* $context(Ctx);
-      return createElement('div', { 'data-testid': 'child' }, `${ctxVal}:${count}`);
+      return createElement("div", { "data-testid": "child" }, `${ctxVal}:${count}`);
     }
 
     function* Parent() {
-      const [val, setVal] = yield* $state('A');
+      const [val, setVal] = yield* $state("A");
       setCtxValue = setVal;
       return createElement(
         Ctx.Provider as never,
@@ -156,35 +156,35 @@ describe('createContext / $context', () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe('A:0');
+    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("A:0");
 
     // Build up state in the child component
     setChildCount!(5);
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe('A:5');
+    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("A:5");
 
     // Change the context value – child state must NOT be reset
-    setCtxValue!('B');
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe('B:5');
+    setCtxValue!("B");
+    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("B:5");
   });
 
-  it('context update propagates through non-consuming intermediate components', () => {
+  it("context update propagates through non-consuming intermediate components", () => {
     // A component that does NOT consume the context must still pass context
     // changes through to a deeply nested consumer.
-    const Ctx = createContext('default');
+    const Ctx = createContext("default");
     let setCtxValue: ((v: string) => void) | null = null;
 
     function* Consumer() {
       const val = yield* $context(Ctx);
-      return createElement('span', { 'data-testid': 'consumer' }, val);
+      return createElement("span", { "data-testid": "consumer" }, val);
     }
 
     // Middle does NOT consume Ctx but is in the subtree
     function* Middle() {
-      return createElement('div', null, createElement(Consumer as never, {}));
+      return createElement("div", null, createElement(Consumer as never, {}));
     }
 
     function* Root() {
-      const [val, setVal] = yield* $state('first');
+      const [val, setVal] = yield* $state("first");
       setCtxValue = setVal;
       return createElement(
         Ctx.Provider as never,
@@ -194,36 +194,36 @@ describe('createContext / $context', () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('first');
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("first");
 
-    setCtxValue!('second');
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('second');
+    setCtxValue!("second");
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("second");
   });
 
-  it('two sibling providers of the same context are isolated', () => {
+  it("two sibling providers of the same context are isolated", () => {
     // Two independent Provider subtrees for the same context must not interfere
     // with each other when either re-renders.
-    const Ctx = createContext('default');
+    const Ctx = createContext("default");
     let setA: ((v: string) => void) | null = null;
     let setB: ((v: string) => void) | null = null;
 
     function* ConsumerA() {
       const val = yield* $context(Ctx);
-      return createElement('span', { 'data-testid': 'a' }, val);
+      return createElement("span", { "data-testid": "a" }, val);
     }
 
     function* ConsumerB() {
       const val = yield* $context(Ctx);
-      return createElement('span', { 'data-testid': 'b' }, val);
+      return createElement("span", { "data-testid": "b" }, val);
     }
 
     function* Root() {
-      const [valA, sA] = yield* $state('A1');
-      const [valB, sB] = yield* $state('B1');
+      const [valA, sA] = yield* $state("A1");
+      const [valB, sB] = yield* $state("B1");
       setA = sA;
       setB = sB;
       return createElement(
-        'div',
+        "div",
         null,
         createElement(
           Ctx.Provider as never,
@@ -239,40 +239,40 @@ describe('createContext / $context', () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe('A1');
-    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe('B1');
+    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe("A1");
+    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe("B1");
 
-    setA!('A2');
-    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe('A2');
-    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe('B1');
+    setA!("A2");
+    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe("A2");
+    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe("B1");
 
-    setB!('B2');
-    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe('A2');
-    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe('B2');
+    setB!("B2");
+    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe("A2");
+    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe("B2");
   });
 
-  it('inner Provider overrides outer Provider for the same context', () => {
+  it("inner Provider overrides outer Provider for the same context", () => {
     // A component that re-provides the same context must shadow the outer value
     // for all its descendants, even after the outer value changes.
-    const Ctx = createContext('default');
+    const Ctx = createContext("default");
     let setOuter: ((v: string) => void) | null = null;
 
     function* Consumer() {
       const val = yield* $context(Ctx);
-      return createElement('span', { 'data-testid': 'consumer' }, val);
+      return createElement("span", { "data-testid": "consumer" }, val);
     }
 
     // Middle re-provides a fixed inner value
     function* Middle() {
       return createElement(
         Ctx.Provider as never,
-        { value: 'inner' },
+        { value: "inner" },
         createElement(Consumer as never, {}),
       );
     }
 
     function* Root() {
-      const [outer, setOuter_] = yield* $state('outer-1');
+      const [outer, setOuter_] = yield* $state("outer-1");
       setOuter = setOuter_;
       return createElement(
         Ctx.Provider as never,
@@ -283,36 +283,36 @@ describe('createContext / $context', () => {
 
     render(createElement(Root as never, {}), container);
     // Consumer is inside Middle's inner provider → sees "inner"
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('inner');
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("inner");
 
     // Change outer value – Consumer must still see "inner" (not the outer value)
-    setOuter!('outer-2');
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('inner');
+    setOuter!("outer-2");
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("inner");
   });
 
-  it('parent reads outer context while child reads overridden inner context', () => {
+  it("parent reads outer context while child reads overridden inner context", () => {
     // A generator that both consumes an outer context value AND re-provides it
     // must receive the outer value itself while descendants receive the inner value.
-    const Ctx = createContext('default');
+    const Ctx = createContext("default");
     let setOuter: ((v: string) => void) | null = null;
 
     function* Child() {
       const val = yield* $context(Ctx);
-      return createElement('span', { 'data-testid': 'child' }, val);
+      return createElement("span", { "data-testid": "child" }, val);
     }
 
     function* Middle() {
       const outerVal = yield* $context(Ctx);
       return createElement(
-        'div',
+        "div",
         null,
-        createElement('span', { 'data-testid': 'middle' }, outerVal),
-        createElement(Ctx.Provider as never, { value: 'inner' }, createElement(Child as never, {})),
+        createElement("span", { "data-testid": "middle" }, outerVal),
+        createElement(Ctx.Provider as never, { value: "inner" }, createElement(Child as never, {})),
       );
     }
 
     function* Root() {
-      const [val, setVal] = yield* $state('outer');
+      const [val, setVal] = yield* $state("outer");
       setOuter = setVal;
       return createElement(
         Ctx.Provider as never,
@@ -322,41 +322,41 @@ describe('createContext / $context', () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="middle"]')!.textContent).toBe('outer');
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe('inner');
+    expect(container.querySelector('[data-testid="middle"]')!.textContent).toBe("outer");
+    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("inner");
 
-    setOuter!('outer-2');
+    setOuter!("outer-2");
     // Middle should see the new outer value
-    expect(container.querySelector('[data-testid="middle"]')!.textContent).toBe('outer-2');
+    expect(container.querySelector('[data-testid="middle"]')!.textContent).toBe("outer-2");
     // Child must still see "inner" (provided by Middle's inner Provider)
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe('inner');
+    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("inner");
   });
 
-  it('non-consuming intermediate component state survives context update', () => {
+  it("non-consuming intermediate component state survives context update", () => {
     // A component that does NOT consume the context must keep its own state
     // when an ancestor provider value changes.
-    const Ctx = createContext('initial');
+    const Ctx = createContext("initial");
     let setCtxValue: ((v: string) => void) | null = null;
     let setMiddleCount: ((v: number) => void) | null = null;
 
     function* Consumer() {
       const val = yield* $context(Ctx);
-      return createElement('span', { 'data-testid': 'consumer' }, val);
+      return createElement("span", { "data-testid": "consumer" }, val);
     }
 
     function* Middle() {
       const [count, setCount] = yield* $state(0);
       setMiddleCount = setCount;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement('span', { 'data-testid': 'middle-count' }, String(count)),
+        createElement("span", { "data-testid": "middle-count" }, String(count)),
         createElement(Consumer as never, {}),
       );
     }
 
     function* Root() {
-      const [val, setVal] = yield* $state('v1');
+      const [val, setVal] = yield* $state("v1");
       setCtxValue = setVal;
       return createElement(
         Ctx.Provider as never,
@@ -366,36 +366,36 @@ describe('createContext / $context', () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('v1');
-    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe('0');
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("v1");
+    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe("0");
 
     // Build state in the intermediate (non-consuming) component
     setMiddleCount!(7);
-    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe('7');
+    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe("7");
 
     // Context changes – Middle's state (count=7) must be preserved
-    setCtxValue!('v2');
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('v2');
-    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe('7');
+    setCtxValue!("v2");
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("v2");
+    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe("7");
   });
 
-  it('multiple different contexts are independently scoped', () => {
+  it("multiple different contexts are independently scoped", () => {
     // Two separate contexts must be completely independent – changing one must
     // not affect the other.
-    const CtxA = createContext('a-default');
-    const CtxB = createContext('b-default');
+    const CtxA = createContext("a-default");
+    const CtxB = createContext("b-default");
     let setA: ((v: string) => void) | null = null;
     let setB: ((v: string) => void) | null = null;
 
     function* Consumer() {
       const a = yield* $context(CtxA);
       const b = yield* $context(CtxB);
-      return createElement('span', { 'data-testid': 'consumer' }, `${a}|${b}`);
+      return createElement("span", { "data-testid": "consumer" }, `${a}|${b}`);
     }
 
     function* Root() {
-      const [valA, sA] = yield* $state('A1');
-      const [valB, sB] = yield* $state('B1');
+      const [valA, sA] = yield* $state("A1");
+      const [valB, sB] = yield* $state("B1");
       setA = sA;
       setB = sB;
       return createElement(
@@ -410,22 +410,22 @@ describe('createContext / $context', () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('A1|B1');
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("A1|B1");
 
-    setA!('A2');
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('A2|B1');
+    setA!("A2");
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("A2|B1");
 
-    setB!('B2');
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe('A2|B2');
+    setB!("B2");
+    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("A2|B2");
   });
 
-  describe('$context with selector', () => {
-    it('selector-only: returns full context value when selector present', () => {
+  describe("$context with selector", () => {
+    it("selector-only: returns full context value when selector present", () => {
       const Ctx = createContext({ a: 1, b: 2 });
 
       function* Consumer() {
         const val = yield* $context(Ctx, (c) => [c.a]);
-        return createElement('span', null, `${val.a}:${val.b}`);
+        return createElement("span", null, `${val.a}:${val.b}`);
       }
 
       render(
@@ -436,10 +436,10 @@ describe('createContext / $context', () => {
         ),
         container,
       );
-      expect(container.querySelector('span')!.textContent).toBe('1:2');
+      expect(container.querySelector("span")!.textContent).toBe("1:2");
     });
 
-    it('selector-only: suppresses rerender when selected deps are stable', () => {
+    it("selector-only: suppresses rerender when selected deps are stable", () => {
       const Ctx = createContext({ a: 0, b: 0 });
       let setVal: ((v: { a: number; b: number }) => void) | null = null;
       let renderCount = 0;
@@ -447,7 +447,7 @@ describe('createContext / $context', () => {
       function* Consumer() {
         yield* $context(Ctx, (c) => [c.a]);
         renderCount++;
-        return createElement('span', null, String(renderCount));
+        return createElement("span", null, String(renderCount));
       }
 
       function* Parent() {
@@ -466,10 +466,10 @@ describe('createContext / $context', () => {
       // Change only `b` — selector selects `a`, so Consumer should NOT rerender.
       setVal!({ a: 1, b: 99 });
       expect(renderCount).toBe(1);
-      expect(container.querySelector('span')!.textContent).toBe('1');
+      expect(container.querySelector("span")!.textContent).toBe("1");
     });
 
-    it('selector-only: rerenders when selected dep changes', () => {
+    it("selector-only: rerenders when selected dep changes", () => {
       const Ctx = createContext({ a: 0, b: 0 });
       let setVal: ((v: { a: number; b: number }) => void) | null = null;
       let renderCount = 0;
@@ -477,7 +477,7 @@ describe('createContext / $context', () => {
       function* Consumer() {
         const val = yield* $context(Ctx, (c) => [c.a]);
         renderCount++;
-        return createElement('span', null, String(val.a));
+        return createElement("span", null, String(val.a));
       }
 
       function* Parent() {
@@ -496,11 +496,11 @@ describe('createContext / $context', () => {
       // Change `a` — selector selects `a`, so Consumer SHOULD rerender.
       setVal!({ a: 99, b: 1 });
       expect(renderCount).toBe(2);
-      expect(container.querySelector('span')!.textContent).toBe('99');
+      expect(container.querySelector("span")!.textContent).toBe("99");
     });
 
-    it('selector + transform: returns transformed value', () => {
-      const Ctx = createContext({ name: 'Alice', age: 30 });
+    it("selector + transform: returns transformed value", () => {
+      const Ctx = createContext({ name: "Alice", age: 30 });
 
       function* Consumer() {
         const name = yield* $context(
@@ -508,22 +508,22 @@ describe('createContext / $context', () => {
           (c) => [c.name] as [string],
           (n) => n.toUpperCase(),
         );
-        return createElement('span', null, name);
+        return createElement("span", null, name);
       }
 
       render(
         createElement(
           Ctx.Provider as never,
-          { value: { name: 'Alice', age: 30 } },
+          { value: { name: "Alice", age: 30 } },
           createElement(Consumer as never, {}),
         ),
         container,
       );
-      expect(container.querySelector('span')!.textContent).toBe('ALICE');
+      expect(container.querySelector("span")!.textContent).toBe("ALICE");
     });
 
-    it('selector + transform: suppresses rerender when deps stable', () => {
-      const Ctx = createContext({ name: 'Alice', count: 0 });
+    it("selector + transform: suppresses rerender when deps stable", () => {
+      const Ctx = createContext({ name: "Alice", count: 0 });
       let setVal: ((v: { name: string; count: number }) => void) | null = null;
       let renderCount = 0;
 
@@ -534,11 +534,11 @@ describe('createContext / $context', () => {
           (n) => n.toUpperCase(),
         );
         renderCount++;
-        return createElement('span', null, String(renderCount));
+        return createElement("span", null, String(renderCount));
       }
 
       function* Parent() {
-        const [val, sv] = yield* $state({ name: 'Alice', count: 0 });
+        const [val, sv] = yield* $state({ name: "Alice", count: 0 });
         setVal = sv;
         return createElement(
           Ctx.Provider as never,
@@ -551,11 +551,11 @@ describe('createContext / $context', () => {
       expect(renderCount).toBe(1);
 
       // Change only `count` — selector tracks `name`, so no rerender.
-      setVal!({ name: 'Alice', count: 99 });
+      setVal!({ name: "Alice", count: 99 });
       expect(renderCount).toBe(1);
     });
 
-    it('selector: hook state ($state) is preserved across suppressed rerenders', () => {
+    it("selector: hook state ($state) is preserved across suppressed rerenders", () => {
       const Ctx = createContext({ a: 0, b: 0 });
       let setVal: ((v: { a: number; b: number }) => void) | null = null;
       let setLocal: ((v: number) => void) | null = null;
@@ -564,7 +564,7 @@ describe('createContext / $context', () => {
         yield* $context(Ctx, (c) => [c.a]);
         const [local, sl] = yield* $state(42);
         setLocal = sl;
-        return createElement('span', null, String(local));
+        return createElement("span", null, String(local));
       }
 
       function* Parent() {
@@ -580,15 +580,15 @@ describe('createContext / $context', () => {
       render(createElement(Parent as never, {}), container);
       // Update local state in Consumer.
       setLocal!(100);
-      expect(container.querySelector('span')!.textContent).toBe('100');
+      expect(container.querySelector("span")!.textContent).toBe("100");
 
       // Trigger a context change that should be suppressed (b changes, a stable).
       setVal!({ a: 1, b: 99 });
       // Consumer should NOT have remounted — local state preserved.
-      expect(container.querySelector('span')!.textContent).toBe('100');
+      expect(container.querySelector("span")!.textContent).toBe("100");
     });
 
-    it('no-selector consumer rerenders in-place when Provider value changes', () => {
+    it("no-selector consumer rerenders in-place when Provider value changes", () => {
       const Ctx = createContext({ a: 0, b: 0 });
       let setVal: ((v: { a: number; b: number }) => void) | null = null;
       let renderCount = 0;
@@ -596,7 +596,7 @@ describe('createContext / $context', () => {
       function* Consumer() {
         const val = yield* $context(Ctx);
         renderCount++;
-        return createElement('span', null, `${val.a}:${val.b}`);
+        return createElement("span", null, `${val.a}:${val.b}`);
       }
 
       function* Parent() {
@@ -615,7 +615,7 @@ describe('createContext / $context', () => {
       // Change only `b` — Consumer has no selector so it always rerenders.
       setVal!({ a: 1, b: 99 });
       expect(renderCount).toBe(2);
-      expect(container.querySelector('span')!.textContent).toBe('1:99');
+      expect(container.querySelector("span")!.textContent).toBe("1:99");
     });
   });
 });

--- a/src/__tests__/create-root.test.ts
+++ b/src/__tests__/create-root.test.ts
@@ -1,15 +1,15 @@
-import { createElement } from '../jsx';
-import { createRoot, render } from '../render';
-import { $state, $patchContext } from '../hooks';
-import { _getCurrentBatch, _getCtxMap } from '../context';
+import { _getCtxMap, _getCurrentBatch } from "../context";
+import { $patchContext, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { createRoot, render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('createRoot', () => {
+describe("createRoot", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -17,23 +17,23 @@ describe('createRoot', () => {
     document.body.removeChild(container);
   });
 
-  it('renders a plain component into the container', () => {
+  it("renders a plain component into the container", () => {
     function Greeting({ name }: { name: string }) {
-      return createElement('h1', null, `Hello, ${name}!`);
+      return createElement("h1", null, `Hello, ${name}!`);
     }
     const root = createRoot(container);
-    root.render(createElement(Greeting as never, { name: 'World' }));
-    expect(container.querySelector('h1')!.textContent).toBe('Hello, World!');
+    root.render(createElement(Greeting as never, { name: "World" }));
+    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
   });
 
-  it('renders a generator component into the container', () => {
+  it("renders a generator component into the container", () => {
     function* Counter() {
       const [count] = yield* $state(0);
-      return createElement('span', null, String(count));
+      return createElement("span", null, String(count));
     }
     const root = createRoot(container);
     root.render(createElement(Counter as never, {}));
-    expect(container.textContent).toBe('0');
+    expect(container.textContent).toBe("0");
   });
 
   it('sets $patch context to "default" for the rendered tree', () => {
@@ -41,27 +41,27 @@ describe('createRoot', () => {
 
     function* Comp() {
       capturedBatch = _getCurrentBatch();
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     const root = createRoot(container);
     root.render(createElement(Comp as never, {}));
-    expect(capturedBatch).toBe('default');
+    expect(capturedBatch).toBe("default");
   });
 
-  it('restores context map after render', () => {
+  it("restores context map after render", () => {
     const before = _getCtxMap();
     const root = createRoot(container);
-    root.render(createElement('div', null));
+    root.render(createElement("div", null));
     expect(_getCtxMap()).toBe(before);
   });
 });
 
-describe('$patchContext', () => {
+describe("$patchContext", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -70,140 +70,140 @@ describe('$patchContext', () => {
   });
 
   it('returns "default" when rendered under createRoot', () => {
-    let patchValue: 'live' | 'default' | undefined;
+    let patchValue: "live" | "default" | undefined;
 
     function* Comp() {
       patchValue = yield* $patchContext();
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     const root = createRoot(container);
     root.render(createElement(Comp as never, {}));
-    expect(patchValue).toBe('default');
+    expect(patchValue).toBe("default");
   });
 
   it('returns "live" inside a $patch="live" parent element', () => {
-    let patchValue: 'live' | 'default' | undefined;
+    let patchValue: "live" | "default" | undefined;
 
     function* Child() {
       patchValue = yield* $patchContext();
-      return createElement('span', null, patchValue);
+      return createElement("span", null, patchValue);
     }
 
     const root = createRoot(container);
-    root.render(createElement('div', { $patch: 'live' }, createElement(Child as never, {})));
-    expect(patchValue).toBe('live');
+    root.render(createElement("div", { $patch: "live" }, createElement(Child as never, {})));
+    expect(patchValue).toBe("live");
   });
 
   it('returns "live" for a component with $patch="live"', () => {
-    let patchValue: 'live' | 'default' | undefined;
+    let patchValue: "live" | "default" | undefined;
 
     function* Comp() {
       patchValue = yield* $patchContext();
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     const root = createRoot(container);
-    root.render(createElement(Comp as never, { $patch: 'live' }));
-    expect(patchValue).toBe('live');
+    root.render(createElement(Comp as never, { $patch: "live" }));
+    expect(patchValue).toBe("live");
   });
 
-  it('rerenders when inherited batch changes', () => {
+  it("rerenders when inherited batch changes", () => {
     let setLive: ((v: boolean) => void) | null = null;
-    let patchValue: 'live' | 'default' | undefined;
+    let patchValue: "live" | "default" | undefined;
 
     function* Child() {
       patchValue = yield* $patchContext();
-      return createElement('span', { id: 'patch' }, patchValue);
+      return createElement("span", { id: "patch" }, patchValue);
     }
 
     function* Parent() {
       const [live, setLive_] = yield* $state(false);
       setLive = setLive_;
       return createElement(
-        'div',
-        { $patch: live ? 'live' : 'default' },
+        "div",
+        { $patch: live ? "live" : "default" },
         createElement(Child as never, {}),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(patchValue).toBe('default');
-    expect(container.querySelector('#patch')!.textContent).toBe('default');
+    expect(patchValue).toBe("default");
+    expect(container.querySelector("#patch")!.textContent).toBe("default");
 
     setLive!(true);
-    expect(patchValue).toBe('live');
-    expect(container.querySelector('#patch')!.textContent).toBe('live');
+    expect(patchValue).toBe("live");
+    expect(container.querySelector("#patch")!.textContent).toBe("live");
   });
 
-  it('works the same as $context(ThemeContext) pattern', () => {
+  it("works the same as $context(ThemeContext) pattern", () => {
     // Verify $patchContext follows the exact same usage pattern as
     // $context — read via yield* inside a generator component.
-    let patchValue: 'live' | 'default' | undefined;
+    let patchValue: "live" | "default" | undefined;
 
     function* Reader() {
       const patch = yield* $patchContext();
       patchValue = patch;
-      return createElement('div', null, patch);
+      return createElement("div", null, patch);
     }
 
     const root = createRoot(container);
     root.render(createElement(Reader as never, {}));
-    expect(patchValue).toBe('default');
-    expect(container.textContent).toBe('default');
+    expect(patchValue).toBe("default");
+    expect(container.textContent).toBe("default");
   });
 
-  it('does not rerender when only $patch prop changes (no $patchContext)', () => {
+  it("does not rerender when only $patch prop changes (no $patchContext)", () => {
     let renderCount = 0;
-    let setPatch: ((v: 'live' | 'default') => void) | null = null;
+    let setPatch: ((v: "live" | "default") => void) | null = null;
 
     function* Child({ label }: { label: string; $patch?: string }) {
       yield* $state(0); // just to make it a stateful generator component
       renderCount++;
-      return createElement('span', { id: 'child' }, label);
+      return createElement("span", { id: "child" }, label);
     }
 
     function* Parent() {
-      const [patch, sp] = yield* $state<'live' | 'default'>('default');
+      const [patch, sp] = yield* $state<"live" | "default">("default");
       setPatch = sp;
-      return createElement(Child as never, { label: 'hello', $patch: patch });
+      return createElement(Child as never, { label: "hello", $patch: patch });
     }
 
     render(createElement(Parent as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(container.querySelector('#child')!.textContent).toBe('hello');
+    expect(container.querySelector("#child")!.textContent).toBe("hello");
 
     // Change only $patch — Child should NOT rerender
-    setPatch!('live');
+    setPatch!("live");
     expect(renderCount).toBe(1);
-    expect(container.querySelector('#child')!.textContent).toBe('hello');
+    expect(container.querySelector("#child")!.textContent).toBe("hello");
   });
 
-  it('rerenders when $patch changes and component consumes $patchContext', () => {
+  it("rerenders when $patch changes and component consumes $patchContext", () => {
     let renderCount = 0;
-    let setPatch: ((v: 'live' | 'default') => void) | null = null;
-    let patchValue: 'live' | 'default' | undefined;
+    let setPatch: ((v: "live" | "default") => void) | null = null;
+    let patchValue: "live" | "default" | undefined;
 
     function* Child(_props: { $patch?: string }) {
       patchValue = yield* $patchContext();
       renderCount++;
-      return createElement('span', { id: 'child' }, patchValue);
+      return createElement("span", { id: "child" }, patchValue);
     }
 
     function* Parent() {
-      const [patch, sp] = yield* $state<'live' | 'default'>('default');
+      const [patch, sp] = yield* $state<"live" | "default">("default");
       setPatch = sp;
       return createElement(Child as never, { $patch: patch });
     }
 
     render(createElement(Parent as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(patchValue).toBe('default');
+    expect(patchValue).toBe("default");
 
     // Change $patch — Child SHOULD rerender because it consumes $patchContext
-    setPatch!('live');
+    setPatch!("live");
     expect(renderCount).toBe(2);
-    expect(patchValue).toBe('live');
-    expect(container.querySelector('#child')!.textContent).toBe('live');
+    expect(patchValue).toBe("live");
+    expect(container.querySelector("#child")!.textContent).toBe("live");
   });
 });

--- a/src/__tests__/jsx.test.ts
+++ b/src/__tests__/jsx.test.ts
@@ -1,42 +1,42 @@
-import { createElement, Fragment, VNode } from '../jsx';
+import { createElement, Fragment, type VNode } from "../jsx";
 
-describe('createElement', () => {
-  it('creates a VNode with the given type and props', () => {
-    const vnode = createElement('div', { className: 'container' });
-    expect(vnode.type).toBe('div');
-    expect(vnode.props).toEqual({ className: 'container' });
+describe("createElement", () => {
+  it("creates a VNode with the given type and props", () => {
+    const vnode = createElement("div", { className: "container" });
+    expect(vnode.type).toBe("div");
+    expect(vnode.props).toEqual({ className: "container" });
     expect(vnode.children).toEqual([]);
   });
 
-  it('uses an empty object when props are null', () => {
-    const vnode = createElement('br', null);
+  it("uses an empty object when props are null", () => {
+    const vnode = createElement("br", null);
     expect(vnode.props).toEqual({});
   });
 
-  it('collects children into the children array', () => {
-    const child = createElement('span', null, 'hello');
-    const vnode = createElement('div', null, child);
+  it("collects children into the children array", () => {
+    const child = createElement("span", null, "hello");
+    const vnode = createElement("div", null, child);
     expect(vnode.children).toHaveLength(1);
     expect(vnode.children[0]).toBe(child);
   });
 
-  it('flattens multiple children', () => {
-    const vnode = createElement('ul', null, 'a', 'b', 'c');
-    expect(vnode.children).toEqual(['a', 'b', 'c']);
+  it("flattens multiple children", () => {
+    const vnode = createElement("ul", null, "a", "b", "c");
+    expect(vnode.children).toEqual(["a", "b", "c"]);
   });
 
-  it('stores a Fragment as the type', () => {
-    const vnode = createElement(Fragment, null, 'a', 'b');
+  it("stores a Fragment as the type", () => {
+    const vnode = createElement(Fragment, null, "a", "b");
     expect(vnode.type).toBe(Fragment);
-    expect(vnode.children).toEqual(['a', 'b']);
+    expect(vnode.children).toEqual(["a", "b"]);
   });
 
-  it('stores a function component as the type', () => {
+  it("stores a function component as the type", () => {
     function* MyComponent() {
-      yield createElement('div', null);
+      yield createElement("div", null);
     }
-    const vnode: VNode = createElement(MyComponent as unknown as VNode['type'], { id: '1' });
+    const vnode: VNode = createElement(MyComponent as unknown as VNode["type"], { id: "1" });
     expect(vnode.type).toBe(MyComponent);
-    expect(vnode.props).toEqual({ id: '1' });
+    expect(vnode.props).toEqual({ id: "1" });
   });
 });

--- a/src/__tests__/key-prop.test.ts
+++ b/src/__tests__/key-prop.test.ts
@@ -1,12 +1,12 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state } from '../hooks';
+import { $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
-describe('$key prop – keyed reconciliation', () => {
+describe("$key prop – keyed reconciliation", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,7 +16,7 @@ describe('$key prop – keyed reconciliation', () => {
 
   // ─── Generator components mixed with falsy values ───
 
-  it('reorders generator components by key without remounting', () => {
+  it("reorders generator components by key without remounting", () => {
     let renderCountA = 0;
     let renderCountB = 0;
     let renderCountC = 0;
@@ -24,18 +24,18 @@ describe('$key prop – keyed reconciliation', () => {
 
     function* ItemA() {
       renderCountA++;
-      const [count, setCount] = yield* $state(10);
-      return createElement('div', { className: 'a' }, `A:${count}`);
+      const [count] = yield* $state(10);
+      return createElement("div", { className: "a" }, `A:${count}`);
     }
     function* ItemB() {
       renderCountB++;
-      const [count, setCount] = yield* $state(20);
-      return createElement('div', { className: 'b' }, `B:${count}`);
+      const [count] = yield* $state(20);
+      return createElement("div", { className: "b" }, `B:${count}`);
     }
     function* ItemC() {
       renderCountC++;
-      const [count, setCount] = yield* $state(30);
-      return createElement('div', { className: 'c' }, `C:${count}`);
+      const [count] = yield* $state(30);
+      return createElement("div", { className: "c" }, `C:${count}`);
     }
 
     const components: Record<string, never> = {
@@ -45,21 +45,21 @@ describe('$key prop – keyed reconciliation', () => {
     };
 
     function* Parent() {
-      const [order, so] = yield* $state(['a', 'b', 'c']);
+      const [order, so] = yield* $state(["a", "b", "c"]);
       setOrder = so;
       return createElement(
-        'div',
-        { id: 'list' },
-        ...order.map((k) => createElement(components[k], { $key: k })),
+        "div",
+        { id: "list" },
+        ...order.map((k) => createElement(components[k]!, { $key: k })),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    const list = container.querySelector('#list')!;
+    const list = container.querySelector("#list")!;
     expect(list.children).toHaveLength(3);
-    expect(list.children[0].textContent).toBe('A:10');
-    expect(list.children[1].textContent).toBe('B:20');
-    expect(list.children[2].textContent).toBe('C:30');
+    expect(list.children[0]!.textContent).toBe("A:10");
+    expect(list.children[1]!.textContent).toBe("B:20");
+    expect(list.children[2]!.textContent).toBe("C:30");
 
     // Save references to original DOM nodes
     const nodeA = list.children[0];
@@ -71,13 +71,13 @@ describe('$key prop – keyed reconciliation', () => {
     renderCountC = 0;
 
     // Reverse order
-    setOrder!(['c', 'b', 'a']);
+    setOrder!(["c", "b", "a"]);
 
     // DOM nodes should be MOVED, not recreated
     expect(list.children).toHaveLength(3);
-    expect(list.children[0].textContent).toBe('C:30');
-    expect(list.children[1].textContent).toBe('B:20');
-    expect(list.children[2].textContent).toBe('A:10');
+    expect(list.children[0]!.textContent).toBe("C:30");
+    expect(list.children[1]!.textContent).toBe("B:20");
+    expect(list.children[2]!.textContent).toBe("A:10");
 
     // Same DOM nodes, just reordered
     expect(list.children[0]).toBe(nodeC);
@@ -90,18 +90,18 @@ describe('$key prop – keyed reconciliation', () => {
     expect(renderCountC).toBe(0);
   });
 
-  it('generator components with keys mixed with falsy values', () => {
+  it("generator components with keys mixed with falsy values", () => {
     let setItems: ((v: (string | null)[]) => void) | null = null;
 
     function* Item({ label }: { label: string }) {
-      return createElement('span', null, label);
+      return createElement("span", null, label);
     }
 
     function* Parent() {
-      const [items, si] = yield* $state<(string | null)[]>(['a', null, 'b', null, 'c']);
+      const [items, si] = yield* $state<(string | null)[]>(["a", null, "b", null, "c"]);
       setItems = si;
       return createElement(
-        'div',
+        "div",
         null,
         ...items.map((item) =>
           item ? createElement(Item as never, { $key: item, label: item }) : null,
@@ -110,25 +110,25 @@ describe('$key prop – keyed reconciliation', () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    const div = container.querySelector('div')!;
-    const spans = div.querySelectorAll('span');
+    const div = container.querySelector("div")!;
+    const spans = div.querySelectorAll("span");
     expect(spans).toHaveLength(3);
-    expect(spans[0].textContent).toBe('a');
-    expect(spans[1].textContent).toBe('b');
-    expect(spans[2].textContent).toBe('c');
+    expect(spans[0]!.textContent).toBe("a");
+    expect(spans[1]!.textContent).toBe("b");
+    expect(spans[2]!.textContent).toBe("c");
 
     const spanA = spans[0];
     const spanB = spans[1];
     const spanC = spans[2];
 
     // Reorder with different falsy positions
-    setItems!([null, 'c', 'a', null, 'b']);
+    setItems!([null, "c", "a", null, "b"]);
 
-    const newSpans = div.querySelectorAll('span');
+    const newSpans = div.querySelectorAll("span");
     expect(newSpans).toHaveLength(3);
-    expect(newSpans[0].textContent).toBe('c');
-    expect(newSpans[1].textContent).toBe('a');
-    expect(newSpans[2].textContent).toBe('b');
+    expect(newSpans[0]!.textContent).toBe("c");
+    expect(newSpans[1]!.textContent).toBe("a");
+    expect(newSpans[2]!.textContent).toBe("b");
 
     // DOM nodes moved, not recreated
     expect(newSpans[0]).toBe(spanC);
@@ -138,14 +138,14 @@ describe('$key prop – keyed reconciliation', () => {
 
   // ─── Plain function components mixed with falsy values ───
 
-  it('reorders plain function components by key without recreating DOM', () => {
+  it("reorders plain function components by key without recreating DOM", () => {
     let setOrder: ((v: string[]) => void) | null = null;
 
     function ItemX() {
-      return createElement('li', null, 'X');
+      return createElement("li", null, "X");
     }
     function ItemY() {
-      return createElement('li', null, 'Y');
+      return createElement("li", null, "Y");
     }
 
     const components: Record<string, never> = {
@@ -154,44 +154,44 @@ describe('$key prop – keyed reconciliation', () => {
     };
 
     function* Parent() {
-      const [order, so] = yield* $state(['x', 'y']);
+      const [order, so] = yield* $state(["x", "y"]);
       setOrder = so;
       return createElement(
-        'ul',
+        "ul",
         null,
-        ...order.map((k) => createElement(components[k], { $key: k })),
+        ...order.map((k) => createElement(components[k]!, { $key: k })),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    const ul = container.querySelector('ul')!;
-    expect(ul.children[0].textContent).toBe('X');
-    expect(ul.children[1].textContent).toBe('Y');
+    const ul = container.querySelector("ul")!;
+    expect(ul.children[0]!.textContent).toBe("X");
+    expect(ul.children[1]!.textContent).toBe("Y");
 
     const nodeX = ul.children[0];
     const nodeY = ul.children[1];
 
     // Reverse
-    setOrder!(['y', 'x']);
+    setOrder!(["y", "x"]);
 
-    expect(ul.children[0].textContent).toBe('Y');
-    expect(ul.children[1].textContent).toBe('X');
+    expect(ul.children[0]!.textContent).toBe("Y");
+    expect(ul.children[1]!.textContent).toBe("X");
     expect(ul.children[0]).toBe(nodeY);
     expect(ul.children[1]).toBe(nodeX);
   });
 
-  it('plain function components with keys mixed with falsy values', () => {
+  it("plain function components with keys mixed with falsy values", () => {
     let setItems: ((v: (string | null)[]) => void) | null = null;
 
     function Tag({ label }: { label: string }) {
-      return createElement('b', null, label);
+      return createElement("b", null, label);
     }
 
     function* Parent() {
-      const [items, si] = yield* $state<(string | null)[]>(['p', null, 'q']);
+      const [items, si] = yield* $state<(string | null)[]>(["p", null, "q"]);
       setItems = si;
       return createElement(
-        'div',
+        "div",
         null,
         ...items.map((item) =>
           item ? createElement(Tag as never, { $key: item, label: item }) : false,
@@ -200,14 +200,14 @@ describe('$key prop – keyed reconciliation', () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    const div = container.querySelector('div')!;
-    const bs = div.querySelectorAll('b');
+    const div = container.querySelector("div")!;
+    const bs = div.querySelectorAll("b");
     expect(bs).toHaveLength(2);
     const bP = bs[0];
     const bQ = bs[1];
 
-    setItems!([null, 'q', null, 'p']);
-    const newBs = div.querySelectorAll('b');
+    setItems!([null, "q", null, "p"]);
+    const newBs = div.querySelectorAll("b");
     expect(newBs).toHaveLength(2);
     expect(newBs[0]).toBe(bQ);
     expect(newBs[1]).toBe(bP);
@@ -215,21 +215,21 @@ describe('$key prop – keyed reconciliation', () => {
 
   // ─── HTML elements mixed with falsy values ───
 
-  it('reorders keyed HTML elements without recreating DOM', () => {
+  it("reorders keyed HTML elements without recreating DOM", () => {
     let setOrder: ((v: string[]) => void) | null = null;
 
     function* Parent() {
-      const [order, so] = yield* $state(['first', 'second', 'third']);
+      const [order, so] = yield* $state(["first", "second", "third"]);
       setOrder = so;
       return createElement(
-        'ul',
+        "ul",
         null,
-        ...order.map((text) => createElement('li', { $key: text }, text)),
+        ...order.map((text) => createElement("li", { $key: text }, text)),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    const ul = container.querySelector('ul')!;
+    const ul = container.querySelector("ul")!;
     expect(ul.children).toHaveLength(3);
 
     const li1 = ul.children[0];
@@ -237,37 +237,37 @@ describe('$key prop – keyed reconciliation', () => {
     const li3 = ul.children[2];
 
     // Reverse
-    setOrder!(['third', 'second', 'first']);
+    setOrder!(["third", "second", "first"]);
 
-    expect(ul.children[0].textContent).toBe('third');
-    expect(ul.children[1].textContent).toBe('second');
-    expect(ul.children[2].textContent).toBe('first');
+    expect(ul.children[0]!.textContent).toBe("third");
+    expect(ul.children[1]!.textContent).toBe("second");
+    expect(ul.children[2]!.textContent).toBe("first");
     expect(ul.children[0]).toBe(li3);
     expect(ul.children[1]).toBe(li2);
     expect(ul.children[2]).toBe(li1);
   });
 
-  it('keyed HTML elements mixed with falsy values', () => {
+  it("keyed HTML elements mixed with falsy values", () => {
     let setItems: ((v: (string | null)[]) => void) | null = null;
 
     function* Parent() {
-      const [items, si] = yield* $state<(string | null)[]>(['a', null, 'b']);
+      const [items, si] = yield* $state<(string | null)[]>(["a", null, "b"]);
       setItems = si;
       return createElement(
-        'div',
+        "div",
         null,
-        ...items.map((item) => (item ? createElement('span', { $key: item }, item) : null)),
+        ...items.map((item) => (item ? createElement("span", { $key: item }, item) : null)),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    const div = container.querySelector('div')!;
-    const spans = div.querySelectorAll('span');
+    const div = container.querySelector("div")!;
+    const spans = div.querySelectorAll("span");
     const spanA = spans[0];
     const spanB = spans[1];
 
-    setItems!(['b', null, null, 'a']);
-    const newSpans = div.querySelectorAll('span');
+    setItems!(["b", null, null, "a"]);
+    const newSpans = div.querySelectorAll("span");
     expect(newSpans).toHaveLength(2);
     expect(newSpans[0]).toBe(spanB);
     expect(newSpans[1]).toBe(spanA);
@@ -275,21 +275,21 @@ describe('$key prop – keyed reconciliation', () => {
 
   // ─── Component keeps working after key-based reorder ───
 
-  it('generator component preserves state and continues working after reorder', () => {
+  it("generator component preserves state and continues working after reorder", () => {
     let setOrder: ((v: string[]) => void) | null = null;
     const setters: Record<string, (v: number) => void> = {};
 
     function* Counter({ id }: { id: string }) {
       const [count, setCount] = yield* $state(0);
       setters[id] = setCount;
-      return createElement('div', { 'data-id': id }, `${id}:${count}`);
+      return createElement("div", { "data-id": id }, `${id}:${count}`);
     }
 
     function* Parent() {
-      const [order, so] = yield* $state(['x', 'y', 'z']);
+      const [order, so] = yield* $state(["x", "y", "z"]);
       setOrder = so;
       return createElement(
-        'div',
+        "div",
         null,
         ...order.map((id) => createElement(Counter as never, { $key: id, id })),
       );
@@ -298,56 +298,56 @@ describe('$key prop – keyed reconciliation', () => {
     render(createElement(Parent as never, {}), container);
 
     // Increment x to 5
-    setters['x'](5);
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe('x:5');
+    setters["x"]!(5);
+    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:5");
 
     // Increment y to 3
-    setters['y'](3);
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe('y:3');
+    setters["y"]!(3);
+    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:3");
 
     // Reorder: z, x, y
-    setOrder!(['z', 'x', 'y']);
+    setOrder!(["z", "x", "y"]);
 
     // State preserved after reorder
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe('x:5');
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe('y:3');
-    expect(container.querySelector('[data-id="z"]')!.textContent).toBe('z:0');
+    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:5");
+    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:3");
+    expect(container.querySelector('[data-id="z"]')!.textContent).toBe("z:0");
 
     // Components still work after reorder (can update state)
-    setters['z'](99);
-    expect(container.querySelector('[data-id="z"]')!.textContent).toBe('z:99');
+    setters["z"]!(99);
+    expect(container.querySelector('[data-id="z"]')!.textContent).toBe("z:99");
 
-    setters['x'](10);
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe('x:10');
+    setters["x"]!(10);
+    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:10");
   });
 
   // ─── Key change alone does NOT cause rerender ───
 
-  it('does not rerender generator component when only key changes', () => {
+  it("does not rerender generator component when only key changes", () => {
     let renderCount = 0;
     let setKey: ((v: string) => void) | null = null;
     let setLabel: ((v: string) => void) | null = null;
 
     function* Child({ label }: { label: string }) {
       renderCount++;
-      return createElement('span', null, label);
+      return createElement("span", null, label);
     }
 
     function* Parent() {
-      const [key, sk] = yield* $state('key-1');
-      const [label, sl] = yield* $state('hello');
+      const [key, sk] = yield* $state("key-1");
+      const [label, sl] = yield* $state("hello");
       setKey = sk;
       setLabel = sl;
-      return createElement('div', null, createElement(Child as never, { $key: key, label }));
+      return createElement("div", null, createElement(Child as never, { $key: key, label }));
     }
 
     render(createElement(Parent as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(container.querySelector('span')!.textContent).toBe('hello');
+    expect(container.querySelector("span")!.textContent).toBe("hello");
 
     // Change only the key — content props unchanged
     renderCount = 0;
-    setKey!('key-2');
+    setKey!("key-2");
 
     // The child should NOT rerender since label didn't change
     // (key change means it's a "new" slot, but same type + same props = skip)
@@ -355,114 +355,114 @@ describe('$key prop – keyed reconciliation', () => {
     // component function + same props appear at the same position with a
     // different key, it may be treated as a new mount or reuse depending on
     // implementation. What matters is the component still works.
-    const span = container.querySelector('span')!;
-    expect(span.textContent).toBe('hello');
+    const span = container.querySelector("span")!;
+    expect(span.textContent).toBe("hello");
 
     // Verify it still works: changing label causes update
-    setLabel!('world');
-    expect(container.querySelector('span')!.textContent).toBe('world');
+    setLabel!("world");
+    expect(container.querySelector("span")!.textContent).toBe("world");
   });
 
   // ─── Props update after reorder causes rerender ───
 
   // ─── Non-keyed siblings preserve state when keyed children reorder ───
 
-  it('non-keyed siblings preserve state when keyed children shuffle', () => {
+  it("non-keyed siblings preserve state when keyed children shuffle", () => {
     let setOrder: ((v: string[]) => void) | null = null;
     const setters: Record<string, (v: number) => void> = {};
 
     function* Counter({ id }: { id: string }) {
       const [count, setCount] = yield* $state(0);
       setters[id] = setCount;
-      return createElement('div', { 'data-id': id }, `${id}:${count}`);
+      return createElement("div", { "data-id": id }, `${id}:${count}`);
     }
 
     function* Parent() {
-      const [order, so] = yield* $state(['x', 'y']);
+      const [order, so] = yield* $state(["x", "y"]);
       setOrder = so;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Counter as never, { id: 'before' }),
+        createElement(Counter as never, { id: "before" }),
         ...order.map((id) => createElement(Counter as never, { $key: id, id })),
-        createElement(Counter as never, { id: 'after' }),
+        createElement(Counter as never, { id: "after" }),
       );
     }
 
     render(createElement(Parent as never, {}), container);
 
     // Build up state on all components
-    setters['before'](10);
-    setters['x'](20);
-    setters['y'](30);
-    setters['after'](40);
+    setters["before"]!(10);
+    setters["x"]!(20);
+    setters["y"]!(30);
+    setters["after"]!(40);
 
-    expect(container.querySelector('[data-id="before"]')!.textContent).toBe('before:10');
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe('x:20');
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe('y:30');
-    expect(container.querySelector('[data-id="after"]')!.textContent).toBe('after:40');
+    expect(container.querySelector('[data-id="before"]')!.textContent).toBe("before:10");
+    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:20");
+    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:30");
+    expect(container.querySelector('[data-id="after"]')!.textContent).toBe("after:40");
 
     // Reverse keyed children
-    setOrder!(['y', 'x']);
+    setOrder!(["y", "x"]);
 
     // All state must be preserved — keyed and non-keyed alike
-    expect(container.querySelector('[data-id="before"]')!.textContent).toBe('before:10');
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe('y:30');
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe('x:20');
-    expect(container.querySelector('[data-id="after"]')!.textContent).toBe('after:40');
+    expect(container.querySelector('[data-id="before"]')!.textContent).toBe("before:10");
+    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:30");
+    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:20");
+    expect(container.querySelector('[data-id="after"]')!.textContent).toBe("after:40");
 
     // Verify DOM order: before, y, x, after
-    const div = container.querySelector('div')!;
-    expect(div.children[0].getAttribute('data-id')).toBe('before');
-    expect(div.children[1].getAttribute('data-id')).toBe('y');
-    expect(div.children[2].getAttribute('data-id')).toBe('x');
-    expect(div.children[3].getAttribute('data-id')).toBe('after');
+    const div = container.querySelector("div")!;
+    expect(div.children[0]!.getAttribute("data-id")).toBe("before");
+    expect(div.children[1]!.getAttribute("data-id")).toBe("y");
+    expect(div.children[2]!.getAttribute("data-id")).toBe("x");
+    expect(div.children[3]!.getAttribute("data-id")).toBe("after");
 
     // All components still work after reorder
-    setters['before'](11);
-    setters['after'](41);
-    setters['x'](21);
-    expect(container.querySelector('[data-id="before"]')!.textContent).toBe('before:11');
-    expect(container.querySelector('[data-id="after"]')!.textContent).toBe('after:41');
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe('x:21');
+    setters["before"]!(11);
+    setters["after"]!(41);
+    setters["x"]!(21);
+    expect(container.querySelector('[data-id="before"]')!.textContent).toBe("before:11");
+    expect(container.querySelector('[data-id="after"]')!.textContent).toBe("after:41");
+    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:21");
   });
 
   // ─── Props update after reorder causes rerender ───
 
-  it('props update on keyed generator component triggers rerender after reorder', () => {
+  it("props update on keyed generator component triggers rerender after reorder", () => {
     let setOrder: ((v: string[]) => void) | null = null;
     let setLabelFor: ((id: string, label: string) => void) | null = null;
 
     function* Item({ id, label }: { id: string; label: string }) {
-      return createElement('span', { 'data-id': id }, label);
+      return createElement("span", { "data-id": id }, label);
     }
 
     function* Parent() {
-      const [order, so] = yield* $state(['a', 'b']);
+      const [order, so] = yield* $state(["a", "b"]);
       const [labels, setLabels] = yield* $state<Record<string, string>>({
-        a: 'Alpha',
-        b: 'Beta',
+        a: "Alpha",
+        b: "Beta",
       });
       setOrder = so;
       setLabelFor = (id: string, label: string) => setLabels({ ...labels, [id]: label });
       return createElement(
-        'div',
+        "div",
         null,
         ...order.map((id) => createElement(Item as never, { $key: id, id, label: labels[id] })),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('[data-id="a"]')!.textContent).toBe('Alpha');
-    expect(container.querySelector('[data-id="b"]')!.textContent).toBe('Beta');
+    expect(container.querySelector('[data-id="a"]')!.textContent).toBe("Alpha");
+    expect(container.querySelector('[data-id="b"]')!.textContent).toBe("Beta");
 
     // Reorder
-    setOrder!(['b', 'a']);
-    expect(container.querySelector('div')!.children[0].getAttribute('data-id')).toBe('b');
-    expect(container.querySelector('div')!.children[1].getAttribute('data-id')).toBe('a');
+    setOrder!(["b", "a"]);
+    expect(container.querySelector("div")!.children[0]!.getAttribute("data-id")).toBe("b");
+    expect(container.querySelector("div")!.children[1]!.getAttribute("data-id")).toBe("a");
 
     // Update label after reorder
-    setLabelFor!('a', 'Alpha Updated');
-    expect(container.querySelector('[data-id="a"]')!.textContent).toBe('Alpha Updated');
+    setLabelFor!("a", "Alpha Updated");
+    expect(container.querySelector('[data-id="a"]')!.textContent).toBe("Alpha Updated");
   });
 });

--- a/src/__tests__/no-wrapper-spans.test.ts
+++ b/src/__tests__/no-wrapper-spans.test.ts
@@ -1,7 +1,7 @@
-import { createElement, Fragment } from '../jsx';
-import { createContext, $context } from '../context';
-import { render } from '../render';
-import { $state } from '../hooks';
+import { $context, createContext } from "../context";
+import { $state } from "../hooks";
+import { createElement, Fragment } from "../jsx";
+import { render } from "../render";
 
 /**
  * Assert that the DOM subtree rooted at `root` contains no
@@ -9,7 +9,7 @@ import { $state } from '../hooks';
  */
 function expectNoDisplayContentsSpans(root: Node): void {
   if (root instanceof HTMLElement) {
-    if (root.tagName === 'SPAN' && root.style.display === 'contents') {
+    if (root.tagName === "SPAN" && root.style.display === "contents") {
       throw new Error(
         `Found <span style="display:contents"> in:\n${(root.parentNode as HTMLElement)?.innerHTML}`,
       );
@@ -20,11 +20,11 @@ function expectNoDisplayContentsSpans(root: Node): void {
   }
 }
 
-describe('no wrapper spans in rendered output', () => {
+describe("no wrapper spans in rendered output", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -34,16 +34,16 @@ describe('no wrapper spans in rendered output', () => {
 
   // ── Plain function components ──
 
-  it('plain component returning a single element', () => {
+  it("plain component returning a single element", () => {
     function Greeting({ name }: { name: string }) {
-      return createElement('h1', null, `Hello, ${name}!`);
+      return createElement("h1", null, `Hello, ${name}!`);
     }
-    render(createElement(Greeting as never, { name: 'World' }), container);
-    expect(container.querySelector('h1')!.textContent).toBe('Hello, World!');
+    render(createElement(Greeting as never, { name: "World" }), container);
+    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
     expectNoDisplayContentsSpans(container);
   });
 
-  it('plain component returning null', () => {
+  it("plain component returning null", () => {
     function Empty() {
       return null;
     }
@@ -51,202 +51,202 @@ describe('no wrapper spans in rendered output', () => {
     expectNoDisplayContentsSpans(container);
   });
 
-  it('nested plain components', () => {
+  it("nested plain components", () => {
     function Inner() {
-      return createElement('span', null, 'inner');
+      return createElement("span", null, "inner");
     }
     function Outer() {
-      return createElement('div', null, createElement(Inner as never, {}));
+      return createElement("div", null, createElement(Inner as never, {}));
     }
     render(createElement(Outer as never, {}), container);
-    expect(container.querySelector('span')!.textContent).toBe('inner');
+    expect(container.querySelector("span")!.textContent).toBe("inner");
     expectNoDisplayContentsSpans(container);
   });
 
   // ── Generator components ──
 
-  it('generator component returning a single element', () => {
+  it("generator component returning a single element", () => {
     function* Card() {
-      return createElement('div', { className: 'card' }, 'content');
+      return createElement("div", { className: "card" }, "content");
     }
     render(createElement(Card as never, {}), container);
-    expect(container.querySelector('.card')!.textContent).toBe('content');
+    expect(container.querySelector(".card")!.textContent).toBe("content");
     expectNoDisplayContentsSpans(container);
   });
 
-  it('generator component with $state', () => {
+  it("generator component with $state", () => {
     let setCount: ((v: number) => void) | null = null;
 
     function* Counter() {
       const [count, sc] = yield* $state(0);
       setCount = sc;
-      return createElement('button', {}, String(count));
+      return createElement("button", {}, String(count));
     }
 
     render(createElement(Counter as never, {}), container);
-    expect(container.querySelector('button')!.textContent).toBe('0');
+    expect(container.querySelector("button")!.textContent).toBe("0");
     expectNoDisplayContentsSpans(container);
 
     setCount!(5);
-    expect(container.querySelector('button')!.textContent).toBe('5');
+    expect(container.querySelector("button")!.textContent).toBe("5");
     expectNoDisplayContentsSpans(container);
   });
 
-  it('nested generator components', () => {
+  it("nested generator components", () => {
     function* Inner() {
-      return createElement('span', null, 'hello');
+      return createElement("span", null, "hello");
     }
     function* Outer() {
-      return createElement('div', null, createElement(Inner as never, {}));
+      return createElement("div", null, createElement(Inner as never, {}));
     }
     render(createElement(Outer as never, {}), container);
-    expect(container.querySelector('span')!.textContent).toBe('hello');
+    expect(container.querySelector("span")!.textContent).toBe("hello");
     expectNoDisplayContentsSpans(container);
   });
 
-  it('generator component inside HTML element', () => {
+  it("generator component inside HTML element", () => {
     function* Label({ text }: { text: string }) {
-      return createElement('span', null, text);
+      return createElement("span", null, text);
     }
     render(
-      createElement('div', { className: 'wrapper' }, createElement(Label as never, { text: 'hi' })),
+      createElement("div", { className: "wrapper" }, createElement(Label as never, { text: "hi" })),
       container,
     );
-    expect(container.querySelector('span')!.textContent).toBe('hi');
+    expect(container.querySelector("span")!.textContent).toBe("hi");
     expectNoDisplayContentsSpans(container);
   });
 
   // ── Multiple children / siblings ──
 
-  it('multiple generator components as siblings', () => {
+  it("multiple generator components as siblings", () => {
     function* A() {
-      return createElement('p', null, 'A');
+      return createElement("p", null, "A");
     }
     function* B() {
-      return createElement('p', null, 'B');
+      return createElement("p", null, "B");
     }
     render(
-      createElement('div', null, createElement(A as never, {}), createElement(B as never, {})),
+      createElement("div", null, createElement(A as never, {}), createElement(B as never, {})),
       container,
     );
-    const ps = container.querySelectorAll('p');
+    const ps = container.querySelectorAll("p");
     expect(ps).toHaveLength(2);
-    expect(ps[0].textContent).toBe('A');
-    expect(ps[1].textContent).toBe('B');
+    expect(ps[0]!.textContent).toBe("A");
+    expect(ps[1]!.textContent).toBe("B");
     expectNoDisplayContentsSpans(container);
   });
 
-  it('mixed children: elements, text, generator and plain components', () => {
+  it("mixed children: elements, text, generator and plain components", () => {
     function* GenChild() {
-      return createElement('em', null, 'gen');
+      return createElement("em", null, "gen");
     }
     function PlainChild() {
-      return createElement('strong', null, 'plain');
+      return createElement("strong", null, "plain");
     }
     render(
       createElement(
-        'section',
+        "section",
         null,
-        createElement('p', null, 'text'),
+        createElement("p", null, "text"),
         createElement(GenChild as never, {}),
         createElement(PlainChild as never, {}),
-        'raw text',
+        "raw text",
       ),
       container,
     );
-    expect(container.querySelector('p')!.textContent).toBe('text');
-    expect(container.querySelector('em')!.textContent).toBe('gen');
-    expect(container.querySelector('strong')!.textContent).toBe('plain');
+    expect(container.querySelector("p")!.textContent).toBe("text");
+    expect(container.querySelector("em")!.textContent).toBe("gen");
+    expect(container.querySelector("strong")!.textContent).toBe("plain");
     expectNoDisplayContentsSpans(container);
   });
 
   // ── Fragment ──
 
-  it('generator returning Fragment with multiple children', () => {
+  it("generator returning Fragment with multiple children", () => {
     function* Multi() {
       return createElement(
         Fragment,
         null,
-        createElement('p', null, 'one'),
-        createElement('p', null, 'two'),
+        createElement("p", null, "one"),
+        createElement("p", null, "two"),
       );
     }
-    render(createElement('div', null, createElement(Multi as never, {})), container);
-    const ps = container.querySelectorAll('p');
+    render(createElement("div", null, createElement(Multi as never, {})), container);
+    const ps = container.querySelectorAll("p");
     expect(ps).toHaveLength(2);
-    expect(ps[0].textContent).toBe('one');
-    expect(ps[1].textContent).toBe('two');
+    expect(ps[0]!.textContent).toBe("one");
+    expect(ps[1]!.textContent).toBe("two");
     expectNoDisplayContentsSpans(container);
   });
 
   // ── Context Providers ──
 
-  it('context Provider with consumer', () => {
-    const Ctx = createContext('default');
+  it("context Provider with consumer", () => {
+    const Ctx = createContext("default");
 
     function* Consumer() {
       const value = yield* $context(Ctx);
-      return createElement('span', null, value);
+      return createElement("span", null, value);
     }
 
     render(
       createElement(
         Ctx.Provider as never,
-        { value: 'provided' },
+        { value: "provided" },
         createElement(Consumer as never, {}),
       ),
       container,
     );
-    expect(container.querySelector('span')!.textContent).toBe('provided');
+    expect(container.querySelector("span")!.textContent).toBe("provided");
     expectNoDisplayContentsSpans(container);
   });
 
-  it('nested Providers', () => {
-    const Ctx = createContext('default');
+  it("nested Providers", () => {
+    const Ctx = createContext("default");
 
     function* Consumer() {
       const value = yield* $context(Ctx);
-      return createElement('span', null, value);
+      return createElement("span", null, value);
     }
 
     render(
       createElement(
         Ctx.Provider as never,
-        { value: 'outer' },
+        { value: "outer" },
         createElement(
           Ctx.Provider as never,
-          { value: 'inner' },
+          { value: "inner" },
           createElement(Consumer as never, {}),
         ),
       ),
       container,
     );
-    expect(container.querySelector('span')!.textContent).toBe('inner');
+    expect(container.querySelector("span")!.textContent).toBe("inner");
     expectNoDisplayContentsSpans(container);
   });
 
   // ── Deep nesting ──
 
-  it('deeply nested: Provider > generator > HTML > plain > generator', () => {
-    const Ctx = createContext('ctx');
+  it("deeply nested: Provider > generator > HTML > plain > generator", () => {
+    const Ctx = createContext("ctx");
 
     function* Leaf() {
       const value = yield* $context(Ctx);
-      return createElement('b', null, value);
+      return createElement("b", null, value);
     }
 
     function PlainWrapper({ $children }: { $children: unknown }) {
-      return createElement('div', { className: 'plain' }, ...($children as never[]));
+      return createElement("div", { className: "plain" }, ...($children as never[]));
     }
 
     function* Middle({ $children }: { $children: unknown }) {
-      return createElement('article', null, ...($children as never[]));
+      return createElement("article", null, ...($children as never[]));
     }
 
     render(
       createElement(
         Ctx.Provider as never,
-        { value: 'deep' },
+        { value: "deep" },
         createElement(
           Middle as never,
           {},
@@ -255,33 +255,33 @@ describe('no wrapper spans in rendered output', () => {
       ),
       container,
     );
-    expect(container.querySelector('b')!.textContent).toBe('deep');
+    expect(container.querySelector("b")!.textContent).toBe("deep");
     expectNoDisplayContentsSpans(container);
   });
 
   // ── After rerender ──
 
-  it('no wrappers after state-driven rerender with children swap', () => {
+  it("no wrappers after state-driven rerender with children swap", () => {
     let toggle: (() => void) | null = null;
 
     function* Child({ label }: { label: string }) {
-      return createElement('span', null, label);
+      return createElement("span", null, label);
     }
 
     function* Parent() {
       const [on, setOn] = yield* $state(true);
       toggle = () => setOn(!on);
       return on
-        ? createElement('div', null, createElement(Child as never, { label: 'A' }))
-        : createElement('div', null, createElement(Child as never, { label: 'B' }));
+        ? createElement("div", null, createElement(Child as never, { label: "A" }))
+        : createElement("div", null, createElement(Child as never, { label: "B" }));
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('span')!.textContent).toBe('A');
+    expect(container.querySelector("span")!.textContent).toBe("A");
     expectNoDisplayContentsSpans(container);
 
     toggle!();
-    expect(container.querySelector('span')!.textContent).toBe('B');
+    expect(container.querySelector("span")!.textContent).toBe("B");
     expectNoDisplayContentsSpans(container);
   });
 });

--- a/src/__tests__/reconciler.test.ts
+++ b/src/__tests__/reconciler.test.ts
@@ -1,6 +1,6 @@
-import { createElement, Fragment } from '../jsx';
-import { render } from '../render';
-import { $state } from '../hooks';
+import { $state } from "../hooks";
+import { createElement, Fragment } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
@@ -8,11 +8,11 @@ import { $state } from '../hooks';
 // Prop memoization (no re-render if props unchanged)
 // ---------------------------------------------------------------------------
 
-describe('prop memoization', () => {
+describe("prop memoization", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -20,23 +20,23 @@ describe('prop memoization', () => {
     document.body.removeChild(container);
   });
 
-  it('does not re-mount a child component when the parent re-renders with unchanged child props', () => {
+  it("does not re-mount a child component when the parent re-renders with unchanged child props", () => {
     let mountCount = 0;
     let parentRerender: (() => void) | null = null;
 
     function* Child({ label }: { label: string }) {
       mountCount++;
-      return createElement('span', null, label);
+      return createElement("span", null, label);
     }
 
     function* Parent(_: Record<string, unknown>, rerender: () => void) {
       parentRerender = rerender;
-      return createElement('div', null, createElement(Child as never, { label: 'hello' }));
+      return createElement("div", null, createElement(Child as never, { label: "hello" }));
     }
 
     render(createElement(Parent as never, {}), container);
     expect(mountCount).toBe(1);
-    expect(container.querySelector('span')!.textContent).toBe('hello');
+    expect(container.querySelector("span")!.textContent).toBe("hello");
 
     // Trigger parent re-render with same child props
     parentRerender!();
@@ -44,32 +44,32 @@ describe('prop memoization', () => {
     expect(mountCount).toBe(1);
   });
 
-  it('remounts a child component when props change', () => {
+  it("remounts a child component when props change", () => {
     let mountCount = 0;
     let setPhase: ((v: number) => void) | null = null;
 
     function* Child({ label }: { label: string }) {
       mountCount++;
-      return createElement('span', null, label);
+      return createElement("span", null, label);
     }
 
     function* Parent() {
       const [phase, sp] = yield* $state(0);
       setPhase = sp;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Child as never, { label: phase === 0 ? 'first' : 'second' }),
+        createElement(Child as never, { label: phase === 0 ? "first" : "second" }),
       );
     }
 
     render(createElement(Parent as never, {}), container);
     expect(mountCount).toBe(1);
-    expect(container.querySelector('span')!.textContent).toBe('first');
+    expect(container.querySelector("span")!.textContent).toBe("first");
 
     setPhase!(1);
     expect(mountCount).toBe(2);
-    expect(container.querySelector('span')!.textContent).toBe('second');
+    expect(container.querySelector("span")!.textContent).toBe("second");
   });
 });
 
@@ -77,11 +77,11 @@ describe('prop memoization', () => {
 // Component renders other components (lifecycle managed by parent)
 // ---------------------------------------------------------------------------
 
-describe('component renders component', () => {
+describe("component renders component", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -89,118 +89,118 @@ describe('component renders component', () => {
     document.body.removeChild(container);
   });
 
-  it('generator renders a plain component child', () => {
+  it("generator renders a plain component child", () => {
     function Greeting({ name }: { name: string }) {
-      return createElement('h1', null, `Hello, ${name}!`);
+      return createElement("h1", null, `Hello, ${name}!`);
     }
 
     function* App() {
-      return createElement('div', null, createElement(Greeting as never, { name: 'World' }));
+      return createElement("div", null, createElement(Greeting as never, { name: "World" }));
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('h1')!.textContent).toBe('Hello, World!');
+    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
   });
 
-  it('generator renders a generator component child', () => {
+  it("generator renders a generator component child", () => {
     function* Label({ text }: { text: string }) {
-      return createElement('em', null, text);
+      return createElement("em", null, text);
     }
 
     function* App() {
-      return createElement('div', null, createElement(Label as never, { text: 'from-child' }));
+      return createElement("div", null, createElement(Label as never, { text: "from-child" }));
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('em')!.textContent).toBe('from-child');
+    expect(container.querySelector("em")!.textContent).toBe("from-child");
   });
 
-  it('child generator component maintains its own state across parent re-renders', () => {
+  it("child generator component maintains its own state across parent re-renders", () => {
     let incrementCounter: (() => void) | null = null;
     let parentRerender: (() => void) | null = null;
 
     function* Counter() {
       const [count, setCount] = yield* $state(0);
       incrementCounter = () => setCount(count + 1);
-      return createElement('span', { id: 'counter' }, String(count));
+      return createElement("span", { id: "counter" }, String(count));
     }
 
     function* Wrapper(_: Record<string, unknown>, rerender: () => void) {
       parentRerender = rerender;
-      return createElement('div', null, createElement(Counter as never, {}));
+      return createElement("div", null, createElement(Counter as never, {}));
     }
 
     render(createElement(Wrapper as never, {}), container);
-    expect(container.querySelector('#counter')!.textContent).toBe('0');
+    expect(container.querySelector("#counter")!.textContent).toBe("0");
 
     // Increment child
     incrementCounter!();
-    expect(container.querySelector('#counter')!.textContent).toBe('1');
+    expect(container.querySelector("#counter")!.textContent).toBe("1");
 
     // Parent re-renders with SAME Counter props → child is reused (not remounted)
     parentRerender!();
     // Counter state is preserved (still at 1)
-    expect(container.querySelector('#counter')!.textContent).toBe('1');
+    expect(container.querySelector("#counter")!.textContent).toBe("1");
   });
 
-  it('parent switching child component type unmounts old and mounts new', () => {
+  it("parent switching child component type unmounts old and mounts new", () => {
     let setPhase: ((v: number) => void) | null = null;
 
     function* CompA() {
-      return createElement('span', { id: 'a' }, 'A');
+      return createElement("span", { id: "a" }, "A");
     }
     function* CompB() {
-      return createElement('span', { id: 'b' }, 'B');
+      return createElement("span", { id: "b" }, "B");
     }
 
     function* Parent() {
       const [phase, sp] = yield* $state(0);
       setPhase = sp;
       return createElement(
-        'div',
+        "div",
         null,
         phase === 0 ? createElement(CompA as never, {}) : createElement(CompB as never, {}),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#a')).not.toBeNull();
-    expect(container.querySelector('#b')).toBeNull();
+    expect(container.querySelector("#a")).not.toBeNull();
+    expect(container.querySelector("#b")).toBeNull();
 
     setPhase!(1);
-    expect(container.querySelector('#a')).toBeNull();
-    expect(container.querySelector('#b')).not.toBeNull();
+    expect(container.querySelector("#a")).toBeNull();
+    expect(container.querySelector("#b")).not.toBeNull();
   });
 
-  it('reconciles HTML element children in place across re-renders', () => {
+  it("reconciles HTML element children in place across re-renders", () => {
     let setStep: ((v: number) => void) | null = null;
 
     function* App() {
       const [step, ss] = yield* $state(0);
       setStep = ss;
       return step === 0
-        ? createElement('p', { className: 'first' }, 'hello')
-        : createElement('p', { className: 'second' }, 'world');
+        ? createElement("p", { className: "first" }, "hello")
+        : createElement("p", { className: "second" }, "world");
     }
 
     render(createElement(App as never, {}), container);
-    const p = container.querySelector('p')!;
-    expect(p.className).toBe('first');
-    expect(p.textContent).toBe('hello');
+    const p = container.querySelector("p")!;
+    expect(p.className).toBe("first");
+    expect(p.textContent).toBe("hello");
 
     setStep!(1);
     // Same <p> element is reused (updated in place)
-    expect(container.querySelector('p')).toBe(p);
-    expect(p.className).toBe('second');
-    expect(p.textContent).toBe('world');
+    expect(container.querySelector("p")).toBe(p);
+    expect(p.className).toBe("second");
+    expect(p.textContent).toBe("world");
   });
 
-  it('generator renders Fragment with multiple component children', () => {
+  it("generator renders Fragment with multiple component children", () => {
     function* A() {
-      return createElement('span', { id: 'a' }, 'A');
+      return createElement("span", { id: "a" }, "A");
     }
     function* B() {
-      return createElement('span', { id: 'b' }, 'B');
+      return createElement("span", { id: "b" }, "B");
     }
 
     function* App() {
@@ -213,7 +213,7 @@ describe('component renders component', () => {
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('#a')!.textContent).toBe('A');
-    expect(container.querySelector('#b')!.textContent).toBe('B');
+    expect(container.querySelector("#a")!.textContent).toBe("A");
+    expect(container.querySelector("#b")!.textContent).toBe("B");
   });
 });

--- a/src/__tests__/render-components.test.ts
+++ b/src/__tests__/render-components.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state } from '../hooks';
+import { $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('render – plain function components', () => {
+describe("render – plain function components", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,40 +16,40 @@ describe('render – plain function components', () => {
     document.body.removeChild(container);
   });
 
-  it('calls the function and renders the returned JSX', () => {
+  it("calls the function and renders the returned JSX", () => {
     function Greeting({ name }: { name: string }) {
-      return createElement('h1', null, `Hello, ${name}!`);
+      return createElement("h1", null, `Hello, ${name}!`);
     }
-    render(createElement(Greeting as never, { name: 'World' }), container);
-    expect(container.querySelector('h1')!.textContent).toBe('Hello, World!');
+    render(createElement(Greeting as never, { name: "World" }), container);
+    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
   });
 
-  it('renders an empty text node when the component returns null', () => {
+  it("renders an empty text node when the component returns null", () => {
     function Empty() {
       return null;
     }
     render(createElement(Empty as never, {}), container);
     const node = container.firstChild!;
     expect(node.nodeType).toBe(Node.TEXT_NODE);
-    expect(node.textContent).toBe('');
+    expect(node.textContent).toBe("");
   });
 
-  it('renders an empty text node when the component returns undefined', () => {
+  it("renders an empty text node when the component returns undefined", () => {
     function Empty() {
       return undefined;
     }
     render(createElement(Empty as never, {}), container);
     const node = container.firstChild!;
     expect(node.nodeType).toBe(Node.TEXT_NODE);
-    expect(node.textContent).toBe('');
+    expect(node.textContent).toBe("");
   });
 });
 
-describe('render – generator components', () => {
+describe("render – generator components", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -57,38 +57,38 @@ describe('render – generator components', () => {
     document.body.removeChild(container);
   });
 
-  it('renders a generator component that returns JSX', () => {
+  it("renders a generator component that returns JSX", () => {
     function* Greeting({ name }: { name: string }) {
-      return createElement('h2', null, `Hi, ${name}!`);
+      return createElement("h2", null, `Hi, ${name}!`);
     }
-    render(createElement(Greeting as never, { name: 'Alice' }), container);
-    expect(container.querySelector('h2')!.textContent).toBe('Hi, Alice!');
+    render(createElement(Greeting as never, { name: "Alice" }), container);
+    expect(container.querySelector("h2")!.textContent).toBe("Hi, Alice!");
   });
 
-  it('rerenders via $state setter', () => {
+  it("rerenders via $state setter", () => {
     let setCount: ((v: number) => void) | null = null;
 
     function* Counter() {
       const [count, sc] = yield* $state(0);
       setCount = sc;
-      return createElement('button', {}, String(count));
+      return createElement("button", {}, String(count));
     }
 
     render(createElement(Counter as never, {}), container);
-    expect(container.querySelector('button')!.textContent).toBe('0');
+    expect(container.querySelector("button")!.textContent).toBe("0");
 
     setCount!(1);
-    expect(container.querySelector('button')!.textContent).toBe('1');
+    expect(container.querySelector("button")!.textContent).toBe("1");
 
     setCount!(5);
-    expect(container.querySelector('button')!.textContent).toBe('5');
+    expect(container.querySelector("button")!.textContent).toBe("5");
   });
 
-  it('rerenders when rerender() is called directly from an event handler', () => {
-    function* Counter(_props: Record<string, unknown>, rerender: () => void) {
+  it("rerenders when rerender() is called directly from an event handler", () => {
+    function* Counter(_props: Record<string, unknown>, _rerender: () => void) {
       const [count, setCount] = yield* $state(0);
       return createElement(
-        'button',
+        "button",
         {
           onClick: () => {
             setCount(count + 1);
@@ -100,49 +100,49 @@ describe('render – generator components', () => {
 
     render(createElement(Counter as never, {}), container);
 
-    expect(container.querySelector('button')!.textContent).toBe('0');
-    container.querySelector('button')!.click();
-    expect(container.querySelector('button')!.textContent).toBe('1');
-    container.querySelector('button')!.click();
-    expect(container.querySelector('button')!.textContent).toBe('2');
+    expect(container.querySelector("button")!.textContent).toBe("0");
+    container.querySelector("button")!.click();
+    expect(container.querySelector("button")!.textContent).toBe("1");
+    container.querySelector("button")!.click();
+    expect(container.querySelector("button")!.textContent).toBe("2");
   });
 
-  it('renders generator components nested inside HTML elements', () => {
+  it("renders generator components nested inside HTML elements", () => {
     function* Label({ text }: { text: string }) {
-      return createElement('span', null, text);
+      return createElement("span", null, text);
     }
 
     render(
       createElement(
-        'div',
-        { className: 'wrapper' },
-        createElement(Label as never, { text: 'nested' }),
+        "div",
+        { className: "wrapper" },
+        createElement(Label as never, { text: "nested" }),
       ),
       container,
     );
 
-    expect(container.querySelector('span')!.textContent).toBe('nested');
+    expect(container.querySelector("span")!.textContent).toBe("nested");
   });
 
-  it('passes children in props', () => {
+  it("passes children in props", () => {
     function* Wrapper({ $children }: { $children: unknown }) {
-      return createElement('section', null, ...($children as never[]));
+      return createElement("section", null, ...($children as never[]));
     }
 
     render(
-      createElement(Wrapper as never, {}, createElement('p', null, 'child content')),
+      createElement(Wrapper as never, {}, createElement("p", null, "child content")),
       container,
     );
 
-    expect(container.querySelector('p')!.textContent).toBe('child content');
+    expect(container.querySelector("p")!.textContent).toBe("child content");
   });
 });
 
-describe('render – generator components with $state', () => {
+describe("render – generator components with $state", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -150,44 +150,44 @@ describe('render – generator components with $state', () => {
     document.body.removeChild(container);
   });
 
-  it('$state persists value across re-renders', () => {
+  it("$state persists value across re-renders", () => {
     let setLabel: ((v: string) => void) | null = null;
 
     function* Label() {
-      const [text, st] = yield* $state('initial');
+      const [text, st] = yield* $state("initial");
       setLabel = st;
-      return createElement('p', null, text);
+      return createElement("p", null, text);
     }
 
     render(createElement(Label as never, {}), container);
-    expect(container.querySelector('p')!.textContent).toBe('initial');
+    expect(container.querySelector("p")!.textContent).toBe("initial");
 
-    setLabel!('updated');
-    expect(container.querySelector('p')!.textContent).toBe('updated');
+    setLabel!("updated");
+    expect(container.querySelector("p")!.textContent).toBe("updated");
 
-    setLabel!('again');
-    expect(container.querySelector('p')!.textContent).toBe('again');
+    setLabel!("again");
+    expect(container.querySelector("p")!.textContent).toBe("again");
   });
 
-  it('multiple $state calls maintain independent state', () => {
+  it("multiple $state calls maintain independent state", () => {
     let setA: ((v: string) => void) | null = null;
     let setB: ((v: number) => void) | null = null;
 
     function* Multi() {
-      const [a, sa] = yield* $state('hello');
+      const [a, sa] = yield* $state("hello");
       const [b, sb] = yield* $state(0);
       setA = sa;
       setB = sb;
-      return createElement('p', null, `${a}-${b}`);
+      return createElement("p", null, `${a}-${b}`);
     }
 
     render(createElement(Multi as never, {}), container);
-    expect(container.querySelector('p')!.textContent).toBe('hello-0');
+    expect(container.querySelector("p")!.textContent).toBe("hello-0");
 
-    setA!('world');
-    expect(container.querySelector('p')!.textContent).toBe('world-0');
+    setA!("world");
+    expect(container.querySelector("p")!.textContent).toBe("world-0");
 
     setB!(42);
-    expect(container.querySelector('p')!.textContent).toBe('world-42');
+    expect(container.querySelector("p")!.textContent).toBe("world-42");
   });
 });

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -1,14 +1,14 @@
-import { createElement, Fragment } from '../jsx';
-import { render, buildNode } from '../render';
-import { $state } from '../hooks';
+import { $state } from "../hooks";
+import { createElement, Fragment } from "../jsx";
+import { buildNode, render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('render – HTML elements', () => {
+describe("render – HTML elements", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,169 +16,169 @@ describe('render – HTML elements', () => {
     document.body.removeChild(container);
   });
 
-  it('renders a plain element', () => {
-    render(createElement('div', null), container);
+  it("renders a plain element", () => {
+    render(createElement("div", null), container);
     expect(container.firstChild).toBeInstanceOf(HTMLDivElement);
   });
 
-  it('renders a text child', () => {
-    render(createElement('p', null, 'Hello World'), container);
-    expect(container.querySelector('p')!.textContent).toBe('Hello World');
+  it("renders a text child", () => {
+    render(createElement("p", null, "Hello World"), container);
+    expect(container.querySelector("p")!.textContent).toBe("Hello World");
   });
 
-  it('renders nested elements', () => {
-    render(createElement('div', null, createElement('span', null, 'inner')), container);
-    expect(container.querySelector('span')!.textContent).toBe('inner');
+  it("renders nested elements", () => {
+    render(createElement("div", null, createElement("span", null, "inner")), container);
+    expect(container.querySelector("span")!.textContent).toBe("inner");
   });
 
-  it('applies className', () => {
-    render(createElement('div', { className: 'foo bar' }), container);
-    expect((container.firstChild as HTMLElement).className).toBe('foo bar');
+  it("applies className", () => {
+    render(createElement("div", { className: "foo bar" }), container);
+    expect((container.firstChild as HTMLElement).className).toBe("foo bar");
   });
 
-  it('applies arbitrary attributes', () => {
-    render(createElement('input', { type: 'text', placeholder: 'name' }), container);
-    const input = container.querySelector('input')!;
-    expect(input.getAttribute('type')).toBe('text');
-    expect(input.getAttribute('placeholder')).toBe('name');
+  it("applies arbitrary attributes", () => {
+    render(createElement("input", { type: "text", placeholder: "name" }), container);
+    const input = container.querySelector("input")!;
+    expect(input.getAttribute("type")).toBe("text");
+    expect(input.getAttribute("placeholder")).toBe("name");
   });
 
-  it('applies event listeners and wraps in SyntheticEvent', () => {
+  it("applies event listeners and wraps in SyntheticEvent", () => {
     const onClick = jest.fn();
-    render(createElement('button', { onClick }, 'click me'), container);
-    container.querySelector('button')!.click();
+    render(createElement("button", { onClick }, "click me"), container);
+    container.querySelector("button")!.click();
     expect(onClick).toHaveBeenCalledTimes(1);
     // The handler receives a SyntheticEvent, not the raw native event
     const syntheticEvent = onClick.mock.calls[0][0];
-    expect(syntheticEvent).toHaveProperty('nativeEvent');
-    expect(syntheticEvent).toHaveProperty('type', 'click');
-    expect(typeof syntheticEvent.preventDefault).toBe('function');
-    expect(typeof syntheticEvent.stopPropagation).toBe('function');
+    expect(syntheticEvent).toHaveProperty("nativeEvent");
+    expect(syntheticEvent).toHaveProperty("type", "click");
+    expect(typeof syntheticEvent.preventDefault).toBe("function");
+    expect(typeof syntheticEvent.stopPropagation).toBe("function");
   });
 
-  it('applies inline styles', () => {
-    render(createElement('div', { style: { color: 'red', fontSize: '14px' } }), container);
+  it("applies inline styles", () => {
+    render(createElement("div", { style: { color: "red", fontSize: "14px" } }), container);
     const el = container.firstChild as HTMLElement;
-    expect(el.style.color).toBe('red');
-    expect(el.style.fontSize).toBe('14px');
+    expect(el.style.color).toBe("red");
+    expect(el.style.fontSize).toBe("14px");
   });
 
-  it('updates changed style properties on rerender', () => {
+  it("updates changed style properties on rerender", () => {
     let setStyle: ((s: Record<string, string>) => void) | null = null;
 
     function* Styled() {
-      const [style, ss] = yield* $state<Record<string, string>>({ color: 'red' });
+      const [style, ss] = yield* $state<Record<string, string>>({ color: "red" });
       setStyle = ss;
-      return createElement('div', { style });
+      return createElement("div", { style });
     }
 
     render(createElement(Styled as never, {}), container);
-    const el = container.querySelector('div') as HTMLElement;
-    expect(el.style.color).toBe('red');
+    const el = container.querySelector("div") as HTMLElement;
+    expect(el.style.color).toBe("red");
 
-    setStyle!({ color: 'blue' });
-    expect(el.style.color).toBe('blue');
+    setStyle!({ color: "blue" });
+    expect(el.style.color).toBe("blue");
   });
 
-  it('removes style properties that are no longer present on rerender', () => {
+  it("removes style properties that are no longer present on rerender", () => {
     let setStyle: ((s: Record<string, string>) => void) | null = null;
 
     function* Styled() {
       const [style, ss] = yield* $state<Record<string, string>>({
-        color: 'red',
-        fontSize: '14px',
+        color: "red",
+        fontSize: "14px",
       });
       setStyle = ss;
-      return createElement('div', { style });
+      return createElement("div", { style });
     }
 
     render(createElement(Styled as never, {}), container);
-    const el = container.querySelector('div') as HTMLElement;
-    expect(el.style.color).toBe('red');
-    expect(el.style.fontSize).toBe('14px');
+    const el = container.querySelector("div") as HTMLElement;
+    expect(el.style.color).toBe("red");
+    expect(el.style.fontSize).toBe("14px");
 
-    setStyle!({ color: 'blue' });
-    expect(el.style.color).toBe('blue');
-    expect(el.style.fontSize).toBe('');
+    setStyle!({ color: "blue" });
+    expect(el.style.color).toBe("blue");
+    expect(el.style.fontSize).toBe("");
   });
 
-  it('clears all styles when style prop is removed', () => {
+  it("clears all styles when style prop is removed", () => {
     let setProps: ((p: Record<string, unknown>) => void) | null = null;
 
     function* Styled() {
       const [props, sp] = yield* $state<Record<string, unknown>>({
-        style: { color: 'red', fontWeight: 'bold' },
+        style: { color: "red", fontWeight: "bold" },
       });
       setProps = sp;
-      return createElement('div', props);
+      return createElement("div", props);
     }
 
     render(createElement(Styled as never, {}), container);
-    const el = container.querySelector('div') as HTMLElement;
-    expect(el.style.color).toBe('red');
-    expect(el.style.fontWeight).toBe('bold');
+    const el = container.querySelector("div") as HTMLElement;
+    expect(el.style.color).toBe("red");
+    expect(el.style.fontWeight).toBe("bold");
 
     setProps!({});
-    expect(el.style.color).toBe('');
-    expect(el.style.fontWeight).toBe('');
+    expect(el.style.color).toBe("");
+    expect(el.style.fontWeight).toBe("");
   });
 
-  it('renders a Fragment with multiple children', () => {
+  it("renders a Fragment with multiple children", () => {
     render(
       createElement(
-        'ul',
+        "ul",
         null,
         createElement(
           Fragment,
           null,
-          createElement('li', null, 'one'),
-          createElement('li', null, 'two'),
+          createElement("li", null, "one"),
+          createElement("li", null, "two"),
         ),
       ),
       container,
     );
-    const items = container.querySelectorAll('li');
+    const items = container.querySelectorAll("li");
     expect(items).toHaveLength(2);
-    expect(items[0].textContent).toBe('one');
-    expect(items[1].textContent).toBe('two');
+    expect(items[0]!.textContent).toBe("one");
+    expect(items[1]!.textContent).toBe("two");
   });
 
-  it('skips null and undefined children', () => {
-    render(createElement('div', null, null, undefined, 'visible'), container);
-    expect(container.querySelector('div')!.textContent).toBe('visible');
+  it("skips null and undefined children", () => {
+    render(createElement("div", null, null, undefined, "visible"), container);
+    expect(container.querySelector("div")!.textContent).toBe("visible");
   });
 
-  it('sets input value as DOM property (not just attribute)', () => {
+  it("sets input value as DOM property (not just attribute)", () => {
     let setValue: ((v: string) => void) | null = null;
 
     function* Controlled() {
-      const [val, sv] = yield* $state('initial');
+      const [val, sv] = yield* $state("initial");
       setValue = sv;
-      return createElement('input', { type: 'text', value: val });
+      return createElement("input", { type: "text", value: val });
     }
 
     render(createElement(Controlled as never, {}), container);
-    const input = container.querySelector('input') as HTMLInputElement;
-    expect(input.value).toBe('initial');
+    const input = container.querySelector("input") as HTMLInputElement;
+    expect(input.value).toBe("initial");
 
-    setValue!('updated');
-    expect(input.value).toBe('updated');
+    setValue!("updated");
+    expect(input.value).toBe("updated");
 
-    setValue!('');
-    expect(input.value).toBe('');
+    setValue!("");
+    expect(input.value).toBe("");
   });
 
-  it('sets checkbox checked as DOM property', () => {
+  it("sets checkbox checked as DOM property", () => {
     let setChecked: ((v: boolean) => void) | null = null;
 
     function* CheckBox() {
       const [checked, sc] = yield* $state(false);
       setChecked = sc;
-      return createElement('input', { type: 'checkbox', checked });
+      return createElement("input", { type: "checkbox", checked });
     }
 
     render(createElement(CheckBox as never, {}), container);
-    const cb = container.querySelector('input') as HTMLInputElement;
+    const cb = container.querySelector("input") as HTMLInputElement;
     expect(cb.checked).toBe(false);
 
     setChecked!(true);
@@ -189,66 +189,66 @@ describe('render – HTML elements', () => {
   });
 });
 
-describe('buildNode', () => {
-  it('returns a text node for strings', () => {
-    const node = buildNode('hello');
+describe("buildNode", () => {
+  it("returns a text node for strings", () => {
+    const node = buildNode("hello");
     expect(node).toBeInstanceOf(Text);
-    expect(node.textContent).toBe('hello');
+    expect(node.textContent).toBe("hello");
   });
 
-  it('returns a text node for numbers', () => {
+  it("returns a text node for numbers", () => {
     const node = buildNode(42);
     expect(node).toBeInstanceOf(Text);
-    expect(node.textContent).toBe('42');
+    expect(node.textContent).toBe("42");
   });
 
-  it('returns an empty text node for null', () => {
+  it("returns an empty text node for null", () => {
     const node = buildNode(null);
     expect(node).toBeInstanceOf(Text);
-    expect(node.textContent).toBe('');
+    expect(node.textContent).toBe("");
   });
 
-  it('returns an empty text node for false', () => {
+  it("returns an empty text node for false", () => {
     const node = buildNode(false);
     expect(node).toBeInstanceOf(Text);
-    expect(node.textContent).toBe('');
+    expect(node.textContent).toBe("");
   });
 });
 
-describe('render – HTML defaults', () => {
+describe("render – HTML defaults", () => {
   it('sets button type to "button" when not specified', () => {
-    const node = buildNode(createElement('button', {}, 'Click')) as HTMLButtonElement;
-    expect(node.getAttribute('type')).toBe('button');
+    const node = buildNode(createElement("button", {}, "Click")) as HTMLButtonElement;
+    expect(node.getAttribute("type")).toBe("button");
   });
 
-  it('preserves explicit button type', () => {
+  it("preserves explicit button type", () => {
     const node = buildNode(
-      createElement('button', { type: 'submit' }, 'Submit'),
+      createElement("button", { type: "submit" }, "Submit"),
     ) as HTMLButtonElement;
-    expect(node.getAttribute('type')).toBe('submit');
+    expect(node.getAttribute("type")).toBe("submit");
   });
 
   it('warns when <a target="_blank"> has no rel', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    buildNode(createElement('a', { href: 'https://example.com', target: '_blank' }, 'link'));
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('noopener'));
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    buildNode(createElement("a", { href: "https://example.com", target: "_blank" }, "link"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("noopener"));
     warn.mockRestore();
   });
 
   it('does not warn when <a target="_blank"> has any rel value', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
     buildNode(
       createElement(
-        'a',
-        { href: 'https://example.com', target: '_blank', rel: 'noopener noreferrer' },
-        'link',
+        "a",
+        { href: "https://example.com", target: "_blank", rel: "noopener noreferrer" },
+        "link",
       ),
     );
     buildNode(
       createElement(
-        'a',
-        { href: 'https://example.com', target: '_blank', rel: 'noreferrer' },
-        'link',
+        "a",
+        { href: "https://example.com", target: "_blank", rel: "noreferrer" },
+        "link",
       ),
     );
     expect(warn).not.toHaveBeenCalled();
@@ -256,8 +256,8 @@ describe('render – HTML defaults', () => {
   });
 
   it('does not warn for <a> without target="_blank"', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    buildNode(createElement('a', { href: 'https://example.com' }, 'link'));
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    buildNode(createElement("a", { href: "https://example.com" }, "link"));
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
   });

--- a/src/__tests__/shown-prop.test.ts
+++ b/src/__tests__/shown-prop.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state } from '../hooks';
+import { $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('shown prop', () => {
+describe("shown prop", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,110 +16,110 @@ describe('shown prop', () => {
     document.body.removeChild(container);
   });
 
-  it('renders an HTML element when shown is true', () => {
-    render(createElement('div', { $shown: true }, 'visible'), container);
-    expect(container.querySelector('div')).not.toBeNull();
-    expect(container.querySelector('div')!.textContent).toBe('visible');
+  it("renders an HTML element when shown is true", () => {
+    render(createElement("div", { $shown: true }, "visible"), container);
+    expect(container.querySelector("div")).not.toBeNull();
+    expect(container.querySelector("div")!.textContent).toBe("visible");
   });
 
-  it('does not render an HTML element when shown is false', () => {
-    render(createElement('div', { $shown: false }, 'hidden'), container);
-    expect(container.querySelector('div')).toBeNull();
+  it("does not render an HTML element when shown is false", () => {
+    render(createElement("div", { $shown: false }, "hidden"), container);
+    expect(container.querySelector("div")).toBeNull();
   });
 
-  it('renders an HTML element when shown is omitted (defaults to shown)', () => {
-    render(createElement('div', null, 'visible'), container);
-    expect(container.querySelector('div')).not.toBeNull();
+  it("renders an HTML element when shown is omitted (defaults to shown)", () => {
+    render(createElement("div", null, "visible"), container);
+    expect(container.querySelector("div")).not.toBeNull();
   });
 
-  it('does not set shown as a DOM attribute', () => {
-    render(createElement('div', { $shown: true }, 'visible'), container);
-    const el = container.querySelector('div')!;
-    expect(el.hasAttribute('$shown')).toBe(false);
+  it("does not set shown as a DOM attribute", () => {
+    render(createElement("div", { $shown: true }, "visible"), container);
+    const el = container.querySelector("div")!;
+    expect(el.hasAttribute("$shown")).toBe(false);
   });
 
-  it('renders a plain function component when shown is true', () => {
+  it("renders a plain function component when shown is true", () => {
     function Greeting() {
-      return createElement('p', null, 'hello');
+      return createElement("p", null, "hello");
     }
     render(
-      createElement('div', null, createElement(Greeting as never, { $shown: true })),
+      createElement("div", null, createElement(Greeting as never, { $shown: true })),
       container,
     );
-    expect(container.querySelector('p')).not.toBeNull();
+    expect(container.querySelector("p")).not.toBeNull();
   });
 
-  it('does not render a plain function component when shown is false', () => {
+  it("does not render a plain function component when shown is false", () => {
     function Greeting() {
-      return createElement('p', null, 'hello');
+      return createElement("p", null, "hello");
     }
     render(
-      createElement('div', null, createElement(Greeting as never, { $shown: false })),
+      createElement("div", null, createElement(Greeting as never, { $shown: false })),
       container,
     );
-    expect(container.querySelector('p')).toBeNull();
+    expect(container.querySelector("p")).toBeNull();
   });
 
-  it('renders a generator component when shown is true', () => {
+  it("renders a generator component when shown is true", () => {
     function* Counter() {
-      return createElement('p', null, 'counter');
+      return createElement("p", null, "counter");
     }
     render(
-      createElement('div', null, createElement(Counter as never, { $shown: true })),
+      createElement("div", null, createElement(Counter as never, { $shown: true })),
       container,
     );
-    expect(container.querySelector('p')).not.toBeNull();
+    expect(container.querySelector("p")).not.toBeNull();
   });
 
-  it('does not render a generator component when shown is false', () => {
+  it("does not render a generator component when shown is false", () => {
     function* Counter() {
-      return createElement('p', null, 'counter');
+      return createElement("p", null, "counter");
     }
     render(
-      createElement('div', null, createElement(Counter as never, { $shown: false })),
+      createElement("div", null, createElement(Counter as never, { $shown: false })),
       container,
     );
-    expect(container.querySelector('p')).toBeNull();
+    expect(container.querySelector("p")).toBeNull();
   });
 
-  it('unmounts an HTML element when shown changes from true to false', () => {
+  it("unmounts an HTML element when shown changes from true to false", () => {
     let setShown: ((v: boolean) => void) | null = null;
 
     function* Wrapper() {
       const [$shown, setS] = yield* $state(true);
       setShown = setS;
-      return createElement('div', { $shown }, 'content');
+      return createElement("div", { $shown }, "content");
     }
 
     render(createElement(Wrapper as never, {}), container);
-    expect(container.querySelector('div')).not.toBeNull();
+    expect(container.querySelector("div")).not.toBeNull();
 
     setShown!(false);
-    expect(container.querySelector('div')).toBeNull();
+    expect(container.querySelector("div")).toBeNull();
   });
 
-  it('mounts an HTML element when shown changes from false to true', () => {
+  it("mounts an HTML element when shown changes from false to true", () => {
     let setShown: ((v: boolean) => void) | null = null;
 
     function* Wrapper() {
       const [$shown, setS] = yield* $state(false);
       setShown = setS;
-      return createElement('div', { $shown }, 'content');
+      return createElement("div", { $shown }, "content");
     }
 
     render(createElement(Wrapper as never, {}), container);
-    expect(container.querySelector('div')).toBeNull();
+    expect(container.querySelector("div")).toBeNull();
 
     setShown!(true);
-    expect(container.querySelector('div')).not.toBeNull();
-    expect(container.querySelector('div')!.textContent).toBe('content');
+    expect(container.querySelector("div")).not.toBeNull();
+    expect(container.querySelector("div")!.textContent).toBe("content");
   });
 
-  it('unmounts a component when shown changes from true to false', () => {
+  it("unmounts a component when shown changes from true to false", () => {
     let setShown: ((v: boolean) => void) | null = null;
 
     function* Inner() {
-      return createElement('p', null, 'inner');
+      return createElement("p", null, "inner");
     }
 
     function* Wrapper() {
@@ -129,17 +129,17 @@ describe('shown prop', () => {
     }
 
     render(createElement(Wrapper as never, {}), container);
-    expect(container.querySelector('p')).not.toBeNull();
+    expect(container.querySelector("p")).not.toBeNull();
 
     setShown!(false);
-    expect(container.querySelector('p')).toBeNull();
+    expect(container.querySelector("p")).toBeNull();
   });
 
-  it('mounts a component when shown changes from false to true', () => {
+  it("mounts a component when shown changes from false to true", () => {
     let setShown: ((v: boolean) => void) | null = null;
 
     function* Inner() {
-      return createElement('p', null, 'inner');
+      return createElement("p", null, "inner");
     }
 
     function* Wrapper() {
@@ -149,10 +149,10 @@ describe('shown prop', () => {
     }
 
     render(createElement(Wrapper as never, {}), container);
-    expect(container.querySelector('p')).toBeNull();
+    expect(container.querySelector("p")).toBeNull();
 
     setShown!(true);
-    expect(container.querySelector('p')).not.toBeNull();
-    expect(container.querySelector('p')!.textContent).toBe('inner');
+    expect(container.querySelector("p")).not.toBeNull();
+    expect(container.querySelector("p")!.textContent).toBe("inner");
   });
 });

--- a/src/__tests__/stop-render-on-update.test.ts
+++ b/src/__tests__/stop-render-on-update.test.ts
@@ -1,12 +1,12 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state, $effect, $memo } from '../hooks';
+import { $effect, $memo, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
-describe('stop-render-on-update', () => {
+describe("stop-render-on-update", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -14,7 +14,7 @@ describe('stop-render-on-update', () => {
     document.body.removeChild(container);
   });
 
-  it('setState returns Promise<void> that resolves after the rerender commits', async () => {
+  it("setState returns Promise<void> that resolves after the rerender commits", async () => {
     let setter: ((v: number) => Promise<void>) | null = null;
     let renderCount = 0;
 
@@ -22,30 +22,28 @@ describe('stop-render-on-update', () => {
       const [n, setN] = yield* $state(0);
       setter = setN;
       renderCount++;
-      return createElement('span', null, String(n));
+      return createElement("span", null, String(n));
     }
 
     render(createElement(Comp as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(container.querySelector('span')!.textContent).toBe('0');
+    expect(container.querySelector("span")!.textContent).toBe("0");
 
     const p = setter!(42);
     // After the promise resolves the DOM must reflect the new state
     await p;
     expect(renderCount).toBe(2);
-    expect(container.querySelector('span')!.textContent).toBe('42');
+    expect(container.querySelector("span")!.textContent).toBe("42");
   });
 
-  it('setState called during synchronous $memo queues the rerender instead of running recursively', () => {
+  it("setState called during synchronous $memo queues the rerender instead of running recursively", () => {
     // Keep track of how many times the component body runs
     let renderCount = 0;
-    let setter: ((v: number) => Promise<void>) | null = null;
     let memoRuns = 0;
 
     function* Comp() {
       renderCount++;
       const [n, setN] = yield* $state(0);
-      setter = setN;
 
       // $memo factory calls setState synchronously — this must be queued,
       // not executed as a nested synchronous rerender.
@@ -56,7 +54,7 @@ describe('stop-render-on-update', () => {
         }
       }, [n]);
 
-      return createElement('span', null, String(n));
+      return createElement("span", null, String(n));
     }
 
     render(createElement(Comp as never, {}), container);
@@ -73,20 +71,16 @@ describe('stop-render-on-update', () => {
     // - Run 1 (cancelled): n=0, deps=[0], memoRuns++, setN(1) → pendingRerender
     // - Run 2 (committed): n=1, deps=[1], memoRuns++ (deps changed)
     expect(memoRuns).toBe(2);
-    expect(container.querySelector('span')!.textContent).toBe('1');
+    expect(container.querySelector("span")!.textContent).toBe("1");
   });
 
-  it('multiple synchronous setState calls during one render collapse into a single follow-up render', () => {
+  it("multiple synchronous setState calls during one render collapse into a single follow-up render", () => {
     let renderCount = 0;
-    let setA: ((v: number) => Promise<void>) | null = null;
-    let setB: ((v: number) => Promise<void>) | null = null;
-
     function* Comp() {
       renderCount++;
       const [a, sa] = yield* $state(0);
       const [b, sb] = yield* $state(0);
-      setA = sa;
-      setB = sb;
+      // sa and sb are used directly in the $memo callback below
 
       // Synchronously update both on first render
       yield* $memo(() => {
@@ -96,7 +90,7 @@ describe('stop-render-on-update', () => {
         }
       }, [a, b]);
 
-      return createElement('span', null, `${a}:${b}`);
+      return createElement("span", null, `${a}:${b}`);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -104,20 +98,18 @@ describe('stop-render-on-update', () => {
     // Initial render: cancelled after first setState
     // Follow-up render: committed with a=10, b=20 (sa(10) and sb(20) both applied)
     // Only ONE follow-up render should happen (both state changes batched)
-    expect(container.querySelector('span')!.textContent).toBe('10:20');
+    expect(container.querySelector("span")!.textContent).toBe("10:20");
     // renderCount is 2: one cancelled, one committed
     expect(renderCount).toBe(2);
   });
 
-  it('$effect cleanup does NOT fire for a cancelled (mid-render-interrupted) render', () => {
+  it("$effect cleanup does NOT fire for a cancelled (mid-render-interrupted) render", () => {
     let cleanupCount = 0;
     let renderCount = 0;
-    let setter: ((v: number) => Promise<void>) | null = null;
 
     function* Comp() {
       renderCount++;
       const [n, setN] = yield* $state(0);
-      setter = setN;
 
       yield* $effect(() => {
         return () => {
@@ -129,7 +121,7 @@ describe('stop-render-on-update', () => {
         if (n === 0) setN(1);
       }, [n]);
 
-      return createElement('span', null, String(n));
+      return createElement("span", null, String(n));
     }
 
     render(createElement(Comp as never, {}), container);
@@ -138,28 +130,28 @@ describe('stop-render-on-update', () => {
     // (and therefore its cleanup never runs either).
     // The committed render is n=1.
     expect(renderCount).toBe(2);
-    expect(container.querySelector('span')!.textContent).toBe('1');
+    expect(container.querySelector("span")!.textContent).toBe("1");
 
     // No cleanup should have fired yet — only one effect was committed (n=1)
     expect(cleanupCount).toBe(0);
   });
 
-  it('await setState resolves after the committed render, allowing async $memo continuation', async () => {
+  it("await setState resolves after the committed render, allowing async $memo continuation", async () => {
     const log: string[] = [];
 
     function* Comp() {
-      const [name, setName] = yield* $state('joona');
+      const [name, setName] = yield* $state("joona");
 
       yield* $memo(async () => {
-        log.push('memo run: ' + name);
+        log.push(`memo run: ${name}`);
         if (name !== name.toUpperCase()) {
-          log.push('calling setName');
+          log.push("calling setName");
           await setName(name.toUpperCase());
-          log.push('setName resolved, name in DOM is now uppercase');
+          log.push("setName resolved, name in DOM is now uppercase");
         }
       }, [name]);
 
-      return createElement('span', null, name);
+      return createElement("span", null, name);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -168,25 +160,25 @@ describe('stop-render-on-update', () => {
     // (synchronously, before the first await in the async factory), which
     // queued a rerender. The first render was cancelled; the second committed
     // with 'JOONA'. After that the async memo's await resolved.
-    expect(container.querySelector('span')!.textContent).toBe('JOONA');
+    expect(container.querySelector("span")!.textContent).toBe("JOONA");
 
     // Yield to the microtask queue so the async continuation runs
     await Promise.resolve();
 
     expect(log).toEqual([
-      'memo run: joona',
-      'calling setName',
-      'memo run: JOONA', // second render, same deps cache hit? No – deps changed (joona→JOONA)
-      'setName resolved, name in DOM is now uppercase',
+      "memo run: joona",
+      "calling setName",
+      "memo run: JOONA", // second render, same deps cache hit? No – deps changed (joona→JOONA)
+      "setName resolved, name in DOM is now uppercase",
     ]);
   });
 
-  it('$memo cache is reused across a cancelled + retried render when deps are unchanged', () => {
+  it("$memo cache is reused across a cancelled + retried render when deps are unchanged", () => {
     let memoRuns = 0;
     let setter: ((v: string) => Promise<void>) | null = null;
 
     function* Comp() {
-      const [label, setLabel] = yield* $state('a');
+      const [label, setLabel] = yield* $state("a");
       setter = setLabel;
 
       // memo deps: [label]
@@ -197,12 +189,12 @@ describe('stop-render-on-update', () => {
 
       // On first render only: change unrelated state to trigger a cancel
       yield* $memo(() => {
-        if (label === 'a') {
-          setLabel('b'); // queues rerender
+        if (label === "a") {
+          setLabel("b"); // queues rerender
         }
       }, [label]);
 
-      return createElement('span', null, derived);
+      return createElement("span", null, derived);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -210,45 +202,45 @@ describe('stop-render-on-update', () => {
     // Run 1 (cancelled, label='a'): memoRuns++ (→1), setLabel('b') queued
     // Run 2 (committed, label='b'): memoRuns++ (→2) because deps changed
     expect(memoRuns).toBe(2);
-    expect(container.querySelector('span')!.textContent).toBe('B');
+    expect(container.querySelector("span")!.textContent).toBe("B");
 
     // Now trigger an external state change that does NOT change the memo deps
-    setter!('b'); // same value → shallowEqual, no rerender
+    setter!("b"); // same value → shallowEqual, no rerender
     // (setter called with same value — $state setter still calls rerender but
     //  since value didn't change the component just re-renders and memo cache hits)
   });
 
-  it('multiple awaited setState calls chain correctly', async () => {
+  it("multiple awaited setState calls chain correctly", async () => {
     const domValues: string[] = [];
 
     function* Comp() {
-      const [val, setVal] = yield* $state('start');
+      const [val, setVal] = yield* $state("start");
 
       yield* $memo(async () => {
-        if (val === 'start') {
-          await setVal('middle');
+        if (val === "start") {
+          await setVal("middle");
           // After this resolves, DOM has 'middle'
-          await setVal('end');
+          await setVal("end");
           // After this resolves, DOM has 'end'
         }
       }, [val]);
 
-      return createElement('span', null, val);
+      return createElement("span", null, val);
     }
 
     render(createElement(Comp as never, {}), container);
     // Synchronous: val='start', setVal('middle') called → queued, render cancelled
     // Committed: val='middle'
-    expect(container.querySelector('span')!.textContent).toBe('middle');
+    expect(container.querySelector("span")!.textContent).toBe("middle");
 
     // First microtask: await setVal('middle') resolved → setVal('end') called
     await Promise.resolve();
     // setVal('end') runs rerender synchronously (isRendering=false)
-    expect(container.querySelector('span')!.textContent).toBe('end');
+    expect(container.querySelector("span")!.textContent).toBe("end");
 
     // Second microtask: await setVal('end') resolved
     await Promise.resolve();
-    domValues.push(container.querySelector('span')!.textContent!);
-    expect(domValues).toEqual(['end']);
+    domValues.push(container.querySelector("span")!.textContent!);
+    expect(domValues).toEqual(["end"]);
   });
 });

--- a/src/__tests__/ui-patch.test.ts
+++ b/src/__tests__/ui-patch.test.ts
@@ -1,6 +1,6 @@
-import { createElement } from '../jsx';
-import { render, startUIPatch, commitUIPatch } from '../render';
-import { $state, $uiPatch } from '../hooks';
+import { $state, $uiPatch } from "../hooks";
+import { createElement } from "../jsx";
+import { commitUIPatch, render, startUIPatch } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
@@ -8,11 +8,11 @@ import { $state, $uiPatch } from '../hooks';
 // Global UI Patch: startUIPatch / commitUIPatch
 // ---------------------------------------------------------------------------
 
-describe('startUIPatch / commitUIPatch (global patch)', () => {
+describe("startUIPatch / commitUIPatch (global patch)", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -22,70 +22,70 @@ describe('startUIPatch / commitUIPatch (global patch)', () => {
     commitUIPatch();
   });
 
-  it('defers DOM updates until commitUIPatch is called', () => {
+  it("defers DOM updates until commitUIPatch is called", () => {
     let setValue: ((v: string) => void) | null = null;
 
     function* Comp() {
-      const [v, sv] = yield* $state('initial');
+      const [v, sv] = yield* $state("initial");
       setValue = sv;
-      return createElement('span', null, v);
+      return createElement("span", null, v);
     }
 
     render(createElement(Comp as never, {}), container);
-    expect(container.textContent).toBe('initial');
+    expect(container.textContent).toBe("initial");
 
     startUIPatch();
-    setValue!('updated');
+    setValue!("updated");
     // DOM not yet changed
-    expect(container.textContent).toBe('initial');
+    expect(container.textContent).toBe("initial");
 
     commitUIPatch();
-    expect(container.textContent).toBe('updated');
+    expect(container.textContent).toBe("updated");
   });
 
-  it('multiple state changes during patch produce exactly one DOM update on commit', () => {
+  it("multiple state changes during patch produce exactly one DOM update on commit", () => {
     const renderCalls: string[] = [];
     let setValue: ((v: string) => void) | null = null;
 
     function* Comp() {
-      const [v, sv] = yield* $state('a');
+      const [v, sv] = yield* $state("a");
       setValue = sv;
       renderCalls.push(v);
-      return createElement('span', null, v);
+      return createElement("span", null, v);
     }
 
     render(createElement(Comp as never, {}), container);
     renderCalls.length = 0; // reset after initial mount
 
     startUIPatch();
-    setValue!('b');
-    setValue!('c');
+    setValue!("b");
+    setValue!("c");
     // Two state changes → two generator runs, but DOM unchanged
-    expect(container.textContent).toBe('a');
+    expect(container.textContent).toBe("a");
 
     commitUIPatch();
     // DOM reflects final state
-    expect(container.textContent).toBe('c');
+    expect(container.textContent).toBe("c");
   });
 
-  it('nested patches: DOM only flushed when depth reaches zero', () => {
+  it("nested patches: DOM only flushed when depth reaches zero", () => {
     let setValue: ((v: string) => void) | null = null;
 
     function* Comp() {
-      const [v, sv] = yield* $state('a');
+      const [v, sv] = yield* $state("a");
       setValue = sv;
-      return createElement('span', null, v);
+      return createElement("span", null, v);
     }
 
     render(createElement(Comp as never, {}), container);
 
     startUIPatch();
     startUIPatch();
-    setValue!('b');
+    setValue!("b");
     commitUIPatch(); // depth 2→1; not flushed yet
-    expect(container.textContent).toBe('a');
+    expect(container.textContent).toBe("a");
     commitUIPatch(); // depth 1→0; flushed now
-    expect(container.textContent).toBe('b');
+    expect(container.textContent).toBe("b");
   });
 
   it('$patch="live" component updates immediately during a global patch', () => {
@@ -93,22 +93,22 @@ describe('startUIPatch / commitUIPatch (global patch)', () => {
     let setFrozen: ((v: string) => void) | null = null;
 
     function* Live() {
-      const [v, sv] = yield* $state('live-a');
+      const [v, sv] = yield* $state("live-a");
       setLive = sv;
-      return createElement('span', { id: 'live' }, v);
+      return createElement("span", { id: "live" }, v);
     }
 
     function* Frozen() {
-      const [v, sv] = yield* $state('frozen-a');
+      const [v, sv] = yield* $state("frozen-a");
       setFrozen = sv;
-      return createElement('span', { id: 'frozen' }, v);
+      return createElement("span", { id: "frozen" }, v);
     }
 
     function* App() {
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Live as never, { $patch: 'live' }),
+        createElement(Live as never, { $patch: "live" }),
         createElement(Frozen as never, {}),
       );
     }
@@ -116,37 +116,37 @@ describe('startUIPatch / commitUIPatch (global patch)', () => {
     render(createElement(App as never, {}), container);
 
     startUIPatch();
-    setLive!('live-b');
-    setFrozen!('frozen-b');
+    setLive!("live-b");
+    setFrozen!("frozen-b");
 
     // Live component updated immediately; frozen component not yet
-    expect(container.querySelector('#live')!.textContent).toBe('live-b');
-    expect(container.querySelector('#frozen')!.textContent).toBe('frozen-a');
+    expect(container.querySelector("#live")!.textContent).toBe("live-b");
+    expect(container.querySelector("#frozen")!.textContent).toBe("frozen-a");
 
     commitUIPatch();
-    expect(container.querySelector('#frozen')!.textContent).toBe('frozen-b');
+    expect(container.querySelector("#frozen")!.textContent).toBe("frozen-b");
   });
 
-  it('unmounting a dirty component before commit does not throw', () => {
+  it("unmounting a dirty component before commit does not throw", () => {
     let setValue: ((v: string) => void) | null = null;
     let setShown: ((v: boolean) => void) | null = null;
 
     function* Inner() {
-      const [v, sv] = yield* $state('x');
+      const [v, sv] = yield* $state("x");
       setValue = sv;
-      return createElement('span', null, v);
+      return createElement("span", null, v);
     }
 
     function* Outer() {
       const [shown, setS] = yield* $state(true);
       setShown = setS;
-      return createElement('div', null, shown ? createElement(Inner as never, {}) : null);
+      return createElement("div", null, shown ? createElement(Inner as never, {}) : null);
     }
 
     render(createElement(Outer as never, {}), container);
 
     startUIPatch();
-    setValue!('y'); // Inner is now dirty
+    setValue!("y"); // Inner is now dirty
     setShown!(false); // Inner is unmounted
 
     expect(() => commitUIPatch()).not.toThrow();
@@ -157,11 +157,11 @@ describe('startUIPatch / commitUIPatch (global patch)', () => {
 // Local UI Patch: $uiPatch
 // ---------------------------------------------------------------------------
 
-describe('$uiPatch (local patch)', () => {
+describe("$uiPatch (local patch)", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -169,54 +169,54 @@ describe('$uiPatch (local patch)', () => {
     document.body.removeChild(container);
   });
 
-  it('defers DOM updates in the component and its descendants until commit', () => {
+  it("defers DOM updates in the component and its descendants until commit", () => {
     let setInner: ((v: string) => void) | null = null;
     let capturedCommit: (() => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      const [v, sv] = yield* $state('child-a');
+      const [v, sv] = yield* $state("child-a");
       setInner = sv;
-      return createElement('span', { id: 'child' }, v);
+      return createElement("span", { id: "child" }, v);
     }
 
     function* Parent() {
       const startPatch = yield* $uiPatch();
       capturedStartPatch = startPatch;
-      return createElement('div', null, createElement(Child as never, {}));
+      return createElement("div", null, createElement(Child as never, {}));
     }
 
     render(createElement(Parent as never, {}), container);
 
     capturedCommit = capturedStartPatch!();
-    setInner!('child-b');
+    setInner!("child-b");
 
     // DOM not yet updated
-    expect(container.querySelector('#child')!.textContent).toBe('child-a');
+    expect(container.querySelector("#child")!.textContent).toBe("child-a");
 
     capturedCommit();
-    expect(container.querySelector('#child')!.textContent).toBe('child-b');
+    expect(container.querySelector("#child")!.textContent).toBe("child-b");
   });
 
-  it('sibling component outside the patch subtree updates immediately', () => {
+  it("sibling component outside the patch subtree updates immediately", () => {
     let setSibling: ((v: string) => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* PatchedArea() {
       const startPatch = yield* $uiPatch();
       capturedStartPatch = startPatch;
-      return createElement('span', { id: 'patched' }, 'content');
+      return createElement("span", { id: "patched" }, "content");
     }
 
     function* Sibling() {
-      const [v, sv] = yield* $state('sib-a');
+      const [v, sv] = yield* $state("sib-a");
       setSibling = sv;
-      return createElement('span', { id: 'sib' }, v);
+      return createElement("span", { id: "sib" }, v);
     }
 
     function* App() {
       return createElement(
-        'div',
+        "div",
         null,
         createElement(PatchedArea as never, {}),
         createElement(Sibling as never, {}),
@@ -226,16 +226,16 @@ describe('$uiPatch (local patch)', () => {
     render(createElement(App as never, {}), container);
 
     const commit = capturedStartPatch!();
-    setSibling!('sib-b');
+    setSibling!("sib-b");
 
     // Sibling is outside the patch scope → updates immediately
-    expect(container.querySelector('#sib')!.textContent).toBe('sib-b');
+    expect(container.querySelector("#sib")!.textContent).toBe("sib-b");
 
     // Committing is a no-op for the sibling but should not throw
     expect(() => commit()).not.toThrow();
   });
 
-  it('snapshot is taken at startPatch() call time', () => {
+  it("snapshot is taken at startPatch() call time", () => {
     // A child mounted AFTER startPatch() is called is not in the snapshot
     // and runs normally.
     let setShow: ((v: boolean) => void) | null = null;
@@ -243,9 +243,9 @@ describe('$uiPatch (local patch)', () => {
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Dynamic() {
-      const [v, sv] = yield* $state('dyn-a');
+      const [v, sv] = yield* $state("dyn-a");
       setDynamic = sv;
-      return createElement('span', { id: 'dyn' }, v);
+      return createElement("span", { id: "dyn" }, v);
     }
 
     function* Parent() {
@@ -253,7 +253,7 @@ describe('$uiPatch (local patch)', () => {
       capturedStartPatch = startPatch;
       const [show, setS] = yield* $state(false);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Dynamic as never, {}) : null);
+      return createElement("div", null, show ? createElement(Dynamic as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
@@ -264,11 +264,11 @@ describe('$uiPatch (local patch)', () => {
     // Mount Dynamic while patch is active (it's not in the snapshot)
     setShow!(true); // Parent is in the patch → deferred
     // DOM not yet updated (Parent itself is deferred)
-    expect(container.querySelector('#dyn')).toBeNull();
+    expect(container.querySelector("#dyn")).toBeNull();
 
     commit();
     // After commit, Dynamic appears
-    expect(container.querySelector('#dyn')!.textContent).toBe('dyn-a');
+    expect(container.querySelector("#dyn")!.textContent).toBe("dyn-a");
     void setDynamic; // silence unused warning
   });
 });
@@ -277,11 +277,11 @@ describe('$uiPatch (local patch)', () => {
 // Live-only reconcile: element visibility during global patches
 // ---------------------------------------------------------------------------
 
-describe('live-only reconcile: element add/remove during global patch', () => {
+describe("live-only reconcile: element add/remove during global patch", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -292,74 +292,74 @@ describe('live-only reconcile: element add/remove during global patch', () => {
 
   // ── Removal ──────────────────────────────────────────────────────────────
 
-  it('removed default element stays visible until commit', () => {
+  it("removed default element stays visible until commit", () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(true);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Child as never, {}) : null);
+      return createElement("div", null, show ? createElement(Child as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     startUIPatch();
     setShow!(false);
     // Still visible — DOM is frozen
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
   it('removed $patch="live" component disappears immediately', () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(true);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        show ? createElement(Child as never, { $patch: 'live' }) : null,
+        show ? createElement(Child as never, { $patch: "live" }) : null,
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     startUIPatch();
     setShow!(false);
     // Removed immediately because $patch="live"
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commitUIPatch();
     // Still gone after commit
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
   it('element inside $patch="live" wrapper removed disappears immediately', () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(true);
       setShow = setS;
       return createElement(
-        'div',
-        { $patch: 'live' },
+        "div",
+        { $patch: "live" },
         show ? createElement(Child as never, {}) : null,
       );
     }
@@ -368,105 +368,105 @@ describe('live-only reconcile: element add/remove during global patch', () => {
 
     startUIPatch();
     setShow!(false);
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
   it('$shown=false with $patch="live" hides element immediately', () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(true);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Child as never, { $shown: show, $patch: 'live' }),
+        createElement(Child as never, { $shown: show, $patch: "live" }),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     startUIPatch();
     setShow!(false);
     // Hidden immediately
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
   it('$shown=false without $patch="live" keeps element visible until commit', () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(true);
       setShow = setS;
-      return createElement('div', null, createElement(Child as never, { $shown: show }));
+      return createElement("div", null, createElement(Child as never, { $shown: show }));
     }
 
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
     setShow!(false);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
   // ── Addition ─────────────────────────────────────────────────────────────
 
-  it('added default element does not appear until commit', () => {
+  it("added default element does not appear until commit", () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(false);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Child as never, {}) : null);
+      return createElement("div", null, show ? createElement(Child as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     startUIPatch();
     setShow!(true);
     // Not yet visible
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
   it('added $patch="live" component appears immediately', () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(false);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        show ? createElement(Child as never, { $patch: 'live' }) : null,
+        show ? createElement(Child as never, { $patch: "live" }) : null,
       );
     }
 
@@ -475,26 +475,26 @@ describe('live-only reconcile: element add/remove during global patch', () => {
     startUIPatch();
     setShow!(true);
     // Appears immediately
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
     // Still there after commit
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
   it('element added inside $patch="live" wrapper appears immediately', () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(false);
       setShow = setS;
       return createElement(
-        'div',
-        { $patch: 'live' },
+        "div",
+        { $patch: "live" },
         show ? createElement(Child as never, {}) : null,
       );
     }
@@ -503,82 +503,82 @@ describe('live-only reconcile: element add/remove during global patch', () => {
 
     startUIPatch();
     setShow!(true);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
   it('$shown=true with $patch="live" shows element immediately', () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(false);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Child as never, { $shown: show, $patch: 'live' }),
+        createElement(Child as never, { $shown: show, $patch: "live" }),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     startUIPatch();
     setShow!(true);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
   // ── Remove then re-add ────────────────────────────────────────────────────
 
-  it('default element removed then re-added stays visible throughout and commit preserves it', () => {
+  it("default element removed then re-added stays visible throughout and commit preserves it", () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(true);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Child as never, {}) : null);
+      return createElement("div", null, show ? createElement(Child as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
     setShow!(false); // remove — frozen, stays visible
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
     setShow!(true); // re-add — still frozen
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
     // Final state: show=true → element present
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
-  it('live element removed then re-added disappears and reappears immediately', () => {
+  it("live element removed then re-added disappears and reappears immediately", () => {
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
       const [show, setS] = yield* $state(true);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        show ? createElement(Child as never, { $patch: 'live' }) : null,
+        show ? createElement(Child as never, { $patch: "live" }) : null,
       );
     }
 
@@ -586,12 +586,12 @@ describe('live-only reconcile: element add/remove during global patch', () => {
 
     startUIPatch();
     setShow!(false); // live remove → gone immediately
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
     setShow!(true); // live re-add → back immediately
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
   // ── Text content inside live context ──────────────────────────────────────
@@ -600,98 +600,98 @@ describe('live-only reconcile: element add/remove during global patch', () => {
     let setValue: ((v: string) => void) | null = null;
 
     function* Parent() {
-      const [v, setV] = yield* $state('a');
+      const [v, setV] = yield* $state("a");
       setValue = setV;
-      return createElement('div', { $patch: 'live' }, v);
+      return createElement("div", { $patch: "live" }, v);
     }
 
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setValue!('b');
-    expect(container.textContent).toBe('b');
+    setValue!("b");
+    expect(container.textContent).toBe("b");
 
     commitUIPatch();
-    expect(container.textContent).toBe('b');
+    expect(container.textContent).toBe("b");
   });
 
-  it('text outside live context stays frozen until commit', () => {
+  it("text outside live context stays frozen until commit", () => {
     let setValue: ((v: string) => void) | null = null;
 
     function* Parent() {
-      const [v, setV] = yield* $state('a');
+      const [v, setV] = yield* $state("a");
       setValue = setV;
-      return createElement('span', null, v);
+      return createElement("span", null, v);
     }
 
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setValue!('b');
-    expect(container.textContent).toBe('a');
+    setValue!("b");
+    expect(container.textContent).toBe("a");
 
     commitUIPatch();
-    expect(container.textContent).toBe('b');
+    expect(container.textContent).toBe("b");
   });
 
   // ── Dynamic $patch changes mid-patch ─────────────────────────────────────
 
-  it('component switches from default to live mid-patch and starts updating immediately', () => {
+  it("component switches from default to live mid-patch and starts updating immediately", () => {
     let setLive: ((v: boolean) => void) | null = null;
     let setValue: ((v: string) => void) | null = null;
 
     function* Child() {
-      const [v, setV] = yield* $state('a');
+      const [v, setV] = yield* $state("a");
       setValue = setV;
-      return createElement('span', { id: 'target' }, v);
+      return createElement("span", { id: "target" }, v);
     }
 
     function* Parent() {
       const [live, setLive_] = yield* $state(false);
       setLive = setLive_;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Child as never, { $patch: live ? 'live' : 'default' }),
+        createElement(Child as never, { $patch: live ? "live" : "default" }),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#target')!.textContent).toBe('a');
+    expect(container.querySelector("#target")!.textContent).toBe("a");
 
     startUIPatch();
     // First update while Child is still default → deferred
-    setValue!('b');
-    expect(container.querySelector('#target')!.textContent).toBe('a');
+    setValue!("b");
+    expect(container.querySelector("#target")!.textContent).toBe("a");
 
     // Switch Child to live (via parent rerender)
     setLive!(true);
     // Now Child's captured batch context is updated to 'live'
     // Subsequent updates should be immediate
-    setValue!('c');
-    expect(container.querySelector('#target')!.textContent).toBe('c');
+    setValue!("c");
+    expect(container.querySelector("#target")!.textContent).toBe("c");
 
     commitUIPatch();
-    expect(container.querySelector('#target')!.textContent).toBe('c');
+    expect(container.querySelector("#target")!.textContent).toBe("c");
   });
 
-  it('component switches from live to default mid-patch and stops updating', () => {
+  it("component switches from live to default mid-patch and stops updating", () => {
     let setLive: ((v: boolean) => void) | null = null;
     let setValue: ((v: string) => void) | null = null;
 
     function* Child() {
-      const [v, setV] = yield* $state('a');
+      const [v, setV] = yield* $state("a");
       setValue = setV;
-      return createElement('span', { id: 'target' }, v);
+      return createElement("span", { id: "target" }, v);
     }
 
     function* Parent() {
       const [live, setLive_] = yield* $state(true);
       setLive = setLive_;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Child as never, { $patch: live ? 'live' : 'default' }),
+        createElement(Child as never, { $patch: live ? "live" : "default" }),
       );
     }
 
@@ -699,53 +699,53 @@ describe('live-only reconcile: element add/remove during global patch', () => {
 
     startUIPatch();
     // Child is live → updates immediately
-    setValue!('b');
-    expect(container.querySelector('#target')!.textContent).toBe('b');
+    setValue!("b");
+    expect(container.querySelector("#target")!.textContent).toBe("b");
 
     // Switch Child to default → stops updating immediately
     setLive!(false);
-    setValue!('c');
+    setValue!("c");
     // Should still show 'b' — deferred now
-    expect(container.querySelector('#target')!.textContent).toBe('b');
+    expect(container.querySelector("#target")!.textContent).toBe("b");
 
     commitUIPatch();
-    expect(container.querySelector('#target')!.textContent).toBe('c');
+    expect(container.querySelector("#target")!.textContent).toBe("c");
   });
 
-  it('live element that becomes default retains its last live state after commit', () => {
+  it("live element that becomes default retains its last live state after commit", () => {
     let setLive: ((v: boolean) => void) | null = null;
     let setValue: ((v: string) => void) | null = null;
 
     function* Child() {
-      const [v, setV] = yield* $state('a');
+      const [v, setV] = yield* $state("a");
       setValue = setV;
-      return createElement('span', { id: 'target' }, v);
+      return createElement("span", { id: "target" }, v);
     }
 
     function* Parent() {
       const [live, setLive_] = yield* $state(true);
       setLive = setLive_;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Child as never, { $patch: live ? 'live' : 'default' }),
+        createElement(Child as never, { $patch: live ? "live" : "default" }),
       );
     }
 
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setValue!('b'); // live → updates immediately
-    expect(container.querySelector('#target')!.textContent).toBe('b');
+    setValue!("b"); // live → updates immediately
+    expect(container.querySelector("#target")!.textContent).toBe("b");
 
     setLive!(false); // switch to default — 'b' stays in DOM
-    expect(container.querySelector('#target')!.textContent).toBe('b');
+    expect(container.querySelector("#target")!.textContent).toBe("b");
 
     // No further state updates — commit should apply pendingVNode for Parent
     // (which has $patch="default" for Child now), reconcile from 'b'
     commitUIPatch();
     // State was never changed again — Child remains at 'b'
-    expect(container.querySelector('#target')!.textContent).toBe('b');
+    expect(container.querySelector("#target")!.textContent).toBe("b");
   });
 });
 
@@ -753,11 +753,11 @@ describe('live-only reconcile: element add/remove during global patch', () => {
 // Live-only reconcile: element add/remove during local patches
 // ---------------------------------------------------------------------------
 
-describe('live-only reconcile: element add/remove during local patch', () => {
+describe("live-only reconcile: element add/remove during local patch", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -765,12 +765,12 @@ describe('live-only reconcile: element add/remove during local patch', () => {
     document.body.removeChild(container);
   });
 
-  it('removed default element stays visible until local commit', () => {
+  it("removed default element stays visible until local commit", () => {
     let setShow: ((v: boolean) => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
@@ -778,17 +778,17 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       capturedStartPatch = startPatch;
       const [show, setS] = yield* $state(true);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Child as never, {}) : null);
+      return createElement("div", null, show ? createElement(Child as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
 
     const commit = capturedStartPatch!();
     setShow!(false);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commit();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
   it('removed $patch="live" component disappears immediately during local patch', () => {
@@ -796,7 +796,7 @@ describe('live-only reconcile: element add/remove during local patch', () => {
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
@@ -805,9 +805,9 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       const [show, setS] = yield* $state(true);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        show ? createElement(Child as never, { $patch: 'live' }) : null,
+        show ? createElement(Child as never, { $patch: "live" }) : null,
       );
     }
 
@@ -815,18 +815,18 @@ describe('live-only reconcile: element add/remove during local patch', () => {
 
     const commit = capturedStartPatch!();
     setShow!(false);
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commit();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
-  it('added default element does not appear until local commit', () => {
+  it("added default element does not appear until local commit", () => {
     let setShow: ((v: boolean) => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
@@ -834,17 +834,17 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       capturedStartPatch = startPatch;
       const [show, setS] = yield* $state(false);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Child as never, {}) : null);
+      return createElement("div", null, show ? createElement(Child as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
 
     const commit = capturedStartPatch!();
     setShow!(true);
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commit();
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
   it('added $patch="live" component appears immediately during local patch', () => {
@@ -852,7 +852,7 @@ describe('live-only reconcile: element add/remove during local patch', () => {
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
@@ -861,9 +861,9 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       const [show, setS] = yield* $state(false);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        show ? createElement(Child as never, { $patch: 'live' }) : null,
+        show ? createElement(Child as never, { $patch: "live" }) : null,
       );
     }
 
@@ -871,18 +871,18 @@ describe('live-only reconcile: element add/remove during local patch', () => {
 
     const commit = capturedStartPatch!();
     setShow!(true);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commit();
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
-  it('live element added then removed during local patch: not present after commit', () => {
+  it("live element added then removed during local patch: not present after commit", () => {
     let setShow: ((v: boolean) => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
@@ -891,9 +891,9 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       const [show, setS] = yield* $state(false);
       setShow = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        show ? createElement(Child as never, { $patch: 'live' }) : null,
+        show ? createElement(Child as never, { $patch: "live" }) : null,
       );
     }
 
@@ -901,20 +901,20 @@ describe('live-only reconcile: element add/remove during local patch', () => {
 
     const commit = capturedStartPatch!();
     setShow!(true); // live-add → appears immediately
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
     setShow!(false); // live-remove → disappears immediately
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commit();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
-  it('default element added then removed during local patch: invisible throughout, absent after commit', () => {
+  it("default element added then removed during local patch: invisible throughout, absent after commit", () => {
     let setShow: ((v: boolean) => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
@@ -922,28 +922,28 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       capturedStartPatch = startPatch;
       const [show, setS] = yield* $state(false);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Child as never, {}) : null);
+      return createElement("div", null, show ? createElement(Child as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
 
     const commit = capturedStartPatch!();
     setShow!(true); // default: still not visible
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
     setShow!(false); // default: still not visible
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commit();
     // Final state: show=false → not present
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 
-  it('default element removed then re-added during local patch: visible throughout and present after commit', () => {
+  it("default element removed then re-added during local patch: visible throughout and present after commit", () => {
     let setShow: ((v: boolean) => void) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'hello');
+      return createElement("span", { id: "target" }, "hello");
     }
 
     function* Parent() {
@@ -951,19 +951,19 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       capturedStartPatch = startPatch;
       const [show, setS] = yield* $state(true);
       setShow = setS;
-      return createElement('div', null, show ? createElement(Child as never, {}) : null);
+      return createElement("div", null, show ? createElement(Child as never, {}) : null);
     }
 
     render(createElement(Parent as never, {}), container);
 
     const commit = capturedStartPatch!();
     setShow!(false); // frozen: still visible
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
     setShow!(true); // frozen: still visible
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     commit();
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
   });
 
   it('$shown with $patch="live" inside local patch scope behaves live', () => {
@@ -971,7 +971,7 @@ describe('live-only reconcile: element add/remove during local patch', () => {
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Child() {
-      return createElement('span', { id: 'target' }, 'x');
+      return createElement("span", { id: "target" }, "x");
     }
 
     function* Parent() {
@@ -980,21 +980,21 @@ describe('live-only reconcile: element add/remove during local patch', () => {
       const [shown, setS] = yield* $state(true);
       setShown = setS;
       return createElement(
-        'div',
+        "div",
         null,
-        createElement(Child as never, { $shown: shown, $patch: 'live' }),
+        createElement(Child as never, { $shown: shown, $patch: "live" }),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('#target')).not.toBeNull();
+    expect(container.querySelector("#target")).not.toBeNull();
 
     const commit = capturedStartPatch!();
     setShown!(false); // live → hides immediately
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
 
     commit();
-    expect(container.querySelector('#target')).toBeNull();
+    expect(container.querySelector("#target")).toBeNull();
   });
 });
 
@@ -1003,11 +1003,11 @@ describe('live-only reconcile: element add/remove during local patch', () => {
 // prevSlot.props = allProps bug in live-only skip path)
 // ---------------------------------------------------------------------------
 
-describe('child component prop updates apply correctly after global patch commit', () => {
+describe("child component prop updates apply correctly after global patch commit", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -1016,102 +1016,102 @@ describe('child component prop updates apply correctly after global patch commit
     commitUIPatch();
   });
 
-  it('child component reflects changed props (e.g. isPending=false) after commit', () => {
+  it("child component reflects changed props (e.g. isPending=false) after commit", () => {
     // Regression: mirrors the real demo flow where setIsPending(true) fires
     // BEFORE the patch (so the DOM shows disabled/wait), then setIsPending(false)
     // fires INSIDE the patch, and the button must be enabled after commit.
     let setPending: ((v: boolean) => Promise<void>) | null = null;
 
     function* Nav(props: { isPending: boolean }) {
-      return createElement('button', { id: 'btn', disabled: props.isPending }, 'click');
+      return createElement("button", { id: "btn", disabled: props.isPending }, "click");
     }
 
     function* App() {
       const [isPending, setP] = yield* $state(false);
       setPending = setP;
-      return createElement('div', null, createElement(Nav as never, { isPending }));
+      return createElement("div", null, createElement(Nav as never, { isPending }));
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(false);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
 
     // Set isPending=true BEFORE the patch (immediate DOM update — buttons disabled)
     setPending!(true);
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(true);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
 
     startUIPatch();
     // Inside patch, clear isPending — DOM frozen (buttons still disabled)
     setPending!(false);
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(true);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
 
     commitUIPatch();
     // After commit: isPending=false must be applied — button must be enabled
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(false);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
   });
 
-  it('child receives isPending=true during patch, then isPending=false at commit', () => {
+  it("child receives isPending=true during patch, then isPending=false at commit", () => {
     let setPending: ((v: boolean) => Promise<void>) | null = null;
     const renderLog: boolean[] = [];
 
     function* Status(props: { pending: boolean }) {
       renderLog.push(props.pending);
-      return createElement('span', { id: 'status' }, props.pending ? 'loading' : 'done');
+      return createElement("span", { id: "status" }, props.pending ? "loading" : "done");
     }
 
     function* App() {
       const [pending, setP] = yield* $state(false);
       setPending = setP;
-      return createElement('div', null, createElement(Status as never, { pending }));
+      return createElement("div", null, createElement(Status as never, { pending }));
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('#status')!.textContent).toBe('done');
+    expect(container.querySelector("#status")!.textContent).toBe("done");
     renderLog.length = 0;
 
     startUIPatch();
     setPending!(true); // App rerenders with pending=true; Status deferred
     // DOM frozen
-    expect(container.querySelector('#status')!.textContent).toBe('done');
+    expect(container.querySelector("#status")!.textContent).toBe("done");
 
     commitUIPatch();
     // After commit, Status must reflect pending=true
-    expect(container.querySelector('#status')!.textContent).toBe('loading');
+    expect(container.querySelector("#status")!.textContent).toBe("loading");
     expect(renderLog[renderLog.length - 1]).toBe(true);
   });
 
-  it('commit applies the FINAL props when child receives multiple prop changes during patch', () => {
+  it("commit applies the FINAL props when child receives multiple prop changes during patch", () => {
     let setLabel: ((v: string) => Promise<void>) | null = null;
 
     function* Label(props: { text: string }) {
-      return createElement('span', { id: 'label' }, props.text);
+      return createElement("span", { id: "label" }, props.text);
     }
 
     function* App() {
-      const [text, setText] = yield* $state('a');
+      const [text, setText] = yield* $state("a");
       setLabel = setText;
-      return createElement('div', null, createElement(Label as never, { text }));
+      return createElement("div", null, createElement(Label as never, { text }));
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('#label')!.textContent).toBe('a');
+    expect(container.querySelector("#label")!.textContent).toBe("a");
 
     startUIPatch();
-    setLabel!('b');
-    setLabel!('c');
+    setLabel!("b");
+    setLabel!("c");
     // Frozen during patch
-    expect(container.querySelector('#label')!.textContent).toBe('a');
+    expect(container.querySelector("#label")!.textContent).toBe("a");
 
     commitUIPatch();
     // Final value after commit
-    expect(container.querySelector('#label')!.textContent).toBe('c');
+    expect(container.querySelector("#label")!.textContent).toBe("c");
   });
 });
 
-describe('child component prop updates apply correctly after local patch commit', () => {
+describe("child component prop updates apply correctly after local patch commit", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -1119,14 +1119,14 @@ describe('child component prop updates apply correctly after local patch commit'
     document.body.removeChild(container);
   });
 
-  it('child reflects changed props after local commit', () => {
+  it("child reflects changed props after local commit", () => {
     // Regression: mirrors the real demo where isPending=true fires BEFORE the patch,
     // then isPending=false fires inside the patch — button must be enabled after commit.
     let setPending: ((v: boolean) => Promise<void>) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Nav(props: { isPending: boolean }) {
-      return createElement('button', { id: 'btn', disabled: props.isPending }, 'click');
+      return createElement("button", { id: "btn", disabled: props.isPending }, "click");
     }
 
     function* App() {
@@ -1134,32 +1134,32 @@ describe('child component prop updates apply correctly after local patch commit'
       capturedStartPatch = startPatch;
       const [isPending, setP] = yield* $state(false);
       setPending = setP;
-      return createElement('div', null, createElement(Nav as never, { isPending }));
+      return createElement("div", null, createElement(Nav as never, { isPending }));
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(false);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
 
     // Set isPending=true BEFORE patch (immediate DOM update)
     setPending!(true);
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(true);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
 
     const commit = capturedStartPatch!();
     // Inside patch, clear isPending — DOM frozen (still disabled)
     setPending!(false);
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(true);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
 
     commit();
     // After commit: isPending=false applied — button must be enabled
-    expect(container.querySelector('#btn')!.hasAttribute('disabled')).toBe(false);
+    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
   });
 
-  it('local patch: child isPending=true at commit time shows loading state', () => {
+  it("local patch: child isPending=true at commit time shows loading state", () => {
     let setPending: ((v: boolean) => Promise<void>) | null = null;
     let capturedStartPatch: (() => () => void) | null = null;
 
     function* Status(props: { pending: boolean }) {
-      return createElement('span', { id: 'status' }, props.pending ? 'loading' : 'done');
+      return createElement("span", { id: "status" }, props.pending ? "loading" : "done");
     }
 
     function* App() {
@@ -1167,17 +1167,17 @@ describe('child component prop updates apply correctly after local patch commit'
       capturedStartPatch = startPatch;
       const [pending, setP] = yield* $state(false);
       setPending = setP;
-      return createElement('div', null, createElement(Status as never, { pending }));
+      return createElement("div", null, createElement(Status as never, { pending }));
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector('#status')!.textContent).toBe('done');
+    expect(container.querySelector("#status")!.textContent).toBe("done");
 
     const commit = capturedStartPatch!();
     setPending!(true); // App rerenders; Status deferred
-    expect(container.querySelector('#status')!.textContent).toBe('done');
+    expect(container.querySelector("#status")!.textContent).toBe("done");
 
     commit();
-    expect(container.querySelector('#status')!.textContent).toBe('loading');
+    expect(container.querySelector("#status")!.textContent).toBe("loading");
   });
 });

--- a/src/__tests__/use-effect.test.ts
+++ b/src/__tests__/use-effect.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state, $effect } from '../hooks';
+import { $effect, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('render – $effect', () => {
+describe("render – $effect", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,21 +16,22 @@ describe('render – $effect', () => {
     document.body.removeChild(container);
   });
 
-  it('runs effect after initial mount', () => {
+  it("runs effect after initial mount", () => {
     const calls: string[] = [];
 
     function* Comp() {
       yield* $effect(() => {
-        calls.push('effect');
+        calls.push("effect");
+        return undefined;
       }, []);
-      return createElement('span', {}, 'hi');
+      return createElement("span", {}, "hi");
     }
 
     render(createElement(Comp as never, {}), container);
-    expect(calls).toEqual(['effect']);
+    expect(calls).toEqual(["effect"]);
   });
 
-  it('does not re-run effect when deps are unchanged', () => {
+  it("does not re-run effect when deps are unchanged", () => {
     const calls: string[] = [];
     let setCount: ((v: number) => void) | null = null;
 
@@ -38,20 +39,21 @@ describe('render – $effect', () => {
       const [count, sc] = yield* $state(0);
       setCount = sc;
       yield* $effect(() => {
-        calls.push('effect');
+        calls.push("effect");
+        return undefined;
       }, []); // empty deps — should only run once
-      return createElement('span', {}, String(count));
+      return createElement("span", {}, String(count));
     }
 
     render(createElement(Comp as never, {}), container);
-    expect(calls).toEqual(['effect']);
+    expect(calls).toEqual(["effect"]);
 
     setCount!(1);
     setCount!(2);
-    expect(calls).toEqual(['effect']); // still only once
+    expect(calls).toEqual(["effect"]); // still only once
   });
 
-  it('re-runs effect and calls previous cleanup when deps change', () => {
+  it("re-runs effect and calls previous cleanup when deps change", () => {
     const log: string[] = [];
     let setId: ((v: number) => void) | null = null;
 
@@ -62,29 +64,29 @@ describe('render – $effect', () => {
         log.push(`effect:${id}`);
         return () => log.push(`cleanup:${id}`);
       }, [id]);
-      return createElement('span', {}, String(id));
+      return createElement("span", {}, String(id));
     }
 
     render(createElement(Comp as never, {}), container);
-    expect(log).toEqual(['effect:1']);
+    expect(log).toEqual(["effect:1"]);
 
     setId!(2);
-    expect(log).toEqual(['effect:1', 'cleanup:1', 'effect:2']);
+    expect(log).toEqual(["effect:1", "cleanup:1", "effect:2"]);
 
     setId!(3);
-    expect(log).toEqual(['effect:1', 'cleanup:1', 'effect:2', 'cleanup:2', 'effect:3']);
+    expect(log).toEqual(["effect:1", "cleanup:1", "effect:2", "cleanup:2", "effect:3"]);
   });
 
-  it('calls cleanup on unmount', () => {
+  it("calls cleanup on unmount", () => {
     const log: string[] = [];
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Inner() {
       yield* $effect(() => {
-        log.push('mount');
-        return () => log.push('unmount');
+        log.push("mount");
+        return () => log.push("unmount");
       }, []);
-      return createElement('span', {}, 'inner');
+      return createElement("span", {}, "inner");
     }
 
     function* Outer() {
@@ -94,27 +96,28 @@ describe('render – $effect', () => {
     }
 
     render(createElement(Outer as never, {}), container);
-    expect(log).toEqual(['mount']);
+    expect(log).toEqual(["mount"]);
 
     setShow!(false);
-    expect(log).toEqual(['mount', 'unmount']);
+    expect(log).toEqual(["mount", "unmount"]);
   });
 
-  it('does not run effect while generator is paused in $render', () => {
+  it("does not run effect while generator is paused in $render", () => {
     const log: string[] = [];
 
     function* Comp() {
       yield* $effect(() => {
-        log.push('effect');
+        log.push("effect");
+        return undefined;
       }, []);
       const answer = yield* (function* (): Generator<unknown, string, unknown> {
         // Inline $render-like pause: yield a VNode to pause the generator
         const caps = (yield {
-          type: Symbol.for('yielderact.useRender.test'),
+          type: Symbol.for("yielderact.useRender.test"),
         }) as null;
         return caps as unknown as string;
       })();
-      return createElement('span', {}, answer);
+      return createElement("span", {}, answer);
     }
 
     // We cannot easily test $render interaction without full plumbing,
@@ -123,24 +126,26 @@ describe('render – $effect', () => {
     // Just verify effect ran after a full render cycle.
     function* Simple() {
       yield* $effect(() => {
-        log.push('ran');
+        log.push("ran");
+        return undefined;
       }, []);
-      return createElement('span', {}, 'ok');
+      return createElement("span", {}, "ok");
     }
 
     render(createElement(Simple as never, {}), container);
-    expect(log).toEqual(['ran']);
+    expect(log).toEqual(["ran"]);
     void Comp; // silence unused warning
   });
 
-  it('passes an AbortSignal to the effect callback', () => {
+  it("passes an AbortSignal to the effect callback", () => {
     let receivedSignal: AbortSignal | null = null;
 
     function* Comp() {
       yield* $effect((signal) => {
         receivedSignal = signal;
+        return undefined;
       }, []);
-      return createElement('span', {}, 'hi');
+      return createElement("span", {}, "hi");
     }
 
     render(createElement(Comp as never, {}), container);
@@ -148,7 +153,7 @@ describe('render – $effect', () => {
     expect((receivedSignal as unknown as AbortSignal).aborted).toBe(false);
   });
 
-  it('aborts the signal when deps change', () => {
+  it("aborts the signal when deps change", () => {
     const signals: AbortSignal[] = [];
     let setId: ((v: number) => void) | null = null;
 
@@ -158,32 +163,34 @@ describe('render – $effect', () => {
       yield* $effect(
         (signal) => {
           signals.push(signal);
+          return undefined;
         },
         [id],
       );
-      return createElement('span', {}, String(id));
+      return createElement("span", {}, String(id));
     }
 
     render(createElement(Comp as never, {}), container);
     expect(signals).toHaveLength(1);
-    expect(signals[0].aborted).toBe(false);
+    expect(signals[0]!.aborted).toBe(false);
 
     setId!(2);
     // The first signal should now be aborted.
-    expect(signals[0].aborted).toBe(true);
+    expect(signals[0]!.aborted).toBe(true);
     expect(signals).toHaveLength(2);
-    expect(signals[1].aborted).toBe(false);
+    expect(signals[1]!.aborted).toBe(false);
   });
 
-  it('aborts the signal on unmount', () => {
+  it("aborts the signal on unmount", () => {
     let capturedSignal: AbortSignal | null = null;
     let setShow: ((v: boolean) => void) | null = null;
 
     function* Inner() {
       yield* $effect((signal) => {
         capturedSignal = signal;
+        return undefined;
       }, []);
-      return createElement('span', {}, 'inner');
+      return createElement("span", {}, "inner");
     }
 
     function* Outer() {
@@ -200,7 +207,7 @@ describe('render – $effect', () => {
     expect((capturedSignal as unknown as AbortSignal).aborted).toBe(true);
   });
 
-  it('aborts the signal before calling the cleanup function', () => {
+  it("aborts the signal before calling the cleanup function", () => {
     const log: string[] = [];
     let setId: ((v: number) => void) | null = null;
 
@@ -215,11 +222,11 @@ describe('render – $effect', () => {
         },
         [id],
       );
-      return createElement('span', {}, String(id));
+      return createElement("span", {}, String(id));
     }
 
     render(createElement(Comp as never, {}), container);
     setId!(2);
-    expect(log).toEqual(['cleanup:1:aborted=true']);
+    expect(log).toEqual(["cleanup:1:aborted=true"]);
   });
 });

--- a/src/__tests__/use-id.test.ts
+++ b/src/__tests__/use-id.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state, $id } from '../hooks';
+import { $id, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('$id', () => {
+describe("$id", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,20 +16,20 @@ describe('$id', () => {
     document.body.removeChild(container);
   });
 
-  it('returns a non-empty string', () => {
+  it("returns a non-empty string", () => {
     let capturedId: string | null = null;
 
     function* Comp() {
       capturedId = yield* $id();
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
-    expect(typeof capturedId).toBe('string');
+    expect(typeof capturedId).toBe("string");
     expect(capturedId!.length).toBeGreaterThan(0);
   });
 
-  it('returns the same id across re-renders', () => {
+  it("returns the same id across re-renders", () => {
     const ids: string[] = [];
     let setValue: ((v: number) => void) | null = null;
 
@@ -38,7 +38,7 @@ describe('$id', () => {
       setValue = sv;
       const id = yield* $id();
       ids.push(id);
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -48,14 +48,14 @@ describe('$id', () => {
     expect(ids[0]).toBe(ids[1]);
   });
 
-  it('returns distinct ids for different hook call sites', () => {
+  it("returns distinct ids for different hook call sites", () => {
     let id1: string | null = null;
     let id2: string | null = null;
 
     function* Comp() {
       id1 = yield* $id();
       id2 = yield* $id();
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);

--- a/src/__tests__/use-memo.test.ts
+++ b/src/__tests__/use-memo.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state, $memo } from '../hooks';
+import { $memo, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('$memo', () => {
+describe("$memo", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,13 +16,13 @@ describe('$memo', () => {
     document.body.removeChild(container);
   });
 
-  it('computes the initial value by calling fn with deps', () => {
+  it("computes the initial value by calling fn with deps", () => {
     const factory = jest.fn((a: number, b: number) => a + b);
     let capturedValue: number | null = null;
 
     function* Comp() {
       capturedValue = yield* $memo(factory, [2, 3]);
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -31,7 +31,7 @@ describe('$memo', () => {
     expect(capturedValue).toBe(5);
   });
 
-  it('does not recompute when deps are the same', () => {
+  it("does not recompute when deps are the same", () => {
     const factory = jest.fn((a: number) => a * 2);
     let setValue: ((v: number) => void) | null = null;
 
@@ -39,7 +39,7 @@ describe('$memo', () => {
       const [v, sv] = yield* $state(10);
       setValue = sv;
       yield* $memo(factory, [5]);
-      return createElement('div', null, String(v));
+      return createElement("div", null, String(v));
     }
 
     render(createElement(Comp as never, {}), container);
@@ -48,7 +48,7 @@ describe('$memo', () => {
     expect(factory).toHaveBeenCalledTimes(1);
   });
 
-  it('recomputes when deps change', () => {
+  it("recomputes when deps change", () => {
     const factory = jest.fn((a: number) => a * 2);
     let setValue: ((v: number) => void) | null = null;
     let capturedValue: number | null = null;
@@ -57,7 +57,7 @@ describe('$memo', () => {
       const [v, sv] = yield* $state(1);
       setValue = sv;
       capturedValue = yield* $memo(factory, [v]);
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -70,7 +70,7 @@ describe('$memo', () => {
     expect(factory).toHaveBeenLastCalledWith(3);
   });
 
-  it('works with empty deps (zero-arg factory)', () => {
+  it("works with empty deps (zero-arg factory)", () => {
     const factory = jest.fn(() => 42);
     let setValue: ((v: number) => void) | null = null;
     let capturedValue: number | null = null;
@@ -79,7 +79,7 @@ describe('$memo', () => {
       const [, sv] = yield* $state(0);
       setValue = sv;
       capturedValue = yield* $memo(factory, []);
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);

--- a/src/__tests__/use-ref.test.ts
+++ b/src/__tests__/use-ref.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state, $ref } from '../hooks';
+import { $ref, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('$ref', () => {
+describe("$ref", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,13 +16,13 @@ describe('$ref', () => {
     document.body.removeChild(container);
   });
 
-  it('returns an object with the initial value in .current', () => {
+  it("returns an object with the initial value in .current", () => {
     let capturedRef: { current: number } | null = null;
 
     function* Comp() {
       const ref = yield* $ref(42);
       capturedRef = ref;
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -30,7 +30,7 @@ describe('$ref', () => {
     expect(capturedRef!.current).toBe(42);
   });
 
-  it('persists the same object across re-renders', () => {
+  it("persists the same object across re-renders", () => {
     const refInstances: object[] = [];
     let setValue: ((v: number) => void) | null = null;
 
@@ -39,7 +39,7 @@ describe('$ref', () => {
       setValue = sv;
       const ref = yield* $ref(0);
       refInstances.push(ref);
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -49,7 +49,7 @@ describe('$ref', () => {
     expect(refInstances[0]).toBe(refInstances[1]);
   });
 
-  it('mutations to .current do not trigger a re-render', () => {
+  it("mutations to .current do not trigger a re-render", () => {
     let renderCount = 0;
     let capturedRef: { current: number } | null = null;
 
@@ -57,7 +57,7 @@ describe('$ref', () => {
       renderCount++;
       const ref = yield* $ref(0);
       capturedRef = ref;
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);

--- a/src/__tests__/use-render.test.ts
+++ b/src/__tests__/use-render.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state, $render, $resume } from '../hooks';
+import { $render, $resume, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('$render (Variant 2 – inline function)', () => {
+describe("$render (Variant 2 – inline function)", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,33 +16,33 @@ describe('$render (Variant 2 – inline function)', () => {
     document.body.removeChild(container);
   });
 
-  it('yields JSX while waiting and returns the value passed to resume', () => {
+  it("yields JSX while waiting and returns the value passed to resume", () => {
     let capturedResume: ((v: string) => void) | null = null;
     let finalText: string | null = null;
 
     function* Comp() {
       const answer = yield* $render<string>(({ resume }) => {
         capturedResume = resume;
-        return createElement('span', null, 'waiting');
+        return createElement("span", null, "waiting");
       }, []);
       finalText = answer;
-      return createElement('p', null, answer);
+      return createElement("p", null, answer);
     }
 
     render(createElement(Comp as never, {}), container);
 
     // While waiting the dialog is shown
-    expect(container.querySelector('span')?.textContent).toBe('waiting');
+    expect(container.querySelector("span")?.textContent).toBe("waiting");
     expect(finalText).toBeNull();
 
     // Resolving unblocks the generator
-    capturedResume!('DONE');
+    capturedResume!("DONE");
 
-    expect(container.querySelector('p')?.textContent).toBe('DONE');
-    expect(finalText).toBe('DONE');
+    expect(container.querySelector("p")?.textContent).toBe("DONE");
+    expect(finalText).toBe("DONE");
   });
 
-  it('resume is idempotent – calling it twice only resolves once', () => {
+  it("resume is idempotent – calling it twice only resolves once", () => {
     let capturedResume: ((v: number) => void) | null = null;
     let resolveCount = 0;
     let finalValue: number | null = null;
@@ -50,11 +50,11 @@ describe('$render (Variant 2 – inline function)', () => {
     function* Comp() {
       const v = yield* $render<number>(({ resume }) => {
         capturedResume = resume;
-        return createElement('span', null);
+        return createElement("span", null);
       }, []);
       resolveCount++;
       finalValue = v;
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -65,7 +65,7 @@ describe('$render (Variant 2 – inline function)', () => {
     expect(finalValue).toBe(1);
   });
 
-  it('resets to waiting on parent rerender while waiting', () => {
+  it("resets to waiting on parent rerender while waiting", () => {
     let capturedResume: ((v: boolean) => void) | null = null;
     let setVal: ((v: number) => void) | null = null;
     let renderCount = 0;
@@ -76,9 +76,9 @@ describe('$render (Variant 2 – inline function)', () => {
       yield* $render<boolean>(({ resume }) => {
         renderCount++;
         capturedResume = resume;
-        return createElement('span', null);
+        return createElement("span", null);
       }, []);
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -90,10 +90,10 @@ describe('$render (Variant 2 – inline function)', () => {
 
     // The generator is still waiting – resolve it now
     capturedResume!(true);
-    expect(container.querySelector('div')).not.toBeNull();
+    expect(container.querySelector("div")).not.toBeNull();
   });
 
-  it('deps change resets the interaction', () => {
+  it("deps change resets the interaction", () => {
     let setDep: ((v: number) => void) | null = null;
     let capturedResume: ((v: string) => void) | null = null;
     let resolveCount = 0;
@@ -104,34 +104,34 @@ describe('$render (Variant 2 – inline function)', () => {
       yield* $render<string>(
         ({ resume }) => {
           capturedResume = resume;
-          return createElement('span', null, String(dep));
+          return createElement("span", null, String(dep));
         },
         [dep],
       );
       resolveCount++;
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
 
     // Resolve first interaction
-    capturedResume!('first');
+    capturedResume!("first");
     expect(resolveCount).toBe(1);
 
     // Change dep → should reset and show dialog again
     setDep!(1);
-    expect(container.querySelector('span')).not.toBeNull();
+    expect(container.querySelector("span")).not.toBeNull();
 
-    capturedResume!('second');
+    capturedResume!("second");
     expect(resolveCount).toBe(2);
   });
 });
 
-describe('$render (Variant 1 – JSX child with $resume)', () => {
+describe("$render (Variant 1 – JSX child with $resume)", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -139,34 +139,34 @@ describe('$render (Variant 1 – JSX child with $resume)', () => {
     document.body.removeChild(container);
   });
 
-  it('child component receives resume via $resume and can resolve the parent', () => {
+  it("child component receives resume via $resume and can resolve the parent", () => {
     let capturedResume: ((v: string) => void) | null = null;
     let finalAnswer: string | null = null;
 
     function* Dialog() {
       const resume = yield* $resume<string>();
       capturedResume = resume;
-      return createElement('span', null, 'dialog');
+      return createElement("span", null, "dialog");
     }
 
     function* Parent() {
       const answer = yield* $render<string>(createElement(Dialog as never, {}));
       finalAnswer = answer;
-      return createElement('p', null, answer);
+      return createElement("p", null, answer);
     }
 
     render(createElement(Parent as never, {}), container);
 
-    expect(container.querySelector('span')?.textContent).toBe('dialog');
+    expect(container.querySelector("span")?.textContent).toBe("dialog");
     expect(finalAnswer).toBeNull();
 
-    capturedResume!('ACCEPTED');
+    capturedResume!("ACCEPTED");
 
-    expect(container.querySelector('p')?.textContent).toBe('ACCEPTED');
-    expect(finalAnswer).toBe('ACCEPTED');
+    expect(container.querySelector("p")?.textContent).toBe("ACCEPTED");
+    expect(finalAnswer).toBe("ACCEPTED");
   });
 
-  it('does not remount the child when the parent rerenders while waiting', () => {
+  it("does not remount the child when the parent rerenders while waiting", () => {
     let mountCount = 0;
     let capturedResume: ((v: string) => void) | null = null;
     let setVal: ((v: number) => void) | null = null;
@@ -175,14 +175,14 @@ describe('$render (Variant 1 – JSX child with $resume)', () => {
       mountCount++;
       const resume = yield* $resume<string>();
       capturedResume = resume;
-      return createElement('span', null, 'dialog');
+      return createElement("span", null, "dialog");
     }
 
     function* Parent() {
       const [, sv] = yield* $state(0);
       setVal = sv;
       yield* $render<string>(createElement(Dialog as never, {}));
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Parent as never, {}), container);
@@ -193,16 +193,16 @@ describe('$render (Variant 1 – JSX child with $resume)', () => {
     expect(mountCount).toBe(1); // Dialog must NOT remount
 
     // Resolve still works after the rerender
-    capturedResume!('OK');
-    expect(container.querySelector('div')).not.toBeNull();
+    capturedResume!("OK");
+    expect(container.querySelector("div")).not.toBeNull();
   });
 });
 
-describe('$resume', () => {
+describe("$resume", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -210,14 +210,14 @@ describe('$resume', () => {
     document.body.removeChild(container);
   });
 
-  it('throws when called outside a $render context', () => {
+  it("throws when called outside a $render context", () => {
     function* Comp() {
       yield* $resume();
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     expect(() => render(createElement(Comp as never, {}), container)).toThrow(
-      '$resume must be called inside a component rendered by $render',
+      "$resume must be called inside a component rendered by $render",
     );
   });
 });

--- a/src/__tests__/use-resolve.test.ts
+++ b/src/__tests__/use-resolve.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state, $resolve, $resolveRaw, $memo } from '../hooks';
+import { $memo, $resolve, $resolveRaw, $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('render – generator components with $resolve', () => {
+describe("render – generator components with $resolve", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,7 +16,7 @@ describe('render – generator components with $resolve', () => {
     document.body.removeChild(container);
   });
 
-  it('shows loading state while promise is pending', async () => {
+  it("shows loading state while promise is pending", async () => {
     let resolvePromise!: (data: string) => void;
     const promise = new Promise<string>((res) => {
       resolvePromise = res;
@@ -26,27 +26,27 @@ describe('render – generator components with $resolve', () => {
       const data = yield* $resolve(
         {
           fn: (_signal) => promise,
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', { id: 'error' }, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", { id: "error" }, "Error"),
         },
         [],
       );
-      return createElement('span', { id: 'data' }, data);
+      return createElement("span", { id: "data" }, data);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
-    expect(container.querySelector('#data')).toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
+    expect(container.querySelector("#data")).toBeNull();
 
-    resolvePromise('Hello World');
+    resolvePromise("Hello World");
     await promise;
 
-    expect(container.querySelector('#loading')).toBeNull();
-    expect(container.querySelector('#data')).not.toBeNull();
-    expect(container.querySelector('#data')!.textContent).toBe('Hello World');
+    expect(container.querySelector("#loading")).toBeNull();
+    expect(container.querySelector("#data")).not.toBeNull();
+    expect(container.querySelector("#data")!.textContent).toBe("Hello World");
   });
 
-  it('shows error state when promise rejects', async () => {
+  it("shows error state when promise rejects", async () => {
     let rejectPromise!: (reason: unknown) => void;
     const promise = new Promise<string>((_res, rej) => {
       rejectPromise = rej;
@@ -56,25 +56,25 @@ describe('render – generator components with $resolve', () => {
       const data = yield* $resolve(
         {
           fn: (_signal) => promise,
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', { id: 'error' }, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", { id: "error" }, "Error"),
         },
         [],
       );
-      return createElement('span', { id: 'data' }, data);
+      return createElement("span", { id: "data" }, data);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    rejectPromise(new Error('network error'));
+    rejectPromise(new Error("network error"));
     await promise.catch(() => {}); // wait for rejection to propagate
 
-    expect(container.querySelector('#error')).not.toBeNull();
-    expect(container.querySelector('#data')).toBeNull();
+    expect(container.querySelector("#error")).not.toBeNull();
+    expect(container.querySelector("#data")).toBeNull();
   });
 
-  it('$resolve can coexist with $state in the same component', async () => {
+  it("$resolve can coexist with $state in the same component", async () => {
     let resolvePromise!: (data: string) => void;
     const promise = new Promise<string>((res) => {
       resolvePromise = res;
@@ -82,32 +82,32 @@ describe('render – generator components with $resolve', () => {
     let setLabel: ((v: string) => void) | null = null;
 
     function* DataComp() {
-      const [label, sl] = yield* $state('prefix');
+      const [label, sl] = yield* $state("prefix");
       setLabel = sl;
       const data = yield* $resolve(
         {
           fn: (_signal) => promise,
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', null, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", null, "Error"),
         },
         [],
       );
-      return createElement('p', { id: 'result' }, `${label}:${data}`);
+      return createElement("p", { id: "result" }, `${label}:${data}`);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    resolvePromise('world');
+    resolvePromise("world");
     await promise;
 
-    expect(container.querySelector('#result')!.textContent).toBe('prefix:world');
+    expect(container.querySelector("#result")!.textContent).toBe("prefix:world");
 
-    setLabel!('updated');
-    expect(container.querySelector('#result')!.textContent).toBe('updated:world');
+    setLabel!("updated");
+    expect(container.querySelector("#result")!.textContent).toBe("updated:world");
   });
 
-  it('$state change while promise is pending triggers fresh run and shows correct state after resolve', async () => {
+  it("$state change while promise is pending triggers fresh run and shows correct state after resolve", async () => {
     let resolvePromise!: (data: string) => void;
     const promise = new Promise<string>((res) => {
       resolvePromise = res;
@@ -115,35 +115,35 @@ describe('render – generator components with $resolve', () => {
     let setLabel: ((v: string) => void) | null = null;
 
     function* DataComp() {
-      const [label, sl] = yield* $state('prefix');
+      const [label, sl] = yield* $state("prefix");
       setLabel = sl;
       const data = yield* $resolve(
         {
           fn: (_signal) => promise,
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', null, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", null, "Error"),
         },
         [],
       );
-      return createElement('p', { id: 'result' }, `${label}:${data}`);
+      return createElement("p", { id: "result" }, `${label}:${data}`);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
     // Change state WHILE the promise is still pending
-    setLabel!('updated');
+    setLabel!("updated");
     // Still loading, but label should be reflected after resolve
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    resolvePromise('world');
+    resolvePromise("world");
     await promise;
 
     // The fresh run after setLabel captured 'updated'; resume uses that generator
-    expect(container.querySelector('#result')!.textContent).toBe('updated:world');
+    expect(container.querySelector("#result")!.textContent).toBe("updated:world");
   });
 
-  it('$resolve re-runs when deps change', async () => {
+  it("$resolve re-runs when deps change", async () => {
     let resolveFirst!: (data: string) => void;
     let resolveSecond!: (data: string) => void;
     const firstPromise = new Promise<string>((res) => {
@@ -165,33 +165,33 @@ describe('render – generator components with $resolve', () => {
             fetchCount++;
             return id === 1 ? firstPromise : secondPromise;
           },
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', null, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", null, "Error"),
         },
         [id],
       );
-      return createElement('p', { id: 'result' }, `${id}:${data}`);
+      return createElement("p", { id: "result" }, `${id}:${data}`);
     }
 
     render(createElement(DataComp as never, {}), container);
     expect(fetchCount).toBe(1);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    resolveFirst('user1');
+    resolveFirst("user1");
     await firstPromise;
-    expect(container.querySelector('#result')!.textContent).toBe('1:user1');
+    expect(container.querySelector("#result")!.textContent).toBe("1:user1");
 
     // Change the dep – should re-run the promise
     setId!(2);
     expect(fetchCount).toBe(2);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    resolveSecond('user2');
+    resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector('#result')!.textContent).toBe('2:user2');
+    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
   });
 
-  it('stale promise result is ignored when deps change before it resolves', async () => {
+  it("stale promise result is ignored when deps change before it resolves", async () => {
     let resolveFirst!: (data: string) => void;
     let resolveSecond!: (data: string) => void;
     const firstPromise = new Promise<string>((res) => {
@@ -209,33 +209,33 @@ describe('render – generator components with $resolve', () => {
       const data = yield* $resolve(
         {
           fn: (_signal) => (id === 1 ? firstPromise : secondPromise),
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', null, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", null, "Error"),
         },
         [id],
       );
-      return createElement('p', { id: 'result' }, `${id}:${data}`);
+      return createElement("p", { id: "result" }, `${id}:${data}`);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
     // Change dep before first promise resolves
     setId!(2);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
     // Resolve second promise first
-    resolveSecond('user2');
+    resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector('#result')!.textContent).toBe('2:user2');
+    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
 
     // Now resolve the stale first promise – should NOT update the DOM
-    resolveFirst('user1');
+    resolveFirst("user1");
     await firstPromise;
-    expect(container.querySelector('#result')!.textContent).toBe('2:user2');
+    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
   });
 
-  it('aborts the previous AbortSignal when deps change', async () => {
+  it("aborts the previous AbortSignal when deps change", async () => {
     const abortedSignals: AbortSignal[] = [];
     let setId: ((v: number) => void) | null = null;
 
@@ -245,15 +245,15 @@ describe('render – generator components with $resolve', () => {
       yield* $resolve(
         {
           fn: (signal) => {
-            signal.addEventListener('abort', () => abortedSignals.push(signal));
+            signal.addEventListener("abort", () => abortedSignals.push(signal));
             return new Promise(() => {}); // never resolves
           },
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', null, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", null, "Error"),
         },
         [id],
       );
-      return createElement('span', {}, 'done');
+      return createElement("span", {}, "done");
     }
 
     render(createElement(DataComp as never, {}), container);
@@ -262,10 +262,10 @@ describe('render – generator components with $resolve', () => {
     // Changing deps should abort the first signal and start a new fetch.
     setId!(2);
     expect(abortedSignals).toHaveLength(1);
-    expect(abortedSignals[0].aborted).toBe(true);
+    expect(abortedSignals[0]!.aborted).toBe(true);
   });
 
-  it('aborts the AbortSignal when the component unmounts', async () => {
+  it("aborts the AbortSignal when the component unmounts", async () => {
     let capturedSignal: AbortSignal | null = null;
     let setShow: ((v: boolean) => void) | null = null;
 
@@ -276,12 +276,12 @@ describe('render – generator components with $resolve', () => {
             capturedSignal = signal;
             return new Promise(() => {}); // never resolves
           },
-          loading: createElement('span', { id: 'loading' }, 'Loading…'),
-          error: createElement('span', null, 'Error'),
+          loading: createElement("span", { id: "loading" }, "Loading…"),
+          error: createElement("span", null, "Error"),
         },
         [],
       );
-      return createElement('span', {}, 'done');
+      return createElement("span", {}, "done");
     }
 
     function* Outer() {
@@ -300,11 +300,11 @@ describe('render – generator components with $resolve', () => {
   });
 });
 
-describe('render – generator components with $resolveRaw', () => {
+describe("render – generator components with $resolveRaw", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -312,7 +312,7 @@ describe('render – generator components with $resolveRaw', () => {
     document.body.removeChild(container);
   });
 
-  it('renders loading state while promise is pending', async () => {
+  it("renders loading state while promise is pending", async () => {
     let resolvePromise!: (data: string) => void;
     const promise = new Promise<string>((res) => {
       resolvePromise = res;
@@ -321,23 +321,23 @@ describe('render – generator components with $resolveRaw', () => {
     function* DataComp() {
       const p = yield* $memo(() => promise, []);
       const { data, loading } = yield* $resolveRaw<string>(p);
-      if (loading) return createElement('span', { id: 'loading' }, 'Loading…');
-      return createElement('span', { id: 'data' }, data);
+      if (loading) return createElement("span", { id: "loading" }, "Loading…");
+      return createElement("span", { id: "data" }, data);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
-    expect(container.querySelector('#data')).toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
+    expect(container.querySelector("#data")).toBeNull();
 
-    resolvePromise('Hello');
+    resolvePromise("Hello");
     await promise;
 
-    expect(container.querySelector('#loading')).toBeNull();
-    expect(container.querySelector('#data')).not.toBeNull();
-    expect(container.querySelector('#data')!.textContent).toBe('Hello');
+    expect(container.querySelector("#loading")).toBeNull();
+    expect(container.querySelector("#data")).not.toBeNull();
+    expect(container.querySelector("#data")!.textContent).toBe("Hello");
   });
 
-  it('renders error state when promise rejects', async () => {
+  it("renders error state when promise rejects", async () => {
     let rejectPromise!: (reason: unknown) => void;
     const promise = new Promise<string>((_res, rej) => {
       rejectPromise = rej;
@@ -346,23 +346,23 @@ describe('render – generator components with $resolveRaw', () => {
     function* DataComp() {
       const p = yield* $memo(() => promise, []);
       const { data, loading, error } = yield* $resolveRaw<string, Error>(p);
-      if (loading) return createElement('span', { id: 'loading' }, 'Loading…');
-      if (error) return createElement('span', { id: 'error' }, error.message);
-      return createElement('span', { id: 'data' }, data);
+      if (loading) return createElement("span", { id: "loading" }, "Loading…");
+      if (error) return createElement("span", { id: "error" }, error.message);
+      return createElement("span", { id: "data" }, data);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    rejectPromise(new Error('network error'));
+    rejectPromise(new Error("network error"));
     await promise.catch(() => {});
 
-    expect(container.querySelector('#error')).not.toBeNull();
-    expect(container.querySelector('#error')!.textContent).toBe('network error');
-    expect(container.querySelector('#data')).toBeNull();
+    expect(container.querySelector("#error")).not.toBeNull();
+    expect(container.querySelector("#error")!.textContent).toBe("network error");
+    expect(container.querySelector("#data")).toBeNull();
   });
 
-  it('re-fetches when the promise reference changes', async () => {
+  it("re-fetches when the promise reference changes", async () => {
     let resolveFirst!: (data: string) => void;
     let resolveSecond!: (data: string) => void;
     const firstPromise = new Promise<string>((res) => {
@@ -378,26 +378,26 @@ describe('render – generator components with $resolveRaw', () => {
       setId = si;
       const p = yield* $memo(() => (id === 1 ? firstPromise : secondPromise), [id]);
       const { data, loading } = yield* $resolveRaw<string>(p);
-      if (loading) return createElement('span', { id: 'loading' }, 'Loading…');
-      return createElement('p', { id: 'result' }, `${id}:${data}`);
+      if (loading) return createElement("span", { id: "loading" }, "Loading…");
+      return createElement("p", { id: "result" }, `${id}:${data}`);
     }
 
     render(createElement(DataComp as never, {}), container);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    resolveFirst('user1');
+    resolveFirst("user1");
     await firstPromise;
-    expect(container.querySelector('#result')!.textContent).toBe('1:user1');
+    expect(container.querySelector("#result")!.textContent).toBe("1:user1");
 
     setId!(2);
-    expect(container.querySelector('#loading')).not.toBeNull();
+    expect(container.querySelector("#loading")).not.toBeNull();
 
-    resolveSecond('user2');
+    resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector('#result')!.textContent).toBe('2:user2');
+    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
   });
 
-  it('ignores stale promise result when promise reference changes', async () => {
+  it("ignores stale promise result when promise reference changes", async () => {
     let resolveFirst!: (data: string) => void;
     let resolveSecond!: (data: string) => void;
     const firstPromise = new Promise<string>((res) => {
@@ -413,21 +413,21 @@ describe('render – generator components with $resolveRaw', () => {
       setId = si;
       const p = yield* $memo(() => (id === 1 ? firstPromise : secondPromise), [id]);
       const { data, loading } = yield* $resolveRaw<string>(p);
-      if (loading) return createElement('span', { id: 'loading' }, 'Loading…');
-      return createElement('p', { id: 'result' }, `${id}:${data}`);
+      if (loading) return createElement("span", { id: "loading" }, "Loading…");
+      return createElement("p", { id: "result" }, `${id}:${data}`);
     }
 
     render(createElement(DataComp as never, {}), container);
 
     setId!(2);
 
-    resolveSecond('user2');
+    resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector('#result')!.textContent).toBe('2:user2');
+    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
 
-    resolveFirst('user1');
+    resolveFirst("user1");
     await firstPromise;
     // Stale result must not overwrite the current render
-    expect(container.querySelector('#result')!.textContent).toBe('2:user2');
+    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
   });
 });

--- a/src/__tests__/use-state.test.ts
+++ b/src/__tests__/use-state.test.ts
@@ -1,14 +1,14 @@
-import { createElement } from '../jsx';
-import { render } from '../render';
-import { $state } from '../hooks';
+import { $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
 
 // jsdom is provided by jest-environment-jsdom (see jest.config.js)
 
-describe('$state', () => {
+describe("$state", () => {
   let container: HTMLElement;
 
   beforeEach(() => {
-    container = document.createElement('div');
+    container = document.createElement("div");
     document.body.appendChild(container);
   });
 
@@ -16,7 +16,7 @@ describe('$state', () => {
     document.body.removeChild(container);
   });
 
-  it('accepts a lazy initializer function called only once', () => {
+  it("accepts a lazy initializer function called only once", () => {
     const init = jest.fn(() => 42);
     let capturedValue: number | null = null;
     let setValue: ((v: number) => void) | null = null;
@@ -25,7 +25,7 @@ describe('$state', () => {
       const [v, sv] = yield* $state(init);
       capturedValue = v;
       setValue = sv;
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);
@@ -38,7 +38,7 @@ describe('$state', () => {
     expect(capturedValue).toBe(99);
   });
 
-  it('accepts a functional updater that receives the previous state', () => {
+  it("accepts a functional updater that receives the previous state", () => {
     const values: number[] = [];
     let setValue: ((v: number | ((prev: number) => number)) => void) | null = null;
 
@@ -46,7 +46,7 @@ describe('$state', () => {
       const [v, sv] = yield* $state(0);
       values.push(v);
       setValue = sv;
-      return createElement('div', null);
+      return createElement("div", null);
     }
 
     render(createElement(Comp as never, {}), container);

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
-import { createElement, Fragment, type Child, type VNode } from './jsx';
-import { depsChanged, type HookContext } from './hooks/symbols';
+import { depsChanged, type HookContext } from "./hooks/symbols";
+import { type Child, createElement, Fragment, type VNode } from "./jsx";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -18,7 +18,7 @@ export interface Context<T> {
 // Internal symbols used to tag Provider functions
 // ---------------------------------------------------------------------------
 
-const PROVIDER_CTX = Symbol('providerCtx');
+const PROVIDER_CTX = Symbol("providerCtx");
 
 /**
  * Hook descriptor type for `useContext`. Yielded by the `useContext` generator
@@ -26,7 +26,7 @@ const PROVIDER_CTX = Symbol('providerCtx');
  *
  * @internal
  */
-export const $CONTEXT = Symbol('$context');
+export const $CONTEXT = Symbol("$context");
 
 // ---------------------------------------------------------------------------
 // Internal descriptor type for useContext (carries optional selector/transform)
@@ -79,7 +79,7 @@ export function createContext<T>(defaultValue: T): Context<T> {
 
   const ctx: Context<T> = {
     _defaultValue: defaultValue,
-    Provider: ContextProvider as Context<T>['Provider'],
+    Provider: ContextProvider as Context<T>["Provider"],
   };
 
   // Tag the provider function so the renderer can identify it and which
@@ -170,10 +170,10 @@ export type UseContextState = {
 /** @internal */
 export function _processContext(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, instance } = ctx;
-  const context = descriptor['ctx'] as Context<unknown>;
+  const context = descriptor["ctx"] as Context<unknown>;
   instance.consumedContexts.add(context);
-  const selector = descriptor['selector'] as ((c: unknown) => unknown[]) | undefined;
-  const transform = descriptor['transform'] as ((...args: unknown[]) => unknown) | undefined;
+  const selector = descriptor["selector"] as ((c: unknown) => unknown[]) | undefined;
+  const transform = descriptor["transform"] as ((...args: unknown[]) => unknown) | undefined;
   const ctxMap = _ctxMap;
   const rawValue = ctxMap.has(context) ? ctxMap.get(context) : context._defaultValue;
 
@@ -250,8 +250,8 @@ export function _resolveCtxValue(
  *
  * @internal
  */
-export const _batchCtx: Context<'live' | 'default'> = {
-  _defaultValue: 'default',
+export const _batchCtx: Context<"live" | "default"> = {
+  _defaultValue: "default",
   Provider: undefined as never,
 };
 
@@ -260,8 +260,8 @@ export const _batchCtx: Context<'live' | 'default'> = {
  * Falls back to `'default'` when no `createRoot` or `$patch` ancestor has set it.
  * @internal
  */
-export function _getCurrentBatch(): 'live' | 'default' {
-  return _resolveCtxValue(_ctxMap, _batchCtx as Context<unknown>) as 'live' | 'default';
+export function _getCurrentBatch(): "live" | "default" {
+  return _resolveCtxValue(_ctxMap, _batchCtx as Context<unknown>) as "live" | "default";
 }
 
 /**
@@ -271,8 +271,8 @@ export function _getCurrentBatch(): 'live' | 'default' {
  */
 export function _instanceBatch(
   capturedCtx: ReadonlyMap<Context<unknown>, unknown>,
-): 'live' | 'default' {
-  return _resolveCtxValue(capturedCtx, _batchCtx as Context<unknown>) as 'live' | 'default';
+): "live" | "default" {
+  return _resolveCtxValue(capturedCtx, _batchCtx as Context<unknown>) as "live" | "default";
 }
 
 /**
@@ -282,7 +282,7 @@ export function _instanceBatch(
  */
 export function _withBatch(
   ctxMap: ReadonlyMap<Context<unknown>, unknown>,
-  batch: 'live' | 'default',
+  batch: "live" | "default",
 ): ReadonlyMap<Context<unknown>, unknown> {
   if ((_resolveCtxValue(ctxMap, _batchCtx as Context<unknown>) as string) === batch) return ctxMap;
   const newMap = new Map(ctxMap);

--- a/src/hooks/$effect.ts
+++ b/src/hooks/$effect.ts
@@ -1,4 +1,4 @@
-import { $EFFECT, depsChanged, type HookContext } from './symbols';
+import { $EFFECT, depsChanged, type HookContext } from "./symbols";
 
 /**
  * Side-effect hook for generator components.
@@ -30,7 +30,7 @@ import { $EFFECT, depsChanged, type HookContext } from './symbols';
  * }
  */
 export function* $effect(
-  fn: (signal: AbortSignal) => (() => void) | void,
+  fn: (signal: AbortSignal) => (() => void) | undefined,
   deps: unknown[],
 ): Generator<unknown, void, unknown> {
   yield { type: $EFFECT, fn, deps };
@@ -40,12 +40,12 @@ export function* $effect(
 export function _processEffect(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   type EffectState = {
     deps: unknown[];
-    cleanup: (() => void) | void;
+    cleanup: (() => void) | undefined;
     controller: AbortController;
   };
   const { hookIndex, hookStates, cleanupFns, pendingEffects } = ctx;
-  const fn = descriptor['fn'] as (signal: AbortSignal) => (() => void) | void;
-  const deps = descriptor['deps'] as unknown[];
+  const fn = descriptor["fn"] as (signal: AbortSignal) => (() => void) | undefined;
+  const deps = descriptor["deps"] as unknown[];
   const existing = hookStates[hookIndex] as EffectState | undefined;
 
   if (!existing || depsChanged(existing.deps, deps)) {

--- a/src/hooks/$id.ts
+++ b/src/hooks/$id.ts
@@ -1,5 +1,5 @@
-import { $ID, type HookContext } from './symbols';
-import { renderState } from '../render/state';
+import { renderState } from "../render/state";
+import { $ID, type HookContext } from "./symbols";
 
 /**
  * Stable unique ID hook for generator components.

--- a/src/hooks/$memo.ts
+++ b/src/hooks/$memo.ts
@@ -1,4 +1,4 @@
-import { $MEMO, depsChanged, type HookContext } from './symbols';
+import { $MEMO, depsChanged, type HookContext } from "./symbols";
 
 /**
  * Memoized value hook for generator components.
@@ -34,8 +34,8 @@ export function* $memo<T>(
 /** @internal */
 export function _processMemo(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates } = ctx;
-  const fn = descriptor['fn'] as (...args: unknown[]) => unknown;
-  const deps = descriptor['deps'] as unknown[];
+  const fn = descriptor["fn"] as (...args: unknown[]) => unknown;
+  const deps = descriptor["deps"] as unknown[];
   const existing = hookStates[hookIndex] as { value: unknown; deps: unknown[] } | undefined;
   if (!existing || depsChanged(existing.deps, deps)) {
     hookStates[hookIndex] = { value: fn(...deps), deps };

--- a/src/hooks/$patch-context.ts
+++ b/src/hooks/$patch-context.ts
@@ -1,4 +1,4 @@
-import { _batchCtx, $context, type UseContextDescriptor } from '../context';
+import { _batchCtx, $context, type UseContextDescriptor } from "../context";
 
 /**
  * Read the current `$patch` batch behaviour from the context.
@@ -12,6 +12,6 @@ import { _batchCtx, $context, type UseContextDescriptor } from '../context';
  *   return <span>{patch === 'live' ? 'Live' : 'Deferred'}</span>;
  * }
  */
-export function* $patchContext(): Generator<UseContextDescriptor, 'live' | 'default', unknown> {
+export function* $patchContext(): Generator<UseContextDescriptor, "live" | "default", unknown> {
   return yield* $context(_batchCtx);
 }

--- a/src/hooks/$ref.ts
+++ b/src/hooks/$ref.ts
@@ -1,4 +1,4 @@
-import { $REF, type HookContext } from './symbols';
+import { $REF, type HookContext } from "./symbols";
 
 /**
  * A mutable ref object whose `.current` property persists across re-renders.
@@ -30,7 +30,7 @@ export function* $ref<T>(initialValue: T): Generator<unknown, RefObject<T>, unkn
 export function _processRef(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates } = ctx;
   if (!(hookIndex in hookStates)) {
-    hookStates[hookIndex] = { current: descriptor['initialValue'] };
+    hookStates[hookIndex] = { current: descriptor["initialValue"] };
   }
   return hookStates[hookIndex];
 }

--- a/src/hooks/$render.ts
+++ b/src/hooks/$render.ts
@@ -1,6 +1,6 @@
-import { type Child, createElement } from '../jsx';
-import { createContext, $context } from '../context';
-import { $RENDER, depsChanged, type HookContext } from './symbols';
+import { $context, createContext } from "../context";
+import { type Child, createElement } from "../jsx";
+import { $RENDER, depsChanged, type HookContext } from "./symbols";
 
 /**
  * Inline render factory passed to `$render` (Variant 2).
@@ -17,7 +17,7 @@ export type UseRenderFn<T> = (props: { resume: (value: T) => void }) => Child;
  * @internal
  */
 export type UseRenderState<T> = {
-  status: 'waiting' | 'resolved';
+  status: "waiting" | "resolved";
   deps: unknown[];
   value: T | undefined;
   /** Stable callback reference – created once per deps change and reused. */
@@ -98,9 +98,9 @@ export function* $render<T>(
     resumeCallback: (value: T) => void;
   };
 
-  const isInline = typeof fnOrChild === 'function';
+  const isInline = typeof fnOrChild === "function";
 
-  while (slot.status === 'waiting') {
+  while (slot.status === "waiting") {
     const rawChild = isInline
       ? (fnOrChild as UseRenderFn<T>)({ resume: resumeCallback })
       : (fnOrChild as Child);
@@ -151,7 +151,7 @@ export function* $render<T>(
 export function* $resume<T>(): Generator<unknown, (value: T) => void, unknown> {
   const fn = yield* $context(_resumeCtx);
   if (fn === null) {
-    throw new Error('$resume must be called inside a component rendered by $render');
+    throw new Error("$resume must be called inside a component rendered by $render");
   }
   return fn as (value: T) => void;
 }
@@ -159,12 +159,12 @@ export function* $resume<T>(): Generator<unknown, (value: T) => void, unknown> {
 /** @internal */
 export function _processRender(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, resume } = ctx;
-  const deps = descriptor['deps'] as unknown[];
+  const deps = descriptor["deps"] as unknown[];
   let slot = hookStates[hookIndex] as UseRenderState<unknown> | undefined;
 
   if (!slot || depsChanged(slot.deps, deps)) {
     const newSlot: UseRenderState<unknown> = {
-      status: 'waiting',
+      status: "waiting",
       deps,
       value: undefined,
       resumeCallback: null!,
@@ -172,15 +172,15 @@ export function _processRender(descriptor: { [key: string]: unknown }, ctx: Hook
     hookStates[hookIndex] = newSlot;
     newSlot.resumeCallback = (value: unknown): void => {
       const s = hookStates[hookIndex] as UseRenderState<unknown>;
-      if (s.status === 'waiting') {
-        s.status = 'resolved';
+      if (s.status === "waiting") {
+        s.status = "resolved";
         s.value = value;
         resume();
       }
     };
     slot = newSlot;
   } else {
-    slot.status = 'waiting';
+    slot.status = "waiting";
   }
 
   return { slot, resumeCallback: slot.resumeCallback };

--- a/src/hooks/$resolve.ts
+++ b/src/hooks/$resolve.ts
@@ -1,5 +1,5 @@
-import { type Child, type AnyComponentFn } from '../jsx';
-import { $RESOLVE_RAW, $RESOLVE, depsChanged, type HookContext } from './symbols';
+import type { AnyComponentFn, Child } from "../jsx";
+import { $RESOLVE, $RESOLVE_RAW, depsChanged, type HookContext } from "./symbols";
 
 /**
  * A value that can be rendered: a VNode-like child, a component function,
@@ -33,7 +33,7 @@ export type ResolveRawResult<T, E = unknown> =
 /** Normalise a Renderable to a `Child` value the renderer can process. */
 function toChild(renderable: Renderable): Child {
   if (renderable == null) return null;
-  if (typeof renderable === 'function') {
+  if (typeof renderable === "function") {
     return { type: renderable as AnyComponentFn, props: {}, children: [] };
   }
   return renderable as Child;
@@ -116,27 +116,27 @@ export function _processResolveRaw(
   ctx: HookContext,
 ): unknown {
   type RawState =
-    | { promise: Promise<unknown>; status: 'pending' }
-    | { promise: Promise<unknown>; status: 'resolved'; data: unknown }
-    | { promise: Promise<unknown>; status: 'rejected'; error: unknown };
+    | { promise: Promise<unknown>; status: "pending" }
+    | { promise: Promise<unknown>; status: "resolved"; data: unknown }
+    | { promise: Promise<unknown>; status: "rejected"; error: unknown };
 
   const { hookIndex, hookStates, rerender } = ctx;
-  const promise = descriptor['promise'] as Promise<unknown>;
+  const promise = descriptor["promise"] as Promise<unknown>;
   const existing = hookStates[hookIndex] as RawState | undefined;
 
   if (!existing || existing.promise !== promise) {
-    const state: RawState = { promise, status: 'pending' };
+    const state: RawState = { promise, status: "pending" };
     hookStates[hookIndex] = state;
     promise.then(
       (data) => {
         if (hookStates[hookIndex] === state) {
-          hookStates[hookIndex] = { promise, status: 'resolved', data };
+          hookStates[hookIndex] = { promise, status: "resolved", data };
           rerender();
         }
       },
       (error) => {
         if (hookStates[hookIndex] === state) {
-          hookStates[hookIndex] = { promise, status: 'rejected', error };
+          hookStates[hookIndex] = { promise, status: "rejected", error };
           rerender();
         }
       },
@@ -144,9 +144,9 @@ export function _processResolveRaw(
   }
 
   const s = hookStates[hookIndex] as RawState;
-  if (s.status === 'resolved')
+  if (s.status === "resolved")
     return { data: s.data, loading: false, error: undefined } as ResolveRawResult<unknown>;
-  if (s.status === 'rejected')
+  if (s.status === "rejected")
     return { data: undefined, loading: false, error: s.error } as ResolveRawResult<unknown>;
   return { data: undefined, loading: true, error: undefined } as ResolveRawResult<unknown>;
 }
@@ -159,8 +159,8 @@ export function _processResolve(descriptor: { [key: string]: unknown }, ctx: Hoo
     controller: AbortController;
   };
   const { hookIndex, hookStates, cleanupFns } = ctx;
-  const fn = descriptor['fn'] as (signal: AbortSignal) => Promise<unknown>;
-  const deps = descriptor['deps'] as unknown[];
+  const fn = descriptor["fn"] as (signal: AbortSignal) => Promise<unknown>;
+  const deps = descriptor["deps"] as unknown[];
   const existing = hookStates[hookIndex] as ResolveState | undefined;
 
   if (!existing || depsChanged(existing.deps, deps)) {

--- a/src/hooks/$state.ts
+++ b/src/hooks/$state.ts
@@ -1,4 +1,4 @@
-import { $STATE, type HookContext } from './symbols';
+import { $STATE, type HookContext } from "./symbols";
 
 /**
  * Persistent state hook for generator components.
@@ -38,12 +38,12 @@ export function* $state<T>(
 export function _processState(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, rerender } = ctx;
   if (!(hookIndex in hookStates)) {
-    const init = descriptor['initialValue'];
-    hookStates[hookIndex] = typeof init === 'function' ? (init as () => unknown)() : init;
+    const init = descriptor["initialValue"];
+    hookStates[hookIndex] = typeof init === "function" ? (init as () => unknown)() : init;
   }
   const setter = (newValue: unknown): Promise<void> => {
     hookStates[hookIndex] =
-      typeof newValue === 'function'
+      typeof newValue === "function"
         ? (newValue as (prev: unknown) => unknown)(hookStates[hookIndex])
         : newValue;
     return rerender();

--- a/src/hooks/$ui-patch.ts
+++ b/src/hooks/$ui-patch.ts
@@ -1,4 +1,4 @@
-import { $UI_PATCH, type HookContext } from './symbols';
+import { $UI_PATCH, type HookContext } from "./symbols";
 
 /**
  * Returns a stable `startPatch` function that begins a **local** UI patch

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -17,31 +17,32 @@
  *   );
  * }
  */
+
+export { $effect } from "./$effect";
+export { $id } from "./$id";
+export { $memo } from "./$memo";
+export { $patchContext } from "./$patch-context";
+export { $ref, type RefObject } from "./$ref";
+export { $render, $resume, type UseRenderFn, type UseRenderState } from "./$render";
 export {
-  $STATE,
-  $REF,
+  $resolve,
+  $resolveRaw,
+  type Renderable,
+  type ResolveRawResult,
+  type UseResolveOptions,
+} from "./$resolve";
+export { $state } from "./$state";
+export { $uiPatch } from "./$ui-patch";
+export {
+  $EFFECT,
   $ID,
   $MEMO,
-  $RESOLVE_RAW,
-  $RESOLVE,
-  $EFFECT,
+  $REF,
   $RENDER,
+  $RESOLVE,
+  $RESOLVE_RAW,
+  $STATE,
   $UI_PATCH,
   depsChanged,
   type HookContext,
-} from './symbols';
-export { $state } from './$state';
-export { type RefObject, $ref } from './$ref';
-export { $id } from './$id';
-export { $memo } from './$memo';
-export {
-  type Renderable,
-  type UseResolveOptions,
-  type ResolveRawResult,
-  $resolveRaw,
-  $resolve,
-} from './$resolve';
-export { $effect } from './$effect';
-export { type UseRenderFn, type UseRenderState, $render, $resume } from './$render';
-export { $uiPatch } from './$ui-patch';
-export { $patchContext } from './$patch-context';
+} from "./symbols";

--- a/src/hooks/symbols.ts
+++ b/src/hooks/symbols.ts
@@ -1,4 +1,4 @@
-import type { GenInstance } from '../render/types';
+import type { GenInstance } from "../render/types";
 
 /**
  * Parameters provided to hook handler functions by the renderer.
@@ -10,7 +10,7 @@ export interface HookContext {
   cleanupFns: ((() => void) | undefined)[];
   pendingEffects: Array<{
     hookIndex: number;
-    fn: (signal: AbortSignal) => (() => void) | void;
+    fn: (signal: AbortSignal) => (() => void) | undefined;
     controller: AbortController;
   }>;
   rerender: () => Promise<void>;
@@ -21,23 +21,23 @@ export interface HookContext {
 }
 
 /** @internal */
-export const $STATE = Symbol('$state');
+export const $STATE = Symbol("$state");
 /** @internal */
-export const $REF = Symbol('$ref');
+export const $REF = Symbol("$ref");
 /** @internal */
-export const $ID = Symbol('$id');
+export const $ID = Symbol("$id");
 /** @internal */
-export const $MEMO = Symbol('$memo');
+export const $MEMO = Symbol("$memo");
 /** @internal */
-export const $RESOLVE_RAW = Symbol('$resolveRaw');
+export const $RESOLVE_RAW = Symbol("$resolveRaw");
 /** @internal */
-export const $RESOLVE = Symbol('$resolve');
+export const $RESOLVE = Symbol("$resolve");
 /** @internal */
-export const $EFFECT = Symbol('$effect');
+export const $EFFECT = Symbol("$effect");
 /** @internal */
-export const $RENDER = Symbol('$render');
+export const $RENDER = Symbol("$render");
 /** @internal */
-export const $UI_PATCH = Symbol('$uiPatch');
+export const $UI_PATCH = Symbol("$uiPatch");
 
 /** Returns true when the dependency arrays differ (shallow Object.is comparison). */
 export function depsChanged(prev: unknown[] | undefined, next: unknown[]): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,50 +22,55 @@
  * render(<Counter />, document.getElementById('root')!);
  * ```
  */
-export { createElement, Fragment } from './jsx';
-export type { SpecialProps } from './jsx';
-export { render, createRoot, startUIPatch, commitUIPatch, flushSync } from './render';
-export type { Root } from './render';
-export { createContext, $context } from './context';
+
+export type { Context } from "./context";
+export { $context, createContext } from "./context";
+export type { SEvent, SyntheticEvent } from "./events";
+export type {
+  RefObject,
+  Renderable,
+  ResolveRawResult,
+  UseRenderFn,
+  UseResolveOptions,
+} from "./hooks";
 export {
-  $state,
   $effect,
-  $resolve,
-  $resolveRaw,
-  $ref,
   $id,
   $memo,
-  $render,
-  $resume,
-  $uiPatch,
   $patchContext,
-} from './hooks';
-export type { VNode, Child, GeneratorComponentFn, PlainComponentFn, AnyComponentFn } from './jsx';
-export type { Context } from './context';
-export type { SyntheticEvent, SEvent } from './events';
+  $ref,
+  $render,
+  $resolve,
+  $resolveRaw,
+  $resume,
+  $state,
+  $uiPatch,
+} from "./hooks";
 export type {
-  UseResolveOptions,
-  Renderable,
-  RefObject,
-  UseRenderFn,
-  ResolveRawResult,
-} from './hooks';
+  AnyComponentFn,
+  Child,
+  GeneratorComponentFn,
+  PlainComponentFn,
+  SpecialProps,
+  VNode,
+} from "./jsx";
+export { createElement, Fragment } from "./jsx";
 export type {
-  CSSProperties,
-  EventHandlers,
-  AriaAttributes,
-  HTMLAttributes,
   AnchorHTMLAttributes,
   AreaHTMLAttributes,
+  AriaAttributes,
   AudioHTMLAttributes,
   ButtonHTMLAttributes,
   CanvasHTMLAttributes,
   ColHTMLAttributes,
+  CSSProperties,
   DetailsHTMLAttributes,
   DialogHTMLAttributes,
   EmbedHTMLAttributes,
+  EventHandlers,
   FieldsetHTMLAttributes,
   FormHTMLAttributes,
+  HTMLAttributes,
   IframeHTMLAttributes,
   ImgHTMLAttributes,
   InputHTMLAttributes,
@@ -85,6 +90,8 @@ export type {
   SlotHTMLAttributes,
   SourceHTMLAttributes,
   StyleHTMLAttributes,
+  SVGAttributes,
+  SvgHTMLAttributes,
   TableHTMLAttributes,
   TdHTMLAttributes,
   TextareaHTMLAttributes,
@@ -92,6 +99,6 @@ export type {
   TimeHTMLAttributes,
   TrackHTMLAttributes,
   VideoHTMLAttributes,
-  SVGAttributes,
-  SvgHTMLAttributes,
-} from './jsx-types';
+} from "./jsx-types";
+export type { Root } from "./render";
+export { commitUIPatch, createRoot, flushSync, render, startUIPatch } from "./render";

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -10,13 +10,13 @@
  *
  *   /\*\* \@jsxImportSource yielderact \*\/
  */
-import { createElement, Fragment, VNode, Child } from './jsx';
+import { type Child, createElement, Fragment, type VNode } from "./jsx";
 
 export { Fragment };
 
 /** Used by the JSX transform for single-child expressions. */
 export function jsx(
-  type: VNode['type'],
+  type: VNode["type"],
   props: { children?: Child; $children?: Child | Child[] } & Record<string, unknown>,
   key?: string | number | null,
 ): VNode {
@@ -25,7 +25,7 @@ export function jsx(
   const { children, $children, ...rest } = props;
   // The automatic JSX transform extracts `key` and passes it as the third
   // argument. Map it to `$key` (string only) for our reconciler.
-  if (key != null) rest.$key = String(key);
+  if (key != null) rest["$key"] = String(key);
   const effectiveChildren = $children ?? children;
   if (effectiveChildren === undefined) {
     return createElement(type, rest);

--- a/src/jsx-types.ts
+++ b/src/jsx-types.ts
@@ -7,8 +7,8 @@
  *
  * @module jsx-types
  */
-import type { SyntheticEvent } from './events';
-import type { Child, SpecialProps } from './jsx';
+import type { SyntheticEvent } from "./events";
+import type { SpecialProps } from "./jsx";
 
 // ---------------------------------------------------------------------------
 // CSS Properties
@@ -343,53 +343,53 @@ export type EventHandlers<T extends EventTarget = EventTarget> = {
 
 /** WAI-ARIA attributes applicable to any HTML element. */
 export interface AriaAttributes {
-  'aria-activedescendant'?: string;
-  'aria-atomic'?: boolean | 'false' | 'true';
-  'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both';
-  'aria-busy'?: boolean | 'false' | 'true';
-  'aria-checked'?: boolean | 'false' | 'mixed' | 'true';
-  'aria-colcount'?: number;
-  'aria-colindex'?: number;
-  'aria-colspan'?: number;
-  'aria-controls'?: string;
-  'aria-current'?: boolean | 'false' | 'true' | 'page' | 'step' | 'location' | 'date' | 'time';
-  'aria-describedby'?: string;
-  'aria-details'?: string;
-  'aria-disabled'?: boolean | 'false' | 'true';
-  'aria-dropeffect'?: 'none' | 'copy' | 'execute' | 'link' | 'move' | 'popup';
-  'aria-errormessage'?: string;
-  'aria-expanded'?: boolean | 'false' | 'true';
-  'aria-flowto'?: string;
-  'aria-grabbed'?: boolean | 'false' | 'true';
-  'aria-haspopup'?: boolean | 'false' | 'true' | 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog';
-  'aria-hidden'?: boolean | 'false' | 'true';
-  'aria-invalid'?: boolean | 'false' | 'true' | 'grammar' | 'spelling';
-  'aria-keyshortcuts'?: string;
-  'aria-label'?: string;
-  'aria-labelledby'?: string;
-  'aria-level'?: number;
-  'aria-live'?: 'off' | 'assertive' | 'polite';
-  'aria-modal'?: boolean | 'false' | 'true';
-  'aria-multiline'?: boolean | 'false' | 'true';
-  'aria-multiselectable'?: boolean | 'false' | 'true';
-  'aria-orientation'?: 'horizontal' | 'vertical';
-  'aria-owns'?: string;
-  'aria-placeholder'?: string;
-  'aria-posinset'?: number;
-  'aria-pressed'?: boolean | 'false' | 'mixed' | 'true';
-  'aria-readonly'?: boolean | 'false' | 'true';
-  'aria-required'?: boolean | 'false' | 'true';
-  'aria-roledescription'?: string;
-  'aria-rowcount'?: number;
-  'aria-rowindex'?: number;
-  'aria-rowspan'?: number;
-  'aria-selected'?: boolean | 'false' | 'true';
-  'aria-setsize'?: number;
-  'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other';
-  'aria-valuemax'?: number;
-  'aria-valuemin'?: number;
-  'aria-valuenow'?: number;
-  'aria-valuetext'?: string;
+  "aria-activedescendant"?: string;
+  "aria-atomic"?: boolean | "false" | "true";
+  "aria-autocomplete"?: "none" | "inline" | "list" | "both";
+  "aria-busy"?: boolean | "false" | "true";
+  "aria-checked"?: boolean | "false" | "mixed" | "true";
+  "aria-colcount"?: number;
+  "aria-colindex"?: number;
+  "aria-colspan"?: number;
+  "aria-controls"?: string;
+  "aria-current"?: boolean | "false" | "true" | "page" | "step" | "location" | "date" | "time";
+  "aria-describedby"?: string;
+  "aria-details"?: string;
+  "aria-disabled"?: boolean | "false" | "true";
+  "aria-dropeffect"?: "none" | "copy" | "execute" | "link" | "move" | "popup";
+  "aria-errormessage"?: string;
+  "aria-expanded"?: boolean | "false" | "true";
+  "aria-flowto"?: string;
+  "aria-grabbed"?: boolean | "false" | "true";
+  "aria-haspopup"?: boolean | "false" | "true" | "menu" | "listbox" | "tree" | "grid" | "dialog";
+  "aria-hidden"?: boolean | "false" | "true";
+  "aria-invalid"?: boolean | "false" | "true" | "grammar" | "spelling";
+  "aria-keyshortcuts"?: string;
+  "aria-label"?: string;
+  "aria-labelledby"?: string;
+  "aria-level"?: number;
+  "aria-live"?: "off" | "assertive" | "polite";
+  "aria-modal"?: boolean | "false" | "true";
+  "aria-multiline"?: boolean | "false" | "true";
+  "aria-multiselectable"?: boolean | "false" | "true";
+  "aria-orientation"?: "horizontal" | "vertical";
+  "aria-owns"?: string;
+  "aria-placeholder"?: string;
+  "aria-posinset"?: number;
+  "aria-pressed"?: boolean | "false" | "mixed" | "true";
+  "aria-readonly"?: boolean | "false" | "true";
+  "aria-required"?: boolean | "false" | "true";
+  "aria-roledescription"?: string;
+  "aria-rowcount"?: number;
+  "aria-rowindex"?: number;
+  "aria-rowspan"?: number;
+  "aria-selected"?: boolean | "false" | "true";
+  "aria-setsize"?: number;
+  "aria-sort"?: "none" | "ascending" | "descending" | "other";
+  "aria-valuemax"?: number;
+  "aria-valuemin"?: number;
+  "aria-valuenow"?: number;
+  "aria-valuetext"?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -406,19 +406,21 @@ export interface AriaAttributes {
  * element, used to narrow `event.currentTarget` in event handlers.
  */
 export interface HTMLAttributes<T extends HTMLElement = HTMLElement>
-  extends SpecialProps<T>, AriaAttributes, EventHandlers<T> {
+  extends SpecialProps<T>,
+    AriaAttributes,
+    EventHandlers<T> {
   // ── Global HTML attributes ───────────────────────────────────────────────
   autoCapitalize?: string;
   autoFocus?: boolean;
   className?: string;
-  contentEditable?: boolean | 'true' | 'false' | 'inherit' | 'plaintext-only';
-  dir?: 'ltr' | 'rtl' | 'auto';
+  contentEditable?: boolean | "true" | "false" | "inherit" | "plaintext-only";
+  dir?: "ltr" | "rtl" | "auto";
   draggable?: boolean;
-  enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send';
+  enterKeyHint?: "enter" | "done" | "go" | "next" | "previous" | "search" | "send";
   hidden?: boolean;
   id?: string;
   inert?: boolean;
-  inputMode?: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+  inputMode?: "none" | "text" | "decimal" | "numeric" | "tel" | "search" | "email" | "url";
   is?: string;
   lang?: string;
   nonce?: string;
@@ -429,7 +431,7 @@ export interface HTMLAttributes<T extends HTMLElement = HTMLElement>
   style?: CSSProperties;
   tabIndex?: number;
   title?: string;
-  translate?: 'yes' | 'no';
+  translate?: "yes" | "no";
 
   /** Any `data-*` attribute. */
   [key: `data-${string}`]: string | number | boolean | undefined;
@@ -449,7 +451,7 @@ export interface AnchorHTMLAttributes extends HTMLAttributes<HTMLAnchorElement> 
   referrerPolicy?: ReferrerPolicy;
   rel?: string;
   /** `string & object` keeps IDE autocomplete for the named values while still accepting any string. */
-  target?: '_self' | '_blank' | '_parent' | '_top' | (string & object);
+  target?: "_self" | "_blank" | "_parent" | "_top" | (string & object);
   type?: string;
 }
 
@@ -462,7 +464,7 @@ export interface AreaHTMLAttributes extends HTMLAttributes<HTMLAreaElement> {
   ping?: string;
   referrerPolicy?: ReferrerPolicy;
   rel?: string;
-  shape?: 'rect' | 'circle' | 'poly' | 'default';
+  shape?: "rect" | "circle" | "poly" | "default";
   target?: string;
 }
 
@@ -470,11 +472,11 @@ export interface AreaHTMLAttributes extends HTMLAttributes<HTMLAreaElement> {
 export interface AudioHTMLAttributes extends HTMLAttributes<HTMLAudioElement> {
   autoPlay?: boolean;
   controls?: boolean;
-  crossOrigin?: 'anonymous' | 'use-credentials';
+  crossOrigin?: "anonymous" | "use-credentials";
   loop?: boolean;
   mediaGroup?: string;
   muted?: boolean;
-  preload?: 'none' | 'metadata' | 'auto' | '';
+  preload?: "none" | "metadata" | "auto" | "";
   src?: string;
 }
 
@@ -500,7 +502,7 @@ export interface ButtonHTMLAttributes extends HTMLAttributes<HTMLButtonElement> 
   formNoValidate?: boolean;
   formTarget?: string;
   name?: string;
-  type?: 'submit' | 'reset' | 'button';
+  type?: "submit" | "reset" | "button";
   value?: string | number;
 }
 
@@ -558,7 +560,7 @@ export interface FormHTMLAttributes extends HTMLAttributes<HTMLFormElement> {
   action?: string;
   autoComplete?: string;
   encType?: string;
-  method?: 'get' | 'post' | 'dialog';
+  method?: "get" | "post" | "dialog";
   name?: string;
   noValidate?: boolean;
   rel?: string;
@@ -577,7 +579,7 @@ export interface IframeHTMLAttributes extends HTMLAttributes<HTMLIFrameElement> 
   allowTransparency?: boolean;
   frameBorder?: string | number;
   height?: string | number;
-  loading?: 'eager' | 'lazy';
+  loading?: "eager" | "lazy";
   name?: string;
   referrerPolicy?: ReferrerPolicy;
   sandbox?: string;
@@ -592,11 +594,11 @@ export interface IframeHTMLAttributes extends HTMLAttributes<HTMLIFrameElement> 
 /** `<img>` */
 export interface ImgHTMLAttributes extends HTMLAttributes<HTMLImageElement> {
   alt?: string;
-  crossOrigin?: 'anonymous' | 'use-credentials';
-  decoding?: 'async' | 'auto' | 'sync';
-  fetchPriority?: 'high' | 'low' | 'auto';
+  crossOrigin?: "anonymous" | "use-credentials";
+  decoding?: "async" | "auto" | "sync";
+  fetchPriority?: "high" | "low" | "auto";
   height?: string | number;
-  loading?: 'eager' | 'lazy';
+  loading?: "eager" | "lazy";
   referrerPolicy?: ReferrerPolicy;
   sizes?: string;
   src?: string;
@@ -610,7 +612,7 @@ export interface InputHTMLAttributes extends HTMLAttributes<HTMLInputElement> {
   accept?: string;
   alt?: string;
   autoComplete?: string;
-  capture?: boolean | 'user' | 'environment';
+  capture?: boolean | "user" | "environment";
   checked?: boolean;
   defaultChecked?: boolean;
   defaultValue?: string | number;
@@ -638,28 +640,28 @@ export interface InputHTMLAttributes extends HTMLAttributes<HTMLInputElement> {
   src?: string;
   step?: string | number;
   type?:
-    | 'button'
-    | 'checkbox'
-    | 'color'
-    | 'date'
-    | 'datetime-local'
-    | 'email'
-    | 'file'
-    | 'hidden'
-    | 'image'
-    | 'month'
-    | 'number'
-    | 'password'
-    | 'radio'
-    | 'range'
-    | 'reset'
-    | 'search'
-    | 'submit'
-    | 'tel'
-    | 'text'
-    | 'time'
-    | 'url'
-    | 'week';
+    | "button"
+    | "checkbox"
+    | "color"
+    | "date"
+    | "datetime-local"
+    | "email"
+    | "file"
+    | "hidden"
+    | "image"
+    | "month"
+    | "number"
+    | "password"
+    | "radio"
+    | "range"
+    | "reset"
+    | "search"
+    | "submit"
+    | "tel"
+    | "text"
+    | "time"
+    | "url"
+    | "week";
   value?: string | number;
   width?: string | number;
 }
@@ -679,8 +681,8 @@ export interface LiHTMLAttributes extends HTMLAttributes<HTMLLIElement> {
 /** `<link>` */
 export interface LinkHTMLAttributes extends HTMLAttributes<HTMLLinkElement> {
   as?: string;
-  crossOrigin?: 'anonymous' | 'use-credentials';
-  fetchPriority?: 'high' | 'low' | 'auto';
+  crossOrigin?: "anonymous" | "use-credentials";
+  fetchPriority?: "high" | "low" | "auto";
   href?: string;
   hrefLang?: string;
   imageSizes?: string;
@@ -734,7 +736,7 @@ export interface ObjectHTMLAttributes extends HTMLAttributes<HTMLObjectElement> 
 export interface OlHTMLAttributes extends HTMLAttributes<HTMLOListElement> {
   reversed?: boolean;
   start?: number;
-  type?: '1' | 'a' | 'A' | 'i' | 'I';
+  type?: "1" | "a" | "A" | "i" | "I";
 }
 
 /** `<optgroup>` */
@@ -829,13 +831,13 @@ export interface TableHTMLAttributes extends HTMLAttributes<HTMLTableElement> {
 /** `<td>` */
 export interface TdHTMLAttributes extends HTMLAttributes<HTMLTableCellElement> {
   abbr?: string;
-  align?: 'left' | 'center' | 'right' | 'justify' | 'char';
+  align?: "left" | "center" | "right" | "justify" | "char";
   colSpan?: number;
   headers?: string;
   height?: string | number;
   rowSpan?: number;
   scope?: string;
-  valign?: 'top' | 'middle' | 'bottom' | 'baseline';
+  valign?: "top" | "middle" | "bottom" | "baseline";
   width?: string | number;
 }
 
@@ -860,11 +862,11 @@ export interface TextareaHTMLAttributes extends HTMLAttributes<HTMLTextAreaEleme
 /** `<th>` */
 export interface ThHTMLAttributes extends HTMLAttributes<HTMLTableCellElement> {
   abbr?: string;
-  align?: 'left' | 'center' | 'right' | 'justify' | 'char';
+  align?: "left" | "center" | "right" | "justify" | "char";
   colSpan?: number;
   headers?: string;
   rowSpan?: number;
-  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+  scope?: "col" | "row" | "colgroup" | "rowgroup";
 }
 
 /** `<time>` */
@@ -875,7 +877,7 @@ export interface TimeHTMLAttributes extends HTMLAttributes<HTMLTimeElement> {
 /** `<track>` */
 export interface TrackHTMLAttributes extends HTMLAttributes<HTMLTrackElement> {
   default?: boolean;
-  kind?: 'subtitles' | 'captions' | 'descriptions' | 'chapters' | 'metadata';
+  kind?: "subtitles" | "captions" | "descriptions" | "chapters" | "metadata";
   label?: string;
   src?: string;
   srcLang?: string;
@@ -885,7 +887,7 @@ export interface TrackHTMLAttributes extends HTMLAttributes<HTMLTrackElement> {
 export interface VideoHTMLAttributes extends HTMLAttributes<HTMLVideoElement> {
   autoPlay?: boolean;
   controls?: boolean;
-  crossOrigin?: 'anonymous' | 'use-credentials';
+  crossOrigin?: "anonymous" | "use-credentials";
   disablePictureInPicture?: boolean;
   disableRemotePlayback?: boolean;
   height?: string | number;
@@ -893,7 +895,7 @@ export interface VideoHTMLAttributes extends HTMLAttributes<HTMLVideoElement> {
   muted?: boolean;
   playsInline?: boolean;
   poster?: string;
-  preload?: 'none' | 'metadata' | 'auto' | '';
+  preload?: "none" | "metadata" | "auto" | "";
   src?: string;
   width?: string | number;
 }
@@ -904,7 +906,9 @@ export interface VideoHTMLAttributes extends HTMLAttributes<HTMLVideoElement> {
 
 /** Presentation attributes shared by all SVG elements. */
 export interface SVGAttributes<T extends SVGElement = SVGElement>
-  extends SpecialProps<T>, AriaAttributes, EventHandlers<T> {
+  extends SpecialProps<T>,
+    AriaAttributes,
+    EventHandlers<T> {
   className?: string;
   id?: string;
   style?: CSSProperties;
@@ -914,15 +918,15 @@ export interface SVGAttributes<T extends SVGElement = SVGElement>
   color?: string;
   fill?: string;
   fillOpacity?: string | number;
-  fillRule?: 'nonzero' | 'evenodd';
+  fillRule?: "nonzero" | "evenodd";
   filter?: string;
   mask?: string;
   opacity?: string | number;
   stroke?: string;
   strokeDasharray?: string | number;
   strokeDashoffset?: string | number;
-  strokeLinecap?: 'butt' | 'round' | 'square' | 'inherit';
-  strokeLinejoin?: 'miter' | 'round' | 'bevel' | 'inherit';
+  strokeLinecap?: "butt" | "round" | "square" | "inherit";
+  strokeLinejoin?: "miter" | "round" | "bevel" | "inherit";
   strokeMiterlimit?: string | number;
   strokeOpacity?: string | number;
   strokeWidth?: string | number;
@@ -932,7 +936,7 @@ export interface SVGAttributes<T extends SVGElement = SVGElement>
 
   // Presentation
   clipPath?: string;
-  clipRule?: 'nonzero' | 'evenodd';
+  clipRule?: "nonzero" | "evenodd";
   colorInterpolation?: string;
   colorRendering?: string;
   cursor?: string;
@@ -1024,7 +1028,7 @@ export interface PolylineSVGAttributes extends SVGAttributes<SVGPolylineElement>
 export interface TextSVGAttributes extends SVGAttributes<SVGTextElement> {
   dx?: string | number;
   dy?: string | number;
-  lengthAdjust?: 'spacing' | 'spacingAndGlyphs';
+  lengthAdjust?: "spacing" | "spacingAndGlyphs";
   rotate?: string | number;
   textLength?: string | number;
   x?: string | number;
@@ -1035,7 +1039,7 @@ export interface TextSVGAttributes extends SVGAttributes<SVGTextElement> {
 export interface TSpanSVGAttributes extends SVGAttributes<SVGTSpanElement> {
   dx?: string | number;
   dy?: string | number;
-  lengthAdjust?: 'spacing' | 'spacingAndGlyphs';
+  lengthAdjust?: "spacing" | "spacingAndGlyphs";
   rotate?: string | number;
   textLength?: string | number;
   x?: string | number;
@@ -1082,7 +1086,7 @@ export interface LinearGradientSVGAttributes extends SVGAttributes<SVGLinearGrad
   gradientTransform?: string;
   gradientUnits?: string;
   href?: string;
-  spreadMethod?: 'pad' | 'reflect' | 'repeat';
+  spreadMethod?: "pad" | "reflect" | "repeat";
   x1?: string | number;
   x2?: string | number;
   y1?: string | number;
@@ -1100,7 +1104,7 @@ export interface RadialGradientSVGAttributes extends SVGAttributes<SVGRadialGrad
   gradientUnits?: string;
   href?: string;
   r?: string | number;
-  spreadMethod?: 'pad' | 'reflect' | 'repeat';
+  spreadMethod?: "pad" | "reflect" | "repeat";
 }
 
 /** `<stop>` */
@@ -1110,7 +1114,7 @@ export interface StopSVGAttributes extends SVGAttributes<SVGStopElement> {
 
 /** `<clipPath>` */
 export interface ClipPathSVGAttributes extends SVGAttributes<SVGClipPathElement> {
-  clipPathUnits?: 'userSpaceOnUse' | 'objectBoundingBox';
+  clipPathUnits?: "userSpaceOnUse" | "objectBoundingBox";
 }
 
 /** `<mask>` */
@@ -1135,8 +1139,8 @@ export interface FilterSVGAttributes extends SVGAttributes<SVGFilterElement> {
 
 /** `<image>` (SVG) */
 export interface ImageSVGAttributes extends SVGAttributes<SVGImageElement> {
-  crossOrigin?: 'anonymous' | 'use-credentials';
-  decoding?: 'async' | 'auto' | 'sync';
+  crossOrigin?: "anonymous" | "use-credentials";
+  decoding?: "async" | "auto" | "sync";
   height?: string | number;
   href?: string;
   preserveAspectRatio?: string;

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,4 +1,4 @@
-import type { IntrinsicElements as IntrinsicElementsDef } from './jsx-types';
+import type { IntrinsicElements as IntrinsicElementsDef } from "./jsx-types";
 
 /**
  * Virtual DOM node produced by createElement / JSX.
@@ -41,7 +41,7 @@ export interface SpecialProps<TRef = unknown> {
    * - `'live'`: updates flush immediately, even during an active patch.
    * - `'default'` (default): updates are deferred until the patch commits.
    */
-  $patch?: 'live' | 'default';
+  $patch?: "live" | "default";
   /**
    * Marks this subtree as deferred (lower priority).
    *
@@ -124,7 +124,7 @@ export type AnyComponentFn<P extends Record<string, unknown> = Record<string, un
  *   );
  * }
  */
-export const Fragment: unique symbol = Symbol('Fragment');
+export const Fragment: unique symbol = Symbol("Fragment");
 
 // ---------------------------------------------------------------------------
 // createElement overloads
@@ -158,14 +158,14 @@ export function createElement(type: symbol, props: null, ...children: Child[]): 
 
 // Overload 4: escape-hatch (union type)
 export function createElement(
-  type: VNode['type'],
+  type: VNode["type"],
   props: Record<string, unknown> | null,
   ...children: Child[]
 ): VNode;
 
 // Implementation
 export function createElement(
-  type: VNode['type'],
+  type: VNode["type"],
   props: Record<string, unknown> | null,
   ...children: Child[]
 ): VNode {

--- a/src/render/events.ts
+++ b/src/render/events.ts
@@ -1,4 +1,4 @@
-import { createSyntheticEvent, type SyntheticEvent } from '../events';
+import { createSyntheticEvent, type SyntheticEvent } from "../events";
 
 /**
  * Maps each DOM element to its currently-registered synthetic event wrappers.
@@ -60,6 +60,6 @@ export function removeSyntheticListener(el: HTMLElement, eventName: string): voi
   const wrapper = listenerWrappers.get(el)?.get(eventName);
   if (wrapper) {
     el.removeEventListener(eventName, wrapper);
-    listenerWrappers.get(el)!.delete(eventName);
+    listenerWrappers.get(el)?.delete(eventName);
   }
 }

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -1,10 +1,10 @@
 import {
   type AnyComponentFn,
-  type GeneratorComponentFn,
-  type VNode,
   type Child,
   Fragment,
-} from '../jsx';
+  type GeneratorComponentFn,
+  type VNode,
+} from "../jsx";
 
 /**
  * Returns true when `fn` is a generator function (i.e. uses `function*`).
@@ -19,7 +19,7 @@ import {
  * is guaranteed by the JS spec for `function*` declarations/expressions.
  */
 export function isGeneratorFn(fn: AnyComponentFn): fn is GeneratorComponentFn {
-  return fn.constructor.name === 'GeneratorFunction';
+  return fn.constructor.name === "GeneratorFunction";
 }
 
 /**
@@ -65,7 +65,7 @@ export function onlyPatchChanged(a: Record<string, unknown>, b: Record<string, u
   let patchDiffers = false;
   for (const k of aKeys) {
     if (Object.is(a[k], b[k])) continue;
-    if (k === '$patch') {
+    if (k === "$patch") {
       patchDiffers = true;
       continue;
     }
@@ -90,7 +90,7 @@ export function onlyPatchChanged(a: Record<string, unknown>, b: Record<string, u
 export function flattenChildren(children: Child[]): Child[] {
   const result: Child[] = [];
   for (const child of children) {
-    if (child != null && typeof child === 'object' && (child as VNode).type === Fragment) {
+    if (child != null && typeof child === "object" && (child as VNode).type === Fragment) {
       result.push(...flattenChildren((child as VNode).children));
     } else {
       result.push(child);
@@ -132,7 +132,7 @@ export function mergedProps(vnode: VNode): Record<string, unknown> {
  * @param props - The (merged) props to check.
  */
 export function isShown(props: Record<string, unknown>): boolean {
-  return props['$shown'] !== false;
+  return props["$shown"] !== false;
 }
 
 /**
@@ -152,7 +152,7 @@ export function isShown(props: Record<string, unknown>): boolean {
  * @returns Props without `$deferred`.
  */
 export function stripDeferred(props: Record<string, unknown>): Record<string, unknown> {
-  if (!('$deferred' in props)) return props;
+  if (!("$deferred" in props)) return props;
   const { $deferred: _, ...rest } = props;
   return rest;
 }

--- a/src/render/hooks-runtime.ts
+++ b/src/render/hooks-runtime.ts
@@ -12,39 +12,39 @@
  * collection, and context propagation.
  */
 
-import { type Child } from '../jsx';
 import {
+  _getProviderCtx,
+  _processContext,
   $CONTEXT,
   type Context,
-  _getProviderCtx,
   type UseContextState,
-  _processContext,
-} from '../context';
-import { clearRef } from './props';
+} from "../context";
 import {
-  $STATE,
-  $REF,
+  $EFFECT,
   $ID,
   $MEMO,
-  $RESOLVE_RAW,
-  $RESOLVE,
-  $EFFECT,
+  $REF,
   $RENDER,
+  $RESOLVE,
+  $RESOLVE_RAW,
+  $STATE,
   $UI_PATCH,
   depsChanged,
   type HookContext,
-} from '../hooks';
-import { _processState } from '../hooks/$state';
-import { _processRef } from '../hooks/$ref';
-import { _processId } from '../hooks/$id';
-import { _processMemo } from '../hooks/$memo';
-import { _processResolveRaw, _processResolve } from '../hooks/$resolve';
-import { _processEffect } from '../hooks/$effect';
-import { _processRender } from '../hooks/$render';
-import { _processUIPatch } from '../hooks/$ui-patch';
-import { type Slot, type GenInstance } from './types';
-import { renderState } from './state';
-import { _flushPendingVNodes } from './patch';
+} from "../hooks";
+import { _processEffect } from "../hooks/$effect";
+import { _processId } from "../hooks/$id";
+import { _processMemo } from "../hooks/$memo";
+import { _processRef } from "../hooks/$ref";
+import { _processRender } from "../hooks/$render";
+import { _processResolve, _processResolveRaw } from "../hooks/$resolve";
+import { _processState } from "../hooks/$state";
+import { _processUIPatch } from "../hooks/$ui-patch";
+import type { Child } from "../jsx";
+import { _flushPendingVNodes } from "./patch";
+import { clearRef } from "./props";
+import { renderState } from "./state";
+import type { GenInstance, Slot } from "./types";
 
 /**
  * Set of all known hook descriptor type symbols for fast membership test.
@@ -78,7 +78,7 @@ const HOOK_SYMBOLS = new Set<symbol>([
 export function isHookDescriptor(value: unknown): boolean {
   return (
     value !== null &&
-    typeof value === 'object' &&
+    typeof value === "object" &&
     HOOK_SYMBOLS.has((value as { type: symbol }).type)
   );
 }
@@ -111,8 +111,9 @@ export function flushEffects(instance: GenInstance): void {
   if (instance.gen !== null) return;
   for (const { hookIndex, fn, controller } of instance.pendingEffects) {
     const cleanup = fn(controller.signal);
-    (instance.hookStates[hookIndex] as { deps: unknown[]; cleanup: (() => void) | void }).cleanup =
-      cleanup;
+    (
+      instance.hookStates[hookIndex] as { deps: unknown[]; cleanup: (() => void) | undefined }
+    ).cleanup = cleanup;
   }
   instance.pendingEffects.length = 0;
 }
@@ -135,8 +136,8 @@ export function unmountSlot(slot: Slot): void {
     unmountSlot(child);
   }
   // Clear $ref on HTML element slots
-  if (typeof slot.type === 'string' && slot.props['$ref']) {
-    clearRef(slot.props['$ref']);
+  if (typeof slot.type === "string" && slot.props["$ref"]) {
+    clearRef(slot.props["$ref"]);
   }
   if (slot.genInstance) {
     for (const child of slot.genInstance.slots) {
@@ -210,7 +211,7 @@ export function processOneDescriptor(
   cleanupFns: ((() => void) | undefined)[],
   pendingEffects: Array<{
     hookIndex: number;
-    fn: (signal: AbortSignal) => (() => void) | void;
+    fn: (signal: AbortSignal) => (() => void) | undefined;
     controller: AbortController;
   }>,
   rerender: () => Promise<void>,
@@ -342,7 +343,7 @@ export function runHooks(
  */
 function _hasStableSelectors(inst: GenInstance, ctx: Context<unknown>, newValue: unknown): boolean {
   for (const s of inst.hookStates) {
-    if (s == null || typeof s !== 'object') continue;
+    if (s == null || typeof s !== "object") continue;
     const state = s as UseContextState;
     if (state.ctx !== ctx) continue;
     if (!state.selector) return false;
@@ -376,11 +377,11 @@ function _hasStableSelectors(inst: GenInstance, ctx: Context<unknown>, newValue:
 export function propagateContextUpdate(
   ctx: Context<unknown>,
   newValue: unknown,
-  slots: import('./types').Slot[],
+  slots: import("./types").Slot[],
 ): void {
   for (const slot of slots) {
     // Stop at an inner Provider for the same context – it overrides the outer value.
-    if (typeof slot.type === 'function' && _getProviderCtx(slot.type) === ctx) {
+    if (typeof slot.type === "function" && _getProviderCtx(slot.type) === ctx) {
       continue;
     }
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,11 +1,11 @@
-import { type VNode } from '../jsx';
-import { buildNode } from './mount';
-import { _getCtxMap, _setCtxMap, _withBatch } from '../context';
-import { renderState } from './state';
+import { _getCtxMap, _setCtxMap, _withBatch } from "../context";
+import type { VNode } from "../jsx";
+import { buildNode } from "./mount";
+import { renderState } from "./state";
 
-export { startUIPatch, commitUIPatch } from './patch';
-export { buildNode } from './mount';
-export { flushSync, scheduleUpdate } from './scheduler';
+export { buildNode } from "./mount";
+export { commitUIPatch, startUIPatch } from "./patch";
+export { flushSync, scheduleUpdate } from "./scheduler";
 
 /**
  * Render a VNode tree into a DOM container (simple one-shot mount).
@@ -64,7 +64,7 @@ export function createRoot(container: Element): Root {
   return {
     render(vnode: VNode): void {
       const prevCtx = _getCtxMap();
-      _setCtxMap(_withBatch(prevCtx, 'default'));
+      _setCtxMap(_withBatch(prevCtx, "default"));
       renderState.isInitialMount = true;
       try {
         container.appendChild(buildNode(vnode));

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -18,31 +18,29 @@
  */
 
 import {
-  Fragment,
-  type VNode,
-  type Child,
-  type AnyComponentFn,
-  type GeneratorComponentFn,
-  type PlainComponentFn,
-} from '../jsx';
-import {
   _getCtxMap,
-  _setCtxMap,
+  _getCurrentPriority,
   _getProviderCtx,
   _instanceBatch,
-  _instancePriority,
-  _getCurrentPriority,
+  _setCtxMap,
   _withBatch,
   _withPriority,
-} from '../context';
-import { type Slot, type GenInstance } from './types';
-import { renderState } from './state';
-import { applyProps } from './props';
-import { isGeneratorFn, mergedProps, isShown, stripDeferred } from './helpers';
-import { runHooks, flushEffects } from './hooks-runtime';
-import { reconcileSlots } from './reconciler';
-import { isPatchActive } from './patch-queue';
-import { scheduleUpdate } from './scheduler';
+} from "../context";
+import {
+  type AnyComponentFn,
+  type Child,
+  Fragment,
+  type GeneratorComponentFn,
+  type PlainComponentFn,
+} from "../jsx";
+import { isGeneratorFn, isShown, mergedProps, stripDeferred } from "./helpers";
+import { flushEffects, runHooks } from "./hooks-runtime";
+import { isPatchActive } from "./patch-queue";
+import { applyProps } from "./props";
+import { reconcileSlots } from "./reconciler";
+import { scheduleUpdate } from "./scheduler";
+import { renderState } from "./state";
+import type { GenInstance, Slot } from "./types";
 
 /**
  * Build a single real DOM node from a virtual DOM node (or primitive value).
@@ -69,10 +67,10 @@ import { scheduleUpdate } from './scheduler';
  *   a `DocumentFragment` containing the output nodes + endMarker.
  */
 export function buildNode(child: Child): Node {
-  if (child == null || typeof child === 'boolean') {
-    return document.createTextNode('');
+  if (child == null || typeof child === "boolean") {
+    return document.createTextNode("");
   }
-  if (typeof child === 'string' || typeof child === 'number') {
+  if (typeof child === "string" || typeof child === "number") {
     return document.createTextNode(String(child));
   }
 
@@ -84,15 +82,15 @@ export function buildNode(child: Child): Node {
     return frag;
   }
 
-  if (typeof child.type === 'function') {
+  if (typeof child.type === "function") {
     const fn = child.type as AnyComponentFn;
     const allPropsRaw = mergedProps(child);
     if (!isShown(allPropsRaw)) {
-      return document.createTextNode('');
+      return document.createTextNode("");
     }
     // Strip $deferred from component props; propagate via context.
     const allProps = stripDeferred(allPropsRaw);
-    const compDeferred = allPropsRaw['$deferred'] as boolean | undefined;
+    const compDeferred = allPropsRaw["$deferred"] as boolean | undefined;
     const prevCtxFn = _getCtxMap();
     if (compDeferred) _setCtxMap(_withPriority(prevCtxFn, _getCurrentPriority() + 1));
     try {
@@ -110,14 +108,14 @@ export function buildNode(child: Child): Node {
   }
 
   if (!isShown(child.props)) {
-    return document.createTextNode('');
+    return document.createTextNode("");
   }
 
   // HTML element — propagate $patch and $deferred to children via context.
   const el = document.createElement(child.type as string);
   applyProps(el, child.props);
-  const elBatch = child.props['$patch'] as 'live' | 'default' | undefined;
-  const elDeferred = child.props['$deferred'] as boolean | undefined;
+  const elBatch = child.props["$patch"] as "live" | "default" | undefined;
+  const elDeferred = child.props["$deferred"] as boolean | undefined;
   const prevCtxBuildNode = _getCtxMap();
   if (elBatch !== undefined) _setCtxMap(_withBatch(prevCtxBuildNode, elBatch));
   if (elDeferred) _setCtxMap(_withPriority(_getCtxMap(), _getCurrentPriority() + 1));
@@ -141,10 +139,10 @@ export function buildNode(child: Child): Node {
 function commitOrDefer(instance: GenInstance, vnode: Child): void {
   const parent = instance.endMarker.parentNode as HTMLElement;
   const effectiveBatch =
-    (instance.props['$patch'] as 'live' | 'default' | undefined) ??
+    (instance.props["$patch"] as "live" | "default" | undefined) ??
     _instanceBatch(instance.capturedCtx);
   const shouldDefer =
-    (renderState.patchDepth > 0 || instance.localPatchRefCount > 0) && effectiveBatch !== 'live';
+    (renderState.patchDepth > 0 || instance.localPatchRefCount > 0) && effectiveBatch !== "live";
   if (shouldDefer) {
     instance.pendingVNode = vnode;
     renderState.dirtyInstances.add(instance);
@@ -190,7 +188,7 @@ export function mountGeneratorComponent(
   fn: GeneratorComponentFn,
   props: Record<string, unknown>,
 ): { fragment: DocumentFragment; genInstance: GenInstance } {
-  const endMarker = document.createComment('');
+  const endMarker = document.createComment("");
 
   /**
    * The context map captured at mount time, representing the **inherited**
@@ -211,7 +209,7 @@ export function mountGeneratorComponent(
   /** Queued effects for the current render pass. See `GenInstance.pendingEffects`. */
   const pendingEffects: Array<{
     hookIndex: number;
-    fn: (signal: AbortSignal) => (() => void) | void;
+    fn: (signal: AbortSignal) => (() => void) | undefined;
     controller: AbortController;
   }> = [];
 
@@ -244,7 +242,7 @@ export function mountGeneratorComponent(
 
     // Restore context: inherited context + own $patch applied for children.
     const prevCtx = _getCtxMap();
-    const ownPatchResume = instance.props['$patch'] as 'live' | 'default' | undefined;
+    const ownPatchResume = instance.props["$patch"] as "live" | "default" | undefined;
     _setCtxMap(
       ownPatchResume !== undefined
         ? _withBatch(instance.capturedCtx, ownPatchResume)
@@ -295,7 +293,8 @@ export function mountGeneratorComponent(
    * @param mounted - `false` on initial mount, `true` on rerenders. Controls
    *   whether nodes are stored for fragment assembly or reconciled in place.
    */
-  function executeRerender(mounted: boolean): Promise<void> {
+  function executeRerender(initiallyMounted: boolean): Promise<void> {
+    let mounted = initiallyMounted;
     // eslint-disable-next-line no-constant-condition
     while (true) {
       instance.isRendering = true;
@@ -308,7 +307,7 @@ export function mountGeneratorComponent(
 
       // Restore context: inherited context + own $patch for children.
       const prevCtx = _getCtxMap();
-      const ownPatch = instance.props['$patch'] as 'live' | 'default' | undefined;
+      const ownPatch = instance.props["$patch"] as "live" | "default" | undefined;
       _setCtxMap(
         ownPatch !== undefined ? _withBatch(instance.capturedCtx, ownPatch) : instance.capturedCtx,
       );
@@ -475,10 +474,10 @@ export function mountContextProvider(
 ): { fragment: DocumentFragment; endMarker: Comment; childSlots: Slot[] } {
   const prevCtxMap = _getCtxMap();
   const newCtxMap = new Map(prevCtxMap);
-  newCtxMap.set(providerCtx as never, props.value);
+  newCtxMap.set(providerCtx as never, props["value"]);
   _setCtxMap(newCtxMap);
 
-  const endMarker = document.createComment('');
+  const endMarker = document.createComment("");
   const fragment = document.createDocumentFragment();
   fragment.appendChild(endMarker);
   let childSlots: Slot[] = [];
@@ -522,14 +521,14 @@ export function mountContextProvider(
  */
 export function mountPlainComponent(fn: PlainComponentFn, props: Record<string, unknown>): Node {
   const vnode = fn(props);
-  if (vnode == null) return document.createTextNode('');
+  if (vnode == null) return document.createTextNode("");
   const node = buildNode(vnode);
   // DocumentFragment gets consumed on append — its children move to the parent
   // and the fragment itself becomes empty. Wrap in a span to preserve a stable
   // slot.node reference for the reconciler's replaceChild/removeChild calls.
   if (node instanceof DocumentFragment) {
-    const host = document.createElement('span');
-    host.style.display = 'contents';
+    const host = document.createElement("span");
+    host.style.display = "contents";
     host.appendChild(node);
     return host;
   }

--- a/src/render/patch-queue.ts
+++ b/src/render/patch-queue.ts
@@ -41,7 +41,7 @@ export function commitPatch(): void {
   if (_ops === null) return;
   const ops = _ops;
   _ops = null;
-  for (let i = 0; i < ops.length; i++) ops[i]();
+  for (let i = 0; i < ops.length; i++) ops[i]!();
 }
 
 /** Returns `true` while a patch is being collected. */

--- a/src/render/patch.ts
+++ b/src/render/patch.ts
@@ -1,8 +1,8 @@
-import { type GenInstance } from './types';
-import { renderState } from './state';
-import { _getCtxMap, _setCtxMap, _withBatch } from '../context';
-import { flushEffects } from './hooks-runtime';
-import { reconcileSlots } from './reconciler';
+import { _getCtxMap, _setCtxMap, _withBatch } from "../context";
+import { flushEffects } from "./hooks-runtime";
+import { reconcileSlots } from "./reconciler";
+import { renderState } from "./state";
+import type { GenInstance } from "./types";
 
 /**
  * Apply deferred DOM updates for a list of generator instances.
@@ -35,7 +35,7 @@ export function _flushPendingVNodes(instances: GenInstance[]): void {
 
     const prevCtx = _getCtxMap();
     // Restore inherited context, then apply own $patch for children.
-    const ownPatch = inst.props['$patch'] as 'live' | 'default' | undefined;
+    const ownPatch = inst.props["$patch"] as "live" | "default" | undefined;
     _setCtxMap(ownPatch !== undefined ? _withBatch(inst.capturedCtx, ownPatch) : inst.capturedCtx);
     const parent = inst.endMarker.parentNode as HTMLElement;
     try {

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -1,14 +1,14 @@
-import { type SyntheticEvent } from '../events';
-import { addSyntheticListener, removeSyntheticListener } from './events';
+import type { SyntheticEvent } from "../events";
+import { addSyntheticListener, removeSyntheticListener } from "./events";
 
 // ── Ref helpers ─────────────────────────────────────────────────────────────
 
 /** Attach a $ref (callback or object) to a DOM element. */
 export function setRef(ref: unknown, el: Element): void {
   if (!ref) return;
-  if (typeof ref === 'function') {
+  if (typeof ref === "function") {
     (ref as (instance: Element | null) => void)(el);
-  } else if (typeof ref === 'object' && 'current' in (ref as object)) {
+  } else if (typeof ref === "object" && "current" in (ref as object)) {
     (ref as { current: unknown }).current = el;
   }
 }
@@ -16,9 +16,9 @@ export function setRef(ref: unknown, el: Element): void {
 /** Clear a $ref (callback with null, or set .current to null). */
 export function clearRef(ref: unknown): void {
   if (!ref) return;
-  if (typeof ref === 'function') {
+  if (typeof ref === "function") {
     (ref as (instance: Element | null) => void)(null);
-  } else if (typeof ref === 'object' && 'current' in (ref as object)) {
+  } else if (typeof ref === "object" && "current" in (ref as object)) {
     (ref as { current: unknown }).current = null;
   }
 }
@@ -58,26 +58,26 @@ export function clearRef(ref: unknown): void {
  */
 export function applyProps(el: HTMLElement, props: Record<string, unknown>): void {
   for (const [key, value] of Object.entries(props)) {
-    if (key.startsWith('$')) continue;
-    if (key.startsWith('on') && typeof value === 'function') {
+    if (key.startsWith("$")) continue;
+    if (key.startsWith("on") && typeof value === "function") {
       addSyntheticListener(el, key.slice(2).toLowerCase(), value as (e: SyntheticEvent) => void);
-    } else if (key === 'className') {
+    } else if (key === "className") {
       el.className = String(value);
-    } else if (key === 'htmlFor') {
-      el.setAttribute('for', String(value));
-    } else if (key === 'style' && typeof value === 'object' && value !== null) {
+    } else if (key === "htmlFor") {
+      el.setAttribute("for", String(value));
+    } else if (key === "style" && typeof value === "object" && value !== null) {
       Object.assign(el.style, value);
     } else if (
-      key === 'value' &&
+      key === "value" &&
       (el instanceof HTMLInputElement ||
         el instanceof HTMLTextAreaElement ||
         el instanceof HTMLSelectElement)
     ) {
       // Use the DOM property so the live value is updated, not just the default
       (el as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value = String(
-        value ?? '',
+        value ?? "",
       );
-    } else if (key === 'checked' && el instanceof HTMLInputElement) {
+    } else if (key === "checked" && el instanceof HTMLInputElement) {
       // Use the DOM property for checkboxes
       el.checked = Boolean(value);
     } else if (value === false) {
@@ -88,20 +88,20 @@ export function applyProps(el: HTMLElement, props: Record<string, unknown>): voi
   }
 
   // Handle $ref on initial mount
-  setRef(props['$ref'], el);
+  setRef(props["$ref"], el);
 
   // Default <button> type to "button" to prevent accidental form submission.
   // The HTML default is "submit", which is almost never the intended behaviour.
-  if (el instanceof HTMLButtonElement && !el.hasAttribute('type')) {
-    el.setAttribute('type', 'button');
+  if (el instanceof HTMLButtonElement && !el.hasAttribute("type")) {
+    el.setAttribute("type", "button");
   }
 
   // Warn when <a target="_blank"> is used without any rel attribute.
   // Without rel the opened page can navigate the opener via window.opener (tab-napping).
   if (
     el instanceof HTMLAnchorElement &&
-    el.getAttribute('target') === '_blank' &&
-    !el.getAttribute('rel')
+    el.getAttribute("target") === "_blank" &&
+    !el.getAttribute("rel")
   ) {
     console.warn(
       'yielderact: <a target="_blank"> is missing rel="noopener". ' +
@@ -134,16 +134,16 @@ export function updateProps(
 ): void {
   // 1. Remove props that no longer exist in nextProps
   for (const key in prevProps) {
-    if (key.startsWith('$')) continue;
+    if (key.startsWith("$")) continue;
     if (key in nextProps) continue;
-    if (key.startsWith('on') && typeof prevProps[key] === 'function') {
+    if (key.startsWith("on") && typeof prevProps[key] === "function") {
       removeSyntheticListener(el, key.slice(2).toLowerCase());
-    } else if (key === 'className') {
-      el.className = '';
-    } else if (key === 'htmlFor') {
-      el.removeAttribute('for');
-    } else if (key === 'style') {
-      el.removeAttribute('style');
+    } else if (key === "className") {
+      el.className = "";
+    } else if (key === "htmlFor") {
+      el.removeAttribute("for");
+    } else if (key === "style") {
+      el.removeAttribute("style");
     } else {
       el.removeAttribute(key);
     }
@@ -151,36 +151,36 @@ export function updateProps(
 
   // 2. Add or update props that changed
   for (const key in nextProps) {
-    if (key.startsWith('$')) continue;
+    if (key.startsWith("$")) continue;
     const next = nextProps[key];
     const prev = prevProps[key];
     if (Object.is(next, prev)) continue;
 
-    if (key.startsWith('on') && typeof next === 'function') {
-      if (typeof prev === 'function') removeSyntheticListener(el, key.slice(2).toLowerCase());
+    if (key.startsWith("on") && typeof next === "function") {
+      if (typeof prev === "function") removeSyntheticListener(el, key.slice(2).toLowerCase());
       addSyntheticListener(el, key.slice(2).toLowerCase(), next as (e: SyntheticEvent) => void);
-    } else if (key === 'style' && typeof next === 'object' && next !== null) {
+    } else if (key === "style" && typeof next === "object" && next !== null) {
       // Clear removed style properties, then apply current ones
-      if (typeof prev === 'object' && prev !== null) {
+      if (typeof prev === "object" && prev !== null) {
         for (const styleProp in prev as Record<string, unknown>) {
           if (!(styleProp in (next as Record<string, unknown>))) {
-            el.style[styleProp as never] = '';
+            el.style[styleProp as never] = "";
           }
         }
       }
       Object.assign(el.style, next);
-    } else if (key === 'className') {
+    } else if (key === "className") {
       el.className = String(next);
-    } else if (key === 'htmlFor') {
-      el.setAttribute('for', String(next));
+    } else if (key === "htmlFor") {
+      el.setAttribute("for", String(next));
     } else if (
-      key === 'value' &&
+      key === "value" &&
       (el instanceof HTMLInputElement ||
         el instanceof HTMLTextAreaElement ||
         el instanceof HTMLSelectElement)
     ) {
-      (el as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value = String(next ?? '');
-    } else if (key === 'checked' && el instanceof HTMLInputElement) {
+      (el as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value = String(next ?? "");
+    } else if (key === "checked" && el instanceof HTMLInputElement) {
       el.checked = Boolean(next);
     } else if (next === false) {
       el.removeAttribute(key);
@@ -190,8 +190,8 @@ export function updateProps(
   }
 
   // 3. Handle $ref changes
-  const prevRef = prevProps['$ref'];
-  const nextRef = nextProps['$ref'];
+  const prevRef = prevProps["$ref"];
+  const nextRef = nextProps["$ref"];
   if (!Object.is(prevRef, nextRef)) {
     clearRef(prevRef);
     setRef(nextRef, el);

--- a/src/render/reconciler.ts
+++ b/src/render/reconciler.ts
@@ -28,48 +28,48 @@
  * yield to the browser for event processing.
  */
 
-import { type VNode, type Child, type AnyComponentFn, type PlainComponentFn } from '../jsx';
 import {
+  _batchCtx,
   _getCtxMap,
-  _setCtxMap,
-  _getProviderCtx,
-  _resolveCtxValue,
   _getCurrentBatch,
   _getCurrentPriority,
+  _getProviderCtx,
   _instanceBatch,
+  _resolveCtxValue,
+  _setCtxMap,
   _withBatch,
   _withPriority,
-  _batchCtx,
   type Context,
-} from '../context';
-import { depsChanged } from '../hooks';
-import { type Slot, type GenInstance } from './types';
-import { renderState } from './state';
-import { applyProps, updateProps } from './props';
+  type UseContextState,
+} from "../context";
+import { depsChanged } from "../hooks";
+import type { AnyComponentFn, Child, PlainComponentFn, VNode } from "../jsx";
 import {
-  isGeneratorFn,
-  shallowEqual,
-  onlyPatchChanged,
   flattenChildren,
-  mergedProps,
+  isGeneratorFn,
   isShown,
+  mergedProps,
+  onlyPatchChanged,
+  shallowEqual,
   stripDeferred,
-} from './helpers';
-import { unmountSlot, propagateContextUpdate } from './hooks-runtime';
-import { type UseContextState } from '../context';
+} from "./helpers";
+import { propagateContextUpdate, unmountSlot } from "./hooks-runtime";
 import {
-  mountGeneratorComponent,
-  mountContextProvider,
-  mountPlainComponent,
   buildNode,
-} from './mount';
+  mountContextProvider,
+  mountGeneratorComponent,
+  mountPlainComponent,
+} from "./mount";
 import {
-  domInsertBefore,
   domAppendChild,
+  domEnqueue,
+  domInsertBefore,
   domRemoveChild,
   domSetText,
-  domEnqueue,
-} from './patch-queue';
+} from "./patch-queue";
+import { applyProps, updateProps } from "./props";
+import { renderState } from "./state";
+import type { GenInstance, Slot } from "./types";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -110,8 +110,8 @@ function removeSlotNodes(parent: Node, slot: Slot): void {
  * Returns `undefined` for primitives, null, false, and VNodes without a key.
  */
 function getChildKey(child: Child): string | undefined {
-  if (child == null || typeof child !== 'object') return undefined;
-  return (child as VNode).props?.$key as string | undefined;
+  if (child == null || typeof child !== "object") return undefined;
+  return (child as VNode).props?.["$key"] as string | undefined;
 }
 
 /**
@@ -174,7 +174,7 @@ function* reconcileKeyedSlotsGen(
   const prevKeyMap = new Map<string | number, number>();
   const nonKeyedPrevIndices: number[] = [];
   for (let i = 0; i < prevSlots.length; i++) {
-    const key = prevSlots[i].props.$key as string | undefined;
+    const key = prevSlots[i]!.props["$key"] as string | undefined;
     if (key !== undefined) {
       prevKeyMap.set(key, i);
     } else {
@@ -188,7 +188,7 @@ function* reconcileKeyedSlotsGen(
   let nonKeyedCursor = 0;
 
   for (let i = 0; i < flatNext.length; i++) {
-    const nextChild = flatNext[i];
+    const nextChild = flatNext[i]!;
     const nextKey = getChildKey(nextChild);
 
     let matchedPrevSlot: Slot | null = null;
@@ -197,15 +197,15 @@ function* reconcileKeyedSlotsGen(
       // Keyed match
       const prevIndex = prevKeyMap.get(nextKey)!;
       if (!usedPrevIndices.has(prevIndex)) {
-        matchedPrevSlot = prevSlots[prevIndex];
+        matchedPrevSlot = prevSlots[prevIndex] ?? null;
         usedPrevIndices.add(prevIndex);
       }
     } else if (nextKey === undefined) {
       // Non-keyed: match positionally against non-keyed prev slots
       while (nonKeyedCursor < nonKeyedPrevIndices.length) {
-        const prevIndex = nonKeyedPrevIndices[nonKeyedCursor++];
+        const prevIndex = nonKeyedPrevIndices[nonKeyedCursor++]!;
         if (!usedPrevIndices.has(prevIndex)) {
-          matchedPrevSlot = prevSlots[prevIndex];
+          matchedPrevSlot = prevSlots[prevIndex] ?? null;
           usedPrevIndices.add(prevIndex);
           break;
         }
@@ -234,8 +234,8 @@ function* reconcileKeyedSlotsGen(
   // Unmount unused prev slots
   for (let i = 0; i < prevSlots.length; i++) {
     if (!usedPrevIndices.has(i)) {
-      unmountSlot(prevSlots[i]);
-      removeSlotNodes(parent, prevSlots[i]);
+      unmountSlot(prevSlots[i]!);
+      removeSlotNodes(parent, prevSlots[i]!);
     }
   }
 
@@ -246,7 +246,7 @@ function* reconcileKeyedSlotsGen(
     if (freshNode) {
       domInsertBefore(parent, freshNode, anchor);
     } else {
-      for (const n of collectSlotDOMNodes(nextSlots[i])) {
+      for (const n of collectSlotDOMNodes(nextSlots[i]!)) {
         domInsertBefore(parent, n, anchor);
       }
     }
@@ -314,7 +314,7 @@ export function* reconcileSlotsGen(
 
   // Remove any extra old DOM nodes (the new list is shorter).
   for (let i = flatNext.length; i < prevSlots.length; i++) {
-    const old = prevSlots[i];
+    const old = prevSlots[i]!;
     unmountSlot(old);
     removeSlotNodes(parent, old);
   }
@@ -411,21 +411,21 @@ function* reconcileOneGen(
     // existing slot is a $patch="live" component (it knows it's live).
     if (renderState.liveOnlyMode && prevSlot) {
       const prevIsLive = prevSlot.genInstance
-        ? ((prevSlot.genInstance.props['$patch'] as 'live' | 'default' | undefined) ??
-            _instanceBatch(prevSlot.genInstance.capturedCtx)) === 'live'
+        ? ((prevSlot.genInstance.props["$patch"] as "live" | "default" | undefined) ??
+            _instanceBatch(prevSlot.genInstance.capturedCtx)) === "live"
         : false;
-      if (_getCurrentBatch() !== 'live' && !prevIsLive) {
+      if (_getCurrentBatch() !== "live" && !prevIsLive) {
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
       }
     }
     // Already empty → reuse.
-    if (prevSlot?.type === 'empty') {
+    if (prevSlot?.type === "empty") {
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
     }
     // Different type was here before → replace with empty placeholder.
-    const node = document.createTextNode('');
+    const node = document.createTextNode("");
     return {
-      slot: { type: 'empty', node, props: {}, childSlots: [], genInstance: null },
+      slot: { type: "empty", node, props: {}, childSlots: [], genInstance: null },
       node,
       replaced: true,
     };
@@ -435,13 +435,13 @@ function* reconcileOneGen(
   // SECTION: Primitive (text / number)
   // Handles: string, number → TextNode.
   // ════════════════════════════════════════════════════════════════════════
-  if (typeof nextChild === 'string' || typeof nextChild === 'number') {
+  if (typeof nextChild === "string" || typeof nextChild === "number") {
     const text = String(nextChild);
-    if (prevSlot?.type === 'text' && prevSlot.node instanceof Text) {
+    if (prevSlot?.type === "text" && prevSlot.node instanceof Text) {
       // Same type (text) → update content in place.
       // In live-only mode, only update when the current batch is live.
       if (
-        (!renderState.liveOnlyMode || _getCurrentBatch() === 'live') &&
+        (!renderState.liveOnlyMode || _getCurrentBatch() === "live") &&
         prevSlot.node.textContent !== text
       ) {
         domSetText(prevSlot.node, text);
@@ -450,13 +450,13 @@ function* reconcileOneGen(
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
     }
     // In live-only default mode, don't insert new text nodes.
-    if (renderState.liveOnlyMode && _getCurrentBatch() !== 'live' && prevSlot) {
+    if (renderState.liveOnlyMode && _getCurrentBatch() !== "live" && prevSlot) {
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
     }
     // Different type was here → replace with new TextNode.
     const node = document.createTextNode(text);
     return {
-      slot: { type: 'text', node, props: { text }, childSlots: [], genInstance: null },
+      slot: { type: "text", node, props: { text }, childSlots: [], genInstance: null },
       node,
       replaced: true,
     };
@@ -474,17 +474,17 @@ function* reconcileOneGen(
     // In live-only mode, only hide when the effective batch is live.
     if (renderState.liveOnlyMode) {
       const effectiveBatch =
-        (allPropsForShown['$patch'] as 'live' | 'default' | undefined) ?? _getCurrentBatch();
-      if (effectiveBatch !== 'live' && prevSlot) {
+        (allPropsForShown["$patch"] as "live" | "default" | undefined) ?? _getCurrentBatch();
+      if (effectiveBatch !== "live" && prevSlot) {
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
       }
     }
-    if (prevSlot?.type === 'empty') {
+    if (prevSlot?.type === "empty") {
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
     }
-    const node = document.createTextNode('');
+    const node = document.createTextNode("");
     return {
-      slot: { type: 'empty', node, props: {}, childSlots: [], genInstance: null },
+      slot: { type: "empty", node, props: {}, childSlots: [], genInstance: null },
       node,
       replaced: true,
     };
@@ -494,7 +494,7 @@ function* reconcileOneGen(
   // SECTION: Function component
   // Handles generator components, plain components, and context Providers.
   // ════════════════════════════════════════════════════════════════════════
-  if (typeof vnode.type === 'function') {
+  if (typeof vnode.type === "function") {
     /** The merged props (including children if any), with $deferred stripped. */
     const allPropsRaw = allPropsForShown;
     const allProps = stripDeferred(allPropsRaw);
@@ -505,7 +505,7 @@ function* reconcileOneGen(
 
     // Propagate $deferred to the subtree via context.
     // Save and restore the context map so siblings are unaffected.
-    const compDeferred = allPropsRaw['$deferred'] as boolean | undefined;
+    const compDeferred = allPropsRaw["$deferred"] as boolean | undefined;
     const prevCtxComp = _getCtxMap();
     if (compDeferred) _setCtxMap(_withPriority(prevCtxComp, _getCurrentPriority() + 1));
     try {
@@ -520,7 +520,7 @@ function* reconcileOneGen(
           const inst = prevSlot.genInstance;
           if (patchOnly && inst) {
             // Forward the new $patch value so shouldDefer reads it correctly.
-            inst.props['$patch'] = allProps['$patch'];
+            inst.props["$patch"] = allProps["$patch"];
             if (inst.consumedContexts.has(_batchCtx as Context<unknown>)) {
               prevSlot.props = allProps;
               inst.capturedCtx = _withBatch(inst.capturedCtx, _getCurrentBatch());
@@ -560,19 +560,19 @@ function* reconcileOneGen(
         // └─────────────────────────────────────────────────────────────────┘
         if (renderState.liveOnlyMode) {
           const effectiveBatch =
-            (allProps['$patch'] as 'live' | 'default' | undefined) ?? _getCurrentBatch();
-          if (effectiveBatch !== 'live') {
+            (allProps["$patch"] as "live" | "default" | undefined) ?? _getCurrentBatch();
+          if (effectiveBatch !== "live") {
             if (prevSlot.genInstance) {
               prevSlot.genInstance.capturedCtx = _withBatch(
                 prevSlot.genInstance.capturedCtx,
                 _getCurrentBatch(),
               );
-              prevSlot.genInstance.props['$patch'] = allProps['$patch'];
+              prevSlot.genInstance.props["$patch"] = allProps["$patch"];
             }
             if (!providerCtx) {
               const hasContentChange = Object.keys({ ...prevSlot.props, ...allProps }).some(
                 (k) =>
-                  k !== '$patch' && k !== '$shown' && !Object.is(prevSlot.props[k], allProps[k]),
+                  k !== "$patch" && k !== "$shown" && !Object.is(prevSlot.props[k], allProps[k]),
               );
               if (!hasContentChange) prevSlot.props = allProps;
             }
@@ -586,11 +586,11 @@ function* reconcileOneGen(
         if (providerCtx) {
           const prevCtxMap = _getCtxMap();
           const newCtxMap = new Map(prevCtxMap);
-          newCtxMap.set(providerCtx as never, allProps.value as unknown);
+          newCtxMap.set(providerCtx as never, allProps["value"] as unknown);
           _setCtxMap(newCtxMap);
           try {
-            if (!Object.is(prevSlot.props['value'], allProps['value'])) {
-              propagateContextUpdate(providerCtx, allProps.value, prevSlot.childSlots);
+            if (!Object.is(prevSlot.props["value"], allProps["value"])) {
+              propagateContextUpdate(providerCtx, allProps["value"], prevSlot.childSlots);
             }
             const childVNode = (fn as PlainComponentFn)(allProps);
             if (childVNode != null) {
@@ -632,12 +632,12 @@ function* reconcileOneGen(
       // └───────────────────────────────────────────────────────────────────┘
       if (renderState.liveOnlyMode && prevSlot?.type !== vnode.type) {
         const effectiveBatch =
-          (allProps['$patch'] as 'live' | 'default' | undefined) ?? _getCurrentBatch();
-        if (effectiveBatch !== 'live') {
+          (allProps["$patch"] as "live" | "default" | undefined) ?? _getCurrentBatch();
+        if (effectiveBatch !== "live") {
           if (prevSlot) return { slot: prevSlot, node: prevSlot.node, replaced: false };
-          const node = document.createTextNode('');
+          const node = document.createTextNode("");
           return {
-            slot: { type: 'empty', node, props: {}, childSlots: [], genInstance: null },
+            slot: { type: "empty", node, props: {}, childSlots: [], genInstance: null },
             node,
             replaced: true,
           };
@@ -696,18 +696,18 @@ function* reconcileOneGen(
   // SECTION: HTML element
   // Handles: string tag names (e.g. 'div', 'span').
   // ════════════════════════════════════════════════════════════════════════
-  if (typeof vnode.type === 'string') {
+  if (typeof vnode.type === "string") {
     // Propagate $patch and $deferred to children via the context map.
     // Save and restore the context map around child reconciliation.
-    const elBatch = vnode.props['$patch'] as 'live' | 'default' | undefined;
-    const elDeferred = vnode.props['$deferred'] as boolean | undefined;
+    const elBatch = vnode.props["$patch"] as "live" | "default" | undefined;
+    const elDeferred = vnode.props["$deferred"] as boolean | undefined;
     const prevCtxEl = _getCtxMap();
     if (elBatch !== undefined) _setCtxMap(_withBatch(prevCtxEl, elBatch));
     if (elDeferred) _setCtxMap(_withPriority(_getCtxMap(), _getCurrentPriority() + 1));
     try {
       if (prevSlot?.type === vnode.type && prevSlot.node instanceof HTMLElement) {
         // ── Same tag → update props in place and reconcile children ──
-        if (!renderState.liveOnlyMode || _getCurrentBatch() === 'live') {
+        if (!renderState.liveOnlyMode || _getCurrentBatch() === "live") {
           const prevProps = prevSlot.props;
           domEnqueue(
             () => updateProps(prevSlot.node as HTMLElement, prevProps, vnode.props),
@@ -723,11 +723,11 @@ function* reconcileOneGen(
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
       }
       // ── Different tag → build fresh element ──
-      if (renderState.liveOnlyMode && _getCurrentBatch() !== 'live') {
+      if (renderState.liveOnlyMode && _getCurrentBatch() !== "live") {
         if (prevSlot) return { slot: prevSlot, node: prevSlot.node, replaced: false };
-        const empty = document.createTextNode('');
+        const empty = document.createTextNode("");
         return {
-          slot: { type: 'empty', node: empty, props: {}, childSlots: [], genInstance: null },
+          slot: { type: "empty", node: empty, props: {}, childSlots: [], genInstance: null },
           node: empty,
           replaced: true,
         };
@@ -783,12 +783,12 @@ function _hasStableContextSelectors(
   ctx: Context<unknown>,
   newValue: unknown,
 ): boolean {
-  let foundAny = false;
+  let _foundAny = false;
   for (const s of inst.hookStates) {
-    if (s == null || typeof s !== 'object') continue;
+    if (s == null || typeof s !== "object") continue;
     const state = s as UseContextState;
     if (state.ctx !== ctx) continue;
-    foundAny = true;
+    _foundAny = true;
     if (!state.selector) return false;
     const newDeps = state.selector(newValue);
     if (depsChanged(state.lastDeps, newDeps)) return false;

--- a/src/render/scheduler.ts
+++ b/src/render/scheduler.ts
@@ -24,10 +24,10 @@
  * effects or context propagation is processed immediately).
  */
 
-import { _getCtxMap, _setCtxMap } from '../context';
-import { renderState } from './state';
-import { beginPatch, commitPatch, savePatchOps, restorePatchOps } from './patch-queue';
-import type { GenInstance } from './types';
+import { _getCtxMap, _setCtxMap } from "../context";
+import { beginPatch, commitPatch, restorePatchOps, savePatchOps } from "./patch-queue";
+import { renderState } from "./state";
+import type { GenInstance } from "./types";
 
 // ── Scheduler state ──────────────────────────────────────────────────────────
 
@@ -53,7 +53,7 @@ let _activePriority: number | null = null;
 let _syncMode = true;
 
 /** Time budget per work chunk in milliseconds. */
-let _timeSlice = 5;
+const _timeSlice = 5;
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
@@ -264,7 +264,7 @@ function _yieldToBrowser(): void {
   const savedCtxMap = _getCtxMap();
   const savedLiveOnlyMode = renderState.liveOnlyMode;
 
-  if (typeof MessageChannel !== 'undefined') {
+  if (typeof MessageChannel !== "undefined") {
     const mc = new MessageChannel();
     mc.port1.onmessage = () => {
       _setCtxMap(savedCtxMap);

--- a/src/render/state.ts
+++ b/src/render/state.ts
@@ -1,4 +1,4 @@
-import { type GenInstance } from './types';
+import type { GenInstance } from "./types";
 
 /**
  * Shared mutable render state.

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -1,5 +1,5 @@
-import { type VNode, type Child, type GeneratorComponentFn } from '../jsx';
-import { type Context } from '../context';
+import type { Context } from "../context";
+import type { Child, GeneratorComponentFn, VNode } from "../jsx";
 
 /**
  * A **Slot** tracks one reconciled position in the rendered DOM tree.
@@ -23,7 +23,7 @@ export interface Slot {
    *
    * Used by `reconcileOne` to detect same-type matches (reuse) vs type changes (replace).
    */
-  type: VNode['type'] | 'text' | 'empty';
+  type: VNode["type"] | "text" | "empty";
 
   /**
    * The real DOM node for this position.
@@ -239,7 +239,7 @@ export interface GenInstance {
    */
   pendingEffects: Array<{
     hookIndex: number;
-    fn: (signal: AbortSignal) => (() => void) | void;
+    fn: (signal: AbortSignal) => (() => void) | undefined;
     controller: AbortController;
   }>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "jsxFactory": "createElement",
     "jsxFragmentFactory": "Fragment",
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/vite-plugin-yielderact.ts
+++ b/vite-plugin-yielderact.ts
@@ -46,7 +46,7 @@
  * When using the published npm package this alias is not necessary because the
  * package ships a `./jsx-dev-runtime` export that maps to the same module.
  */
-import type { Plugin } from 'vite';
+import type { Plugin } from "vite";
 
 /**
  * Returns a Vite plugin that configures the esbuild JSX transform to use
@@ -54,12 +54,12 @@ import type { Plugin } from 'vite';
  */
 export function yielderactPlugin(): Plugin {
   return {
-    name: 'vite-plugin-yielderact',
+    name: "vite-plugin-yielderact",
     config() {
       return {
         esbuild: {
-          jsx: 'automatic',
-          jsxImportSource: 'yielderact',
+          jsx: "automatic",
+          jsxImportSource: "yielderact",
         },
       };
     },


### PR DESCRIPTION
## Summary

Replace Prettier with Biome for linting and formatting, and enable stricter TypeScript compiler options (`noUncheckedIndexedAccess`, `noPropertyAccessFromIndexSignature`). This is PR 1 of the codebase refactor plan (issue #71).

## Changes

- **Biome setup:** Added `biome.json` with recommended rules + custom rules from the issue #71 spec. Configured VCS integration to respect `.gitignore`.
- **Prettier removal:** Removed `prettier` devDependency and `.prettierrc`. All formatting now handled by Biome.
- **Package.json scripts:** Added `lint`, `lint:fix`, `format`, `format:check` scripts using Biome.
- **TypeScript strict options:** Enabled `noUncheckedIndexedAccess` and `noPropertyAccessFromIndexSignature` in `tsconfig.json`.
- **Build fixes:** Fixed all TS compilation errors from stricter settings across `src/` (bracket notation for index signature access, non-null assertions for bounded array indexing).
- **Test fixes:** Fixed TS errors in all 18 test suites (unused variables, array index assertions, effect callback return types).
- **Lint fixes:** Auto-fixed import sorting, quote style, unused imports across 87 files. Manually fixed unused variables, parameter reassignment, and template literal usage.
- **CI:** Updated `.github/workflows/ci.yml` to use `npm run lint` (Biome) instead of Prettier format check.
- **CLAUDE.md:** Updated execution policy, development commands, and coding standards to reflect Biome tooling.

### Rule decisions

| Rule | Setting | Reason |
|------|---------|--------|
| `noNonNullAssertion` | `warn` | 395+ instances; will be promoted to `error` in PR 2 (hook state types) |
| `useYield` | `off` | False positive — yielderact generator components can validly return without yielding |
| `useLiteralKeys` | `off` | Conflicts with `noPropertyAccessFromIndexSignature` (TS requires bracket notation for index sigs) |
| `useButtonType` | `off` | yielderact defaults `<button>` type to `"button"` at framework level (`src/render/props.ts`) |
| `useExhaustiveDependencies` | `off` | Not applicable — yielderact hooks use a different deps model than React |

Closes #71 (partial — PR 1 of 5)

## Verification

- `npm run lint` — 0 errors, warnings only
- `npm run build` — passes
- `npm test` — 197 tests pass (18 suites)
- `npm run test:visual` — 57 tests pass

## CLAUDE.md Update

Yes — updated execution policy step 2, added new script documentation, added Biome/TypeScript notes to coding standards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)