### PR TITLE
refactor: HookState discriminated union + type helpers

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -155,6 +155,7 @@ export function* $context<T, D extends unknown[], R>(
  * @internal
  */
 export type UseContextState = {
+  kind: "context";
   /** The context object this hook subscribes to. */
   ctx: Context<unknown>;
   /** Optional selector function — extracts deps from the context value. */
@@ -179,6 +180,7 @@ export function _processContext(descriptor: { [key: string]: unknown }, ctx: Hoo
 
   if (!selector) {
     hookStates[hookIndex] = {
+      kind: "context",
       ctx: context,
       selector: undefined,
       transform: undefined,
@@ -189,12 +191,18 @@ export function _processContext(descriptor: { [key: string]: unknown }, ctx: Hoo
   }
 
   const newDeps = selector(rawValue);
-  const prev = hookStates[hookIndex] as UseContextState | undefined;
-  if (prev?.selector && !depsChanged(prev.lastDeps, newDeps)) {
+  const prev = hookStates[hookIndex];
+  if (
+    prev !== undefined &&
+    prev.kind === "context" &&
+    prev.selector &&
+    !depsChanged(prev.lastDeps, newDeps)
+  ) {
     return prev.lastResult;
   }
   const result = transform ? transform(...newDeps) : rawValue;
   hookStates[hookIndex] = {
+    kind: "context",
     ctx: context,
     selector,
     transform,

--- a/src/hooks/$effect.ts
+++ b/src/hooks/$effect.ts
@@ -38,28 +38,25 @@ export function* $effect(
 
 /** @internal */
 export function _processEffect(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
-  type EffectState = {
-    deps: unknown[];
-    cleanup: (() => void) | undefined;
-    controller: AbortController;
-  };
   const { hookIndex, hookStates, cleanupFns, pendingEffects } = ctx;
   const fn = descriptor["fn"] as (signal: AbortSignal) => (() => void) | undefined;
   const deps = descriptor["deps"] as unknown[];
-  const existing = hookStates[hookIndex] as EffectState | undefined;
+  const existing = hookStates[hookIndex];
 
-  if (!existing || depsChanged(existing.deps, deps)) {
-    if (existing) {
+  if (existing === undefined || existing.kind !== "effect" || depsChanged(existing.deps, deps)) {
+    if (existing !== undefined && existing.kind === "effect") {
       existing.controller.abort();
       existing.cleanup?.();
     }
     const controller = new AbortController();
-    hookStates[hookIndex] = { deps, cleanup: undefined, controller } satisfies EffectState;
+    hookStates[hookIndex] = { kind: "effect", deps, cleanup: undefined, controller };
     pendingEffects.push({ hookIndex, fn, controller });
     cleanupFns[hookIndex] = () => {
-      const state = hookStates[hookIndex] as EffectState;
-      state.controller.abort();
-      state.cleanup?.();
+      const state = hookStates[hookIndex];
+      if (state !== undefined && state.kind === "effect") {
+        state.controller.abort();
+        state.cleanup?.();
+      }
     };
   }
   return undefined;

--- a/src/hooks/$id.ts
+++ b/src/hooks/$id.ts
@@ -28,8 +28,11 @@ export function* $id(): Generator<unknown, string, unknown> {
 /** @internal */
 export function _processId(ctx: HookContext): unknown {
   const { hookIndex, hookStates } = ctx;
-  if (!(hookIndex in hookStates)) {
-    hookStates[hookIndex] = `:r${renderState.idCounter++}:`;
+  const existing = hookStates[hookIndex];
+  if (existing === undefined || existing.kind !== "id") {
+    const newState = { kind: "id" as const, id: `:r${renderState.idCounter++}:` };
+    hookStates[hookIndex] = newState;
+    return newState.id;
   }
-  return hookStates[hookIndex];
+  return existing.id;
 }

--- a/src/hooks/$memo.ts
+++ b/src/hooks/$memo.ts
@@ -36,9 +36,11 @@ export function _processMemo(descriptor: { [key: string]: unknown }, ctx: HookCo
   const { hookIndex, hookStates } = ctx;
   const fn = descriptor["fn"] as (...args: unknown[]) => unknown;
   const deps = descriptor["deps"] as unknown[];
-  const existing = hookStates[hookIndex] as { value: unknown; deps: unknown[] } | undefined;
-  if (!existing || depsChanged(existing.deps, deps)) {
-    hookStates[hookIndex] = { value: fn(...deps), deps };
+  const existing = hookStates[hookIndex];
+  if (existing === undefined || existing.kind !== "memo" || depsChanged(existing.deps, deps)) {
+    const newState = { kind: "memo" as const, value: fn(...deps), deps };
+    hookStates[hookIndex] = newState;
+    return newState.value;
   }
-  return (hookStates[hookIndex] as { value: unknown }).value;
+  return existing.value;
 }

--- a/src/hooks/$ref.ts
+++ b/src/hooks/$ref.ts
@@ -29,8 +29,11 @@ export function* $ref<T>(initialValue: T): Generator<unknown, RefObject<T>, unkn
 /** @internal */
 export function _processRef(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates } = ctx;
-  if (!(hookIndex in hookStates)) {
-    hookStates[hookIndex] = { current: descriptor["initialValue"] };
+  const existing = hookStates[hookIndex];
+  if (existing === undefined || existing.kind !== "ref") {
+    const newState = { kind: "ref" as const, current: descriptor["initialValue"] };
+    hookStates[hookIndex] = newState;
+    return newState;
   }
-  return hookStates[hookIndex];
+  return existing;
 }

--- a/src/hooks/$render.ts
+++ b/src/hooks/$render.ts
@@ -17,6 +17,7 @@ export type UseRenderFn<T> = (props: { resume: (value: T) => void }) => Child;
  * @internal
  */
 export type UseRenderState<T> = {
+  kind: "render";
   status: "waiting" | "resolved";
   deps: unknown[];
   value: T | undefined;
@@ -160,10 +161,12 @@ export function* $resume<T>(): Generator<unknown, (value: T) => void, unknown> {
 export function _processRender(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, resume } = ctx;
   const deps = descriptor["deps"] as unknown[];
-  let slot = hookStates[hookIndex] as UseRenderState<unknown> | undefined;
+  const existing = hookStates[hookIndex];
+  let slot: UseRenderState<unknown>;
 
-  if (!slot || depsChanged(slot.deps, deps)) {
+  if (existing === undefined || existing.kind !== "render" || depsChanged(existing.deps, deps)) {
     const newSlot: UseRenderState<unknown> = {
+      kind: "render",
       status: "waiting",
       deps,
       value: undefined,
@@ -171,8 +174,8 @@ export function _processRender(descriptor: { [key: string]: unknown }, ctx: Hook
     };
     hookStates[hookIndex] = newSlot;
     newSlot.resumeCallback = (value: unknown): void => {
-      const s = hookStates[hookIndex] as UseRenderState<unknown>;
-      if (s.status === "waiting") {
+      const s = hookStates[hookIndex];
+      if (s !== undefined && s.kind === "render" && s.status === "waiting") {
         s.status = "resolved";
         s.value = value;
         resume();
@@ -180,7 +183,8 @@ export function _processRender(descriptor: { [key: string]: unknown }, ctx: Hook
     };
     slot = newSlot;
   } else {
-    slot.status = "waiting";
+    existing.status = "waiting";
+    slot = existing;
   }
 
   return { slot, resumeCallback: slot.resumeCallback };

--- a/src/hooks/$resolve.ts
+++ b/src/hooks/$resolve.ts
@@ -115,59 +115,61 @@ export function _processResolveRaw(
   descriptor: { [key: string]: unknown },
   ctx: HookContext,
 ): unknown {
-  type RawState =
-    | { promise: Promise<unknown>; status: "pending" }
-    | { promise: Promise<unknown>; status: "resolved"; data: unknown }
-    | { promise: Promise<unknown>; status: "rejected"; error: unknown };
-
   const { hookIndex, hookStates, rerender } = ctx;
   const promise = descriptor["promise"] as Promise<unknown>;
-  const existing = hookStates[hookIndex] as RawState | undefined;
+  const existing = hookStates[hookIndex];
 
-  if (!existing || existing.promise !== promise) {
-    const state: RawState = { promise, status: "pending" };
+  if (existing === undefined || existing.kind !== "resolve-raw" || existing.promise !== promise) {
+    const state: import("../render/types").ResolveRawHookState = {
+      kind: "resolve-raw",
+      promise,
+      status: "pending",
+    };
     hookStates[hookIndex] = state;
     promise.then(
       (data) => {
         if (hookStates[hookIndex] === state) {
-          hookStates[hookIndex] = { promise, status: "resolved", data };
+          hookStates[hookIndex] = { kind: "resolve-raw", promise, status: "resolved", data };
           rerender();
         }
       },
-      (error) => {
+      (error: unknown) => {
         if (hookStates[hookIndex] === state) {
-          hookStates[hookIndex] = { promise, status: "rejected", error };
+          hookStates[hookIndex] = { kind: "resolve-raw", promise, status: "rejected", error };
           rerender();
         }
       },
     );
   }
 
-  const s = hookStates[hookIndex] as RawState;
-  if (s.status === "resolved")
-    return { data: s.data, loading: false, error: undefined } as ResolveRawResult<unknown>;
-  if (s.status === "rejected")
-    return { data: undefined, loading: false, error: s.error } as ResolveRawResult<unknown>;
-  return { data: undefined, loading: true, error: undefined } as ResolveRawResult<unknown>;
+  const s = hookStates[hookIndex];
+  if (s !== undefined && s.kind === "resolve-raw") {
+    if (s.status === "resolved")
+      return { data: s.data, loading: false, error: undefined } satisfies ResolveRawResult<unknown>;
+    if (s.status === "rejected")
+      return {
+        data: undefined,
+        loading: false,
+        error: s.error,
+      } satisfies ResolveRawResult<unknown>;
+  }
+  return { data: undefined, loading: true, error: undefined } satisfies ResolveRawResult<unknown>;
 }
 
 /** @internal */
 export function _processResolve(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
-  type ResolveState = {
-    deps: unknown[];
-    promise: Promise<unknown>;
-    controller: AbortController;
-  };
   const { hookIndex, hookStates, cleanupFns } = ctx;
   const fn = descriptor["fn"] as (signal: AbortSignal) => Promise<unknown>;
   const deps = descriptor["deps"] as unknown[];
-  const existing = hookStates[hookIndex] as ResolveState | undefined;
+  const existing = hookStates[hookIndex];
 
-  if (!existing || depsChanged(existing.deps, deps)) {
-    existing?.controller.abort();
+  if (existing === undefined || existing.kind !== "resolve" || depsChanged(existing.deps, deps)) {
+    if (existing !== undefined && existing.kind === "resolve") {
+      existing.controller.abort();
+    }
     const controller = new AbortController();
     const promise = fn(controller.signal);
-    hookStates[hookIndex] = { deps, promise, controller } satisfies ResolveState;
+    hookStates[hookIndex] = { kind: "resolve", deps, promise, controller };
     cleanupFns[hookIndex] = () => controller.abort();
     return promise;
   }

--- a/src/hooks/$state.ts
+++ b/src/hooks/$state.ts
@@ -37,16 +37,22 @@ export function* $state<T>(
 /** @internal */
 export function _processState(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, rerender } = ctx;
-  if (!(hookIndex in hookStates)) {
+  const existing = hookStates[hookIndex];
+  if (existing === undefined || existing.kind !== "state") {
     const init = descriptor["initialValue"];
-    hookStates[hookIndex] = typeof init === "function" ? (init as () => unknown)() : init;
+    hookStates[hookIndex] = {
+      kind: "state",
+      value: typeof init === "function" ? (init as () => unknown)() : init,
+    };
   }
+  // SAFETY: We just ensured hookStates[hookIndex] is a StateHookState above.
+  const stateObj = hookStates[hookIndex] as import("../render/types").StateHookState;
   const setter = (newValue: unknown): Promise<void> => {
-    hookStates[hookIndex] =
+    stateObj.value =
       typeof newValue === "function"
-        ? (newValue as (prev: unknown) => unknown)(hookStates[hookIndex])
+        ? (newValue as (prev: unknown) => unknown)(stateObj.value)
         : newValue;
     return rerender();
   };
-  return [hookStates[hookIndex], setter];
+  return [stateObj.value, setter];
 }

--- a/src/hooks/$ui-patch.ts
+++ b/src/hooks/$ui-patch.ts
@@ -45,8 +45,9 @@ export function* $uiPatch(): Generator<unknown, () => () => void, unknown> {
 /** @internal */
 export function _processUIPatch(ctx: HookContext): unknown {
   const { hookIndex, hookStates, instance, collectDescendants, flushPendingVNodes } = ctx;
-  if (!(hookIndex in hookStates)) {
-    hookStates[hookIndex] = (): (() => void) => {
+  const existing = hookStates[hookIndex];
+  if (existing === undefined || existing.kind !== "ui-patch") {
+    const startPatch = (): (() => void) => {
       const snapshot = collectDescendants(instance);
 
       instance.localPatchRefCount++;
@@ -60,6 +61,8 @@ export function _processUIPatch(ctx: HookContext): unknown {
         flushPendingVNodes([instance, ...snapshot]);
       };
     };
+    hookStates[hookIndex] = { kind: "ui-patch", startPatch };
+    return startPatch;
   }
-  return hookStates[hookIndex];
+  return existing.startPatch;
 }

--- a/src/hooks/symbols.ts
+++ b/src/hooks/symbols.ts
@@ -1,4 +1,4 @@
-import type { GenInstance } from "../render/types";
+import type { GenInstance, HookState } from "../render/types";
 
 /**
  * Parameters provided to hook handler functions by the renderer.
@@ -6,7 +6,7 @@ import type { GenInstance } from "../render/types";
  */
 export interface HookContext {
   hookIndex: number;
-  hookStates: unknown[];
+  hookStates: HookState[];
   cleanupFns: ((() => void) | undefined)[];
   pendingEffects: Array<{
     hookIndex: number;

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -7,6 +7,19 @@ import {
 } from "../jsx";
 
 /**
+ * Type guard: returns `true` when `child` is a VNode (an object with a `type` field).
+ *
+ * Narrows the `Child` union (`VNode | string | number | boolean | null | undefined`)
+ * to `VNode`, eliminating the need for `as VNode` casts after the check.
+ *
+ * **Called by:** `flattenChildren` (to detect Fragment wrappers), and the
+ * reconciler (to narrow children before type-specific handling).
+ */
+export function isVNode(child: Child): child is VNode {
+  return child !== null && child !== undefined && typeof child === "object";
+}
+
+/**
  * Returns true when `fn` is a generator function (i.e. uses `function*`).
  *
  * **Called by:**
@@ -90,8 +103,8 @@ export function onlyPatchChanged(a: Record<string, unknown>, b: Record<string, u
 export function flattenChildren(children: Child[]): Child[] {
   const result: Child[] = [];
   for (const child of children) {
-    if (child != null && typeof child === "object" && (child as VNode).type === Fragment) {
-      result.push(...flattenChildren((child as VNode).children));
+    if (isVNode(child) && child.type === Fragment) {
+      result.push(...flattenChildren(child.children));
     } else {
       result.push(child);
     }
@@ -117,6 +130,20 @@ export function flattenChildren(children: Child[]): Child[] {
  */
 export function mergedProps(vnode: VNode): Record<string, unknown> {
   return vnode.children.length > 0 ? { ...vnode.props, $children: vnode.children } : vnode.props;
+}
+
+/**
+ * Read the `$patch` mode from a props object.
+ *
+ * Returns `'live'`, `'default'`, or `undefined` (when not set).
+ * Avoids the `as "live" | "default" | undefined` cast that would otherwise
+ * be needed at every call site.
+ *
+ * **Called by:** reconciler and mount — whenever the effective batch behaviour
+ * needs to be determined from a VNode's props.
+ */
+export function getPatchMode(props: Record<string, unknown>): "live" | "default" | undefined {
+  return props["$patch"] as "live" | "default" | undefined;
 }
 
 /**

--- a/src/render/hooks-runtime.ts
+++ b/src/render/hooks-runtime.ts
@@ -12,13 +12,7 @@
  * collection, and context propagation.
  */
 
-import {
-  _getProviderCtx,
-  _processContext,
-  $CONTEXT,
-  type Context,
-  type UseContextState,
-} from "../context";
+import { _getProviderCtx, _processContext, $CONTEXT, type Context } from "../context";
 import {
   $EFFECT,
   $ID,
@@ -44,7 +38,7 @@ import type { Child } from "../jsx";
 import { _flushPendingVNodes } from "./patch";
 import { clearRef } from "./props";
 import { renderState } from "./state";
-import type { GenInstance, Slot } from "./types";
+import type { GenInstance, HookState, Slot } from "./types";
 
 /**
  * Set of all known hook descriptor type symbols for fast membership test.
@@ -111,9 +105,10 @@ export function flushEffects(instance: GenInstance): void {
   if (instance.gen !== null) return;
   for (const { hookIndex, fn, controller } of instance.pendingEffects) {
     const cleanup = fn(controller.signal);
-    (
-      instance.hookStates[hookIndex] as { deps: unknown[]; cleanup: (() => void) | undefined }
-    ).cleanup = cleanup;
+    const state = instance.hookStates[hookIndex];
+    if (state !== undefined && state.kind === "effect") {
+      state.cleanup = cleanup;
+    }
   }
   instance.pendingEffects.length = 0;
 }
@@ -207,7 +202,7 @@ export function collectDescendants(instance: GenInstance): GenInstance[] {
 export function processOneDescriptor(
   descriptor: { type: symbol; [key: string]: unknown },
   hookIndex: number,
-  hookStates: unknown[],
+  hookStates: HookState[],
   cleanupFns: ((() => void) | undefined)[],
   pendingEffects: Array<{
     hookIndex: number;
@@ -343,12 +338,11 @@ export function runHooks(
  */
 function _hasStableSelectors(inst: GenInstance, ctx: Context<unknown>, newValue: unknown): boolean {
   for (const s of inst.hookStates) {
-    if (s == null || typeof s !== "object") continue;
-    const state = s as UseContextState;
-    if (state.ctx !== ctx) continue;
-    if (!state.selector) return false;
-    const newDeps = state.selector(newValue);
-    if (depsChanged(state.lastDeps, newDeps)) return false;
+    if (s === undefined || s.kind !== "context") continue;
+    if (s.ctx !== ctx) continue;
+    if (!s.selector) return false;
+    const newDeps = s.selector(newValue);
+    if (depsChanged(s.lastDeps, newDeps)) return false;
   }
   return true;
 }

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -33,14 +33,14 @@ import {
   type GeneratorComponentFn,
   type PlainComponentFn,
 } from "../jsx";
-import { isGeneratorFn, isShown, mergedProps, stripDeferred } from "./helpers";
+import { getPatchMode, isGeneratorFn, isShown, mergedProps, stripDeferred } from "./helpers";
 import { flushEffects, runHooks } from "./hooks-runtime";
 import { isPatchActive } from "./patch-queue";
 import { applyProps } from "./props";
 import { reconcileSlots } from "./reconciler";
 import { scheduleUpdate } from "./scheduler";
 import { renderState } from "./state";
-import type { GenInstance, Slot } from "./types";
+import type { GenInstance, HookState, Slot } from "./types";
 
 /**
  * Build a single real DOM node from a virtual DOM node (or primitive value).
@@ -114,7 +114,7 @@ export function buildNode(child: Child): Node {
   // HTML element — propagate $patch and $deferred to children via context.
   const el = document.createElement(child.type as string);
   applyProps(el, child.props);
-  const elBatch = child.props["$patch"] as "live" | "default" | undefined;
+  const elBatch = getPatchMode(child.props);
   const elDeferred = child.props["$deferred"] as boolean | undefined;
   const prevCtxBuildNode = _getCtxMap();
   if (elBatch !== undefined) _setCtxMap(_withBatch(prevCtxBuildNode, elBatch));
@@ -138,9 +138,7 @@ export function buildNode(child: Child): Node {
  */
 function commitOrDefer(instance: GenInstance, vnode: Child): void {
   const parent = instance.endMarker.parentNode as HTMLElement;
-  const effectiveBatch =
-    (instance.props["$patch"] as "live" | "default" | undefined) ??
-    _instanceBatch(instance.capturedCtx);
+  const effectiveBatch = getPatchMode(instance.props) ?? _instanceBatch(instance.capturedCtx);
   const shouldDefer =
     (renderState.patchDepth > 0 || instance.localPatchRefCount > 0) && effectiveBatch !== "live";
   if (shouldDefer) {
@@ -201,7 +199,7 @@ export function mountGeneratorComponent(
   const priority = _getCurrentPriority();
 
   /** Per-hook persistent state array. See `GenInstance.hookStates`. */
-  const hookStates: unknown[] = [];
+  const hookStates: HookState[] = [];
 
   /** Per-hook cleanup functions. See `GenInstance.cleanupFns`. */
   const cleanupFns: ((() => void) | undefined)[] = [];
@@ -242,7 +240,7 @@ export function mountGeneratorComponent(
 
     // Restore context: inherited context + own $patch applied for children.
     const prevCtx = _getCtxMap();
-    const ownPatchResume = instance.props["$patch"] as "live" | "default" | undefined;
+    const ownPatchResume = getPatchMode(instance.props);
     _setCtxMap(
       ownPatchResume !== undefined
         ? _withBatch(instance.capturedCtx, ownPatchResume)
@@ -307,7 +305,7 @@ export function mountGeneratorComponent(
 
       // Restore context: inherited context + own $patch for children.
       const prevCtx = _getCtxMap();
-      const ownPatch = instance.props["$patch"] as "live" | "default" | undefined;
+      const ownPatch = getPatchMode(instance.props);
       _setCtxMap(
         ownPatch !== undefined ? _withBatch(instance.capturedCtx, ownPatch) : instance.capturedCtx,
       );
@@ -332,8 +330,10 @@ export function mountGeneratorComponent(
         // Revert deps for effects queued during this cancelled render so the
         // retry re-queues them (their deps in hookStates already match).
         for (const pe of instance.pendingEffects) {
-          const state = instance.hookStates[pe.hookIndex] as { deps: unknown[] } | undefined;
-          if (state) state.deps = [];
+          const state = instance.hookStates[pe.hookIndex];
+          if (state !== undefined && state.kind === "effect") {
+            state.deps = [];
+          }
         }
         // A mid-render setState was queued — retry with the accumulated state.
         instance.pendingRerender = false;

--- a/src/render/patch.ts
+++ b/src/render/patch.ts
@@ -1,4 +1,5 @@
 import { _getCtxMap, _setCtxMap, _withBatch } from "../context";
+import { getPatchMode } from "./helpers";
 import { flushEffects } from "./hooks-runtime";
 import { reconcileSlots } from "./reconciler";
 import { renderState } from "./state";
@@ -35,7 +36,7 @@ export function _flushPendingVNodes(instances: GenInstance[]): void {
 
     const prevCtx = _getCtxMap();
     // Restore inherited context, then apply own $patch for children.
-    const ownPatch = inst.props["$patch"] as "live" | "default" | undefined;
+    const ownPatch = getPatchMode(inst.props);
     _setCtxMap(ownPatch !== undefined ? _withBatch(inst.capturedCtx, ownPatch) : inst.capturedCtx);
     const parent = inst.endMarker.parentNode as HTMLElement;
     try {

--- a/src/render/reconciler.ts
+++ b/src/render/reconciler.ts
@@ -40,14 +40,15 @@ import {
   _withBatch,
   _withPriority,
   type Context,
-  type UseContextState,
 } from "../context";
 import { depsChanged } from "../hooks";
 import type { AnyComponentFn, Child, PlainComponentFn, VNode } from "../jsx";
 import {
   flattenChildren,
+  getPatchMode,
   isGeneratorFn,
   isShown,
+  isVNode,
   mergedProps,
   onlyPatchChanged,
   shallowEqual,
@@ -110,8 +111,8 @@ function removeSlotNodes(parent: Node, slot: Slot): void {
  * Returns `undefined` for primitives, null, false, and VNodes without a key.
  */
 function getChildKey(child: Child): string | undefined {
-  if (child == null || typeof child !== "object") return undefined;
-  return (child as VNode).props?.["$key"] as string | undefined;
+  if (!isVNode(child)) return undefined;
+  return child.props["$key"] as string | undefined;
 }
 
 /**
@@ -411,7 +412,7 @@ function* reconcileOneGen(
     // existing slot is a $patch="live" component (it knows it's live).
     if (renderState.liveOnlyMode && prevSlot) {
       const prevIsLive = prevSlot.genInstance
-        ? ((prevSlot.genInstance.props["$patch"] as "live" | "default" | undefined) ??
+        ? (getPatchMode(prevSlot.genInstance.props) ??
             _instanceBatch(prevSlot.genInstance.capturedCtx)) === "live"
         : false;
       if (_getCurrentBatch() !== "live" && !prevIsLive) {
@@ -462,6 +463,7 @@ function* reconcileOneGen(
     };
   }
 
+  // SAFETY: All other Child types (null, false, string, number) are handled above.
   const vnode = nextChild as VNode;
 
   // ════════════════════════════════════════════════════════════════════════
@@ -473,8 +475,7 @@ function* reconcileOneGen(
   if (!isShown(allPropsForShown)) {
     // In live-only mode, only hide when the effective batch is live.
     if (renderState.liveOnlyMode) {
-      const effectiveBatch =
-        (allPropsForShown["$patch"] as "live" | "default" | undefined) ?? _getCurrentBatch();
+      const effectiveBatch = getPatchMode(allPropsForShown) ?? _getCurrentBatch();
       if (effectiveBatch !== "live" && prevSlot) {
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
       }
@@ -505,7 +506,7 @@ function* reconcileOneGen(
 
     // Propagate $deferred to the subtree via context.
     // Save and restore the context map so siblings are unaffected.
-    const compDeferred = allPropsRaw["$deferred"] as boolean | undefined;
+    const compDeferred = allPropsRaw["$deferred"] as boolean | undefined; // SAFETY: $deferred is always boolean | undefined
     const prevCtxComp = _getCtxMap();
     if (compDeferred) _setCtxMap(_withPriority(prevCtxComp, _getCurrentPriority() + 1));
     try {
@@ -559,8 +560,7 @@ function* reconcileOneGen(
         // │ Live-only mode: skip non-live components                       │
         // └─────────────────────────────────────────────────────────────────┘
         if (renderState.liveOnlyMode) {
-          const effectiveBatch =
-            (allProps["$patch"] as "live" | "default" | undefined) ?? _getCurrentBatch();
+          const effectiveBatch = getPatchMode(allProps) ?? _getCurrentBatch();
           if (effectiveBatch !== "live") {
             if (prevSlot.genInstance) {
               prevSlot.genInstance.capturedCtx = _withBatch(
@@ -631,8 +631,7 @@ function* reconcileOneGen(
       // │ Live-only mode: structural changes (type mismatch / no prevSlot) │
       // └───────────────────────────────────────────────────────────────────┘
       if (renderState.liveOnlyMode && prevSlot?.type !== vnode.type) {
-        const effectiveBatch =
-          (allProps["$patch"] as "live" | "default" | undefined) ?? _getCurrentBatch();
+        const effectiveBatch = getPatchMode(allProps) ?? _getCurrentBatch();
         if (effectiveBatch !== "live") {
           if (prevSlot) return { slot: prevSlot, node: prevSlot.node, replaced: false };
           const node = document.createTextNode("");
@@ -699,7 +698,7 @@ function* reconcileOneGen(
   if (typeof vnode.type === "string") {
     // Propagate $patch and $deferred to children via the context map.
     // Save and restore the context map around child reconciliation.
-    const elBatch = vnode.props["$patch"] as "live" | "default" | undefined;
+    const elBatch = getPatchMode(vnode.props);
     const elDeferred = vnode.props["$deferred"] as boolean | undefined;
     const prevCtxEl = _getCtxMap();
     if (elBatch !== undefined) _setCtxMap(_withBatch(prevCtxEl, elBatch));
@@ -785,13 +784,12 @@ function _hasStableContextSelectors(
 ): boolean {
   let _foundAny = false;
   for (const s of inst.hookStates) {
-    if (s == null || typeof s !== "object") continue;
-    const state = s as UseContextState;
-    if (state.ctx !== ctx) continue;
+    if (s === undefined || s.kind !== "context") continue;
+    if (s.ctx !== ctx) continue;
     _foundAny = true;
-    if (!state.selector) return false;
-    const newDeps = state.selector(newValue);
-    if (depsChanged(state.lastDeps, newDeps)) return false;
+    if (!s.selector) return false;
+    const newDeps = s.selector(newValue);
+    if (depsChanged(s.lastDeps, newDeps)) return false;
   }
   return true;
 }

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -1,5 +1,84 @@
-import type { Context } from "../context";
+import type { Context, UseContextState } from "../context";
+import type { UseRenderState } from "../hooks/$render";
 import type { Child, GeneratorComponentFn, VNode } from "../jsx";
+
+// ── Hook state discriminated union ──────────────────────────────────────────
+//
+// Each hook stores a tagged object in `GenInstance.hookStates`. The `kind`
+// discriminant allows type-safe narrowing without `as` casts, especially in
+// cross-cutting code like `flushEffects` and `_hasStableSelectors`.
+
+/** Persistent state for a `$state` hook. */
+export interface StateHookState {
+  kind: "state";
+  value: unknown;
+}
+
+/** Persistent state for a `$ref` hook. Holds the mutable ref object. */
+export interface RefHookState {
+  kind: "ref";
+  current: unknown;
+}
+
+/** Persistent state for a `$id` hook. Holds the stable unique ID string. */
+export interface IdHookState {
+  kind: "id";
+  id: string;
+}
+
+/** Persistent state for a `$memo` hook. */
+export interface MemoHookState {
+  kind: "memo";
+  value: unknown;
+  deps: unknown[];
+}
+
+/** Persistent state for a `$effect` hook. */
+export interface EffectHookState {
+  kind: "effect";
+  deps: unknown[];
+  cleanup: (() => void) | undefined;
+  controller: AbortController;
+}
+
+/** Persistent state for a `$resolveRaw` hook. */
+export type ResolveRawHookState =
+  | { kind: "resolve-raw"; promise: Promise<unknown>; status: "pending" }
+  | { kind: "resolve-raw"; promise: Promise<unknown>; status: "resolved"; data: unknown }
+  | { kind: "resolve-raw"; promise: Promise<unknown>; status: "rejected"; error: unknown };
+
+/** Persistent state for a `$resolve` hook. */
+export interface ResolveHookState {
+  kind: "resolve";
+  deps: unknown[];
+  promise: Promise<unknown>;
+  controller: AbortController;
+}
+
+/** Persistent state for a `$uiPatch` hook. */
+export interface UIPatchHookState {
+  kind: "ui-patch";
+  startPatch: () => () => void;
+}
+
+/**
+ * Discriminated union of all possible hook state values.
+ *
+ * Each variant is tagged with a `kind` field that allows type-safe narrowing
+ * when iterating `GenInstance.hookStates` (e.g. in `flushEffects` or
+ * `_hasStableSelectors`).
+ */
+export type HookState =
+  | StateHookState
+  | RefHookState
+  | IdHookState
+  | MemoHookState
+  | EffectHookState
+  | UseContextState
+  | ResolveRawHookState
+  | ResolveHookState
+  | UseRenderState<unknown>
+  | UIPatchHookState;
 
 /**
  * A **Slot** tracks one reconciled position in the rendered DOM tree.
@@ -192,22 +271,13 @@ export interface GenInstance {
    * Persistent per-hook storage array. Index `i` corresponds to the `i`-th
    * hook descriptor yielded during the component body.
    *
-   * Contents vary by hook type:
-   * - `useState`: the current state value.
-   * - `useRef`: `{ current: T }` ref object.
-   * - `useId`: the stable `":rN:"` ID string.
-   * - `useMemo`: `{ value, deps }`.
-   * - `useContext`: `UseContextState` with `ctx`, `selector`, `lastDeps`, `lastResult`.
-   * - `useResolveRaw`: `{ promise, status, data?, error? }`.
-   * - `useResolve`: `{ deps, promise, controller }`.
-   * - `useEffect`: `{ deps, cleanup, controller }`.
-   * - `useRender`: `UseRenderState` with `status`, `deps`, `value`, `resumeCallback`.
-   * - `useUIPatch`: the `startPatch` function.
+   * Each entry is a tagged object from the {@link HookState} discriminated
+   * union. The `kind` field allows type-safe narrowing in cross-cutting code.
    *
    * **Survives across re-renders.** Written by `processOneDescriptor`,
    * read by subsequent renders to preserve state.
    */
-  hookStates: unknown[];
+  hookStates: HookState[];
 
   /**
    * Per-hook cleanup functions, parallel to `hookStates`.


### PR DESCRIPTION
## Summary

- Replace `hookStates: unknown[]` with a tagged `HookState` discriminated union where each hook state carries a `kind` field, enabling type-safe narrowing without `as` casts in cross-cutting code (`flushEffects`, `_hasStableSelectors`, `_hasStableContextSelectors`).
- Add `isVNode` type guard and `getPatchMode` helper to reduce casts throughout the reconciler and mount modules.
- Update all 10 hook handler files to construct properly tagged state objects and use discriminant checks for reading.

## Changes

- **`src/render/types.ts`**: Define 10 hook state interfaces (`StateHookState`, `RefHookState`, `IdHookState`, `MemoHookState`, `EffectHookState`, `ResolveRawHookState`, `ResolveHookState`, `UIPatchHookState`) and the `HookState` discriminated union. Change `GenInstance.hookStates` from `unknown[]` to `HookState[]`.
- **`src/context.ts`**: Add `kind: "context"` to `UseContextState`. Update `_processContext` to use kind checks instead of `as` casts.
- **`src/hooks/$render.ts`**: Add `kind: "render"` to `UseRenderState`. Update `_processRender` to use kind checks.
- **`src/hooks/symbols.ts`**: Update `HookContext.hookStates` from `unknown[]` to `HookState[]`.
- **All hook handlers** (`$state`, `$ref`, `$id`, `$memo`, `$effect`, `$resolve`, `$ui-patch`): Construct tagged `{ kind: '...' }` objects when writing to hookStates; use discriminant checks or SAFETY-commented casts when reading.
- **`src/render/hooks-runtime.ts`**: Replace `as UseContextState` casts in `_hasStableSelectors` and `flushEffects` with `kind` discriminant checks. Remove unused `UseContextState` import.
- **`src/render/reconciler.ts`**: Replace `as UseContextState` cast in `_hasStableContextSelectors`. Replace `$patch` casts with `getPatchMode()` helper. Use `isVNode` in `getChildKey`.
- **`src/render/mount.ts`**: Use `HookState[]` type for hookStates. Replace `$patch` casts with `getPatchMode()`. Use kind check in cancelled render revert.
- **`src/render/patch.ts`**: Replace `$patch` cast with `getPatchMode()`.
- **`src/render/helpers.ts`**: Add `isVNode(child)` type guard and `getPatchMode(props)` helper. Update `flattenChildren` to use `isVNode`.

Closes #71

## Verification

- `npm run build` — passes
- `npm test` — 197 tests pass
- `npm run test:visual` — 57 tests pass
- `npm run lint:fix` — no new issues (all warnings pre-existing)

## CLAUDE.md Update

No CLAUDE.md changes needed for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)