### PR TITLE
refactor: eliminate global state with per-root RenderContext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,12 +80,21 @@ function* Counter(_props: object) {
 
 ### Core Module Map
 
-| File             | Responsibility                      |
-| :--------------- | :---------------------------------- |
-| `jsx.ts`         | VNode types & `createElement`       |
-| `render.ts`      | Reconciliation & DOM mounting       |
-| `hooks.ts`       | State management (`useState`, etc.) |
-| `jsx-runtime.ts` | Automatic JSX transform             |
+| File                     | Responsibility                                        |
+| :----------------------- | :---------------------------------------------------- |
+| `jsx.ts`                 | VNode types & `createElement`                         |
+| `render/types.ts`        | `RenderContext`, `GenInstance`, `Slot`, `HookState`    |
+| `render/state.ts`        | `createRenderContext()`, active context pointer        |
+| `render/index.ts`        | `render()`, `createRoot()` entry points               |
+| `render/mount.ts`        | DOM construction & generator component lifecycle      |
+| `render/reconciler.ts`   | Positional reconciliation (diff + patch)              |
+| `render/hooks-runtime.ts`| Hook descriptor dispatch, effect flushing, unmount    |
+| `render/scheduler.ts`    | Priority-aware cooperative scheduler                  |
+| `render/patch-queue.ts`  | Atomic DOM commit queue                               |
+| `render/patch.ts`        | Global/local UI patch (`startUIPatch`/`commitUIPatch`)|
+| `context.ts`             | `createContext`, `$context`, context map helpers       |
+| `hooks/*.ts`             | Individual hook implementations                       |
+| `jsx-runtime.ts`         | Automatic JSX transform                               |
 
 ---
 
@@ -98,3 +107,4 @@ function* Counter(_props: object) {
 - **Special Props:** Always support the `$shown={boolean}` prop.
 - **Dependencies:** Zero-dependency goal.
 - **JSX Config:** `react-jsx` with `jsxImportSource: "yielderact"`.
+- **Multi-root:** Each `render()`/`createRoot()` creates an independent `RenderContext` with its own state (patch depth, dirty instances, scheduler queue, context map, DOM ops queue). The global `idCounter` is the only shared state (IDs must be globally unique).

--- a/src/__tests__/create-root.test.ts
+++ b/src/__tests__/create-root.test.ts
@@ -50,10 +50,52 @@ describe("createRoot", () => {
   });
 
   it("restores context map after render", () => {
-    const before = _getCtxMap();
     const root = createRoot(container);
     root.render(createElement("div", null));
-    expect(_getCtxMap()).toBe(before);
+    // After render completes, the root's context map is restored to its
+    // initial state (no leftover Provider values from the rendered tree).
+    const after = _getCtxMap();
+    expect(after.size).toBe(0);
+  });
+
+  it("two independent createRoot calls do not share state", () => {
+    const container2 = document.createElement("div");
+    document.body.appendChild(container2);
+
+    let setCount1: ((v: number | ((p: number) => number)) => void) | null = null;
+    let setCount2: ((v: number | ((p: number) => number)) => void) | null = null;
+
+    function* Counter1() {
+      const [count, set] = yield* $state(0);
+      setCount1 = set;
+      return createElement("span", { id: "c1" }, String(count));
+    }
+
+    function* Counter2() {
+      const [count, set] = yield* $state(100);
+      setCount2 = set;
+      return createElement("span", { id: "c2" }, String(count));
+    }
+
+    const root1 = createRoot(container);
+    const root2 = createRoot(container2);
+    root1.render(createElement(Counter1 as never, {}));
+    root2.render(createElement(Counter2 as never, {}));
+
+    expect(container.querySelector("#c1")!.textContent).toBe("0");
+    expect(container2.querySelector("#c2")!.textContent).toBe("100");
+
+    // Update root 1 — root 2 must not be affected.
+    setCount1!(5);
+    expect(container.querySelector("#c1")!.textContent).toBe("5");
+    expect(container2.querySelector("#c2")!.textContent).toBe("100");
+
+    // Update root 2 — root 1 must not be affected.
+    setCount2!(200);
+    expect(container.querySelector("#c1")!.textContent).toBe("5");
+    expect(container2.querySelector("#c2")!.textContent).toBe("200");
+
+    document.body.removeChild(container2);
   });
 });
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import { depsChanged, type HookContext } from "./hooks/symbols";
 import { type Child, createElement, Fragment, type VNode } from "./jsx";
+import { _requireActiveCtx } from "./render/state";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -41,10 +42,8 @@ export interface UseContextDescriptor {
 }
 
 // ---------------------------------------------------------------------------
-// Module-level context map (updated during rendering)
+// Context map — stored on the active RenderContext, accessed via helpers
 // ---------------------------------------------------------------------------
-
-let _ctxMap: ReadonlyMap<Context<unknown>, unknown> = new Map();
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -175,7 +174,7 @@ export function _processContext(descriptor: { [key: string]: unknown }, ctx: Hoo
   instance.consumedContexts.add(context);
   const selector = descriptor["selector"] as ((c: unknown) => unknown[]) | undefined;
   const transform = descriptor["transform"] as ((...args: unknown[]) => unknown) | undefined;
-  const ctxMap = _ctxMap;
+  const ctxMap = _requireActiveCtx().ctxMap;
   const rawValue = ctxMap.has(context) ? ctxMap.get(context) : context._defaultValue;
 
   if (!selector) {
@@ -216,14 +215,14 @@ export function _processContext(descriptor: { [key: string]: unknown }, ctx: Hoo
 // Internal helpers used by the renderer
 // ---------------------------------------------------------------------------
 
-/** Get the current module-level context map. */
+/** Get the current context map from the active render context. */
 export function _getCtxMap(): ReadonlyMap<Context<unknown>, unknown> {
-  return _ctxMap;
+  return _requireActiveCtx().ctxMap;
 }
 
-/** Replace the module-level context map. */
+/** Set the context map on the active render context. */
 export function _setCtxMap(map: ReadonlyMap<Context<unknown>, unknown>): void {
-  _ctxMap = map;
+  _requireActiveCtx().ctxMap = map;
 }
 
 /**
@@ -269,7 +268,9 @@ export const _batchCtx: Context<"live" | "default"> = {
  * @internal
  */
 export function _getCurrentBatch(): "live" | "default" {
-  return _resolveCtxValue(_ctxMap, _batchCtx as Context<unknown>) as "live" | "default";
+  return _resolveCtxValue(_requireActiveCtx().ctxMap, _batchCtx as Context<unknown>) as
+    | "live"
+    | "default";
 }
 
 /**
@@ -323,7 +324,7 @@ export const _priorityCtx: Context<number> = {
  * @internal
  */
 export function _getCurrentPriority(): number {
-  return _resolveCtxValue(_ctxMap, _priorityCtx as Context<unknown>) as number;
+  return _resolveCtxValue(_requireActiveCtx().ctxMap, _priorityCtx as Context<unknown>) as number;
 }
 
 /**

--- a/src/hooks/$id.ts
+++ b/src/hooks/$id.ts
@@ -1,4 +1,4 @@
-import { renderState } from "../render/state";
+import { nextId } from "../render/state";
 import { $ID, type HookContext } from "./symbols";
 
 /**
@@ -30,7 +30,7 @@ export function _processId(ctx: HookContext): unknown {
   const { hookIndex, hookStates } = ctx;
   const existing = hookStates[hookIndex];
   if (existing === undefined || existing.kind !== "id") {
-    const newState = { kind: "id" as const, id: `:r${renderState.idCounter++}:` };
+    const newState = { kind: "id" as const, id: nextId() };
     hookStates[hookIndex] = newState;
     return newState.id;
   }

--- a/src/render/hooks-runtime.ts
+++ b/src/render/hooks-runtime.ts
@@ -37,7 +37,6 @@ import { _processUIPatch } from "../hooks/$ui-patch";
 import type { Child } from "../jsx";
 import { _flushPendingVNodes } from "./patch";
 import { clearRef } from "./props";
-import { renderState } from "./state";
 import type { GenInstance, HookState, Slot } from "./types";
 
 /**
@@ -118,7 +117,7 @@ export function flushEffects(instance: GenInstance): void {
  *
  * Calls every cleanup function registered by hooks (`useEffect`,
  * `useResolve`) on every `GenInstance` in the subtree. Also removes the
- * instance from `renderState.dirtyInstances` so that a pending
+ * instance from `renderCtx.dirtyInstances` so that a pending
  * `commitUIPatch` doesn't try to reconcile a dead component.
  *
  * **Called by:** `reconcileSlots` in `reconciler.ts` — when a slot is
@@ -141,10 +140,10 @@ export function unmountSlot(slot: Slot): void {
     for (const fn of slot.genInstance.cleanupFns) {
       fn?.();
     }
-    // Remove from global dirty set so commitUIPatch skips unmounted instances.
+    // Remove from dirty set so commitUIPatch skips unmounted instances.
     // localPatchRefCount is intentionally left as-is; the local patch commit()
     // checks pendingVNode === undefined and skips accordingly.
-    renderState.dirtyInstances.delete(slot.genInstance);
+    slot.genInstance.renderCtx.dirtyInstances.delete(slot.genInstance);
   }
 }
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,7 +1,7 @@
 import { _getCtxMap, _setCtxMap, _withBatch } from "../context";
 import type { VNode } from "../jsx";
 import { buildNode } from "./mount";
-import { renderState } from "./state";
+import { _setActiveCtx, createRenderContext } from "./state";
 
 export { buildNode } from "./mount";
 export { commitUIPatch, startUIPatch } from "./patch";
@@ -24,11 +24,13 @@ export { flushSync, scheduleUpdate } from "./scheduler";
  * @param container - The DOM element to mount into.
  */
 export function render(vnode: VNode, container: Element): void {
-  renderState.isInitialMount = true;
+  const rctx = createRenderContext();
+  _setActiveCtx(rctx);
+  rctx.isInitialMount = true;
   try {
     container.appendChild(buildNode(vnode));
   } finally {
-    renderState.isInitialMount = false;
+    rctx.isInitialMount = false;
   }
 }
 
@@ -61,15 +63,17 @@ export interface Root {
  * @returns A `Root` object with a `render` method.
  */
 export function createRoot(container: Element): Root {
+  const rctx = createRenderContext();
   return {
     render(vnode: VNode): void {
+      _setActiveCtx(rctx);
       const prevCtx = _getCtxMap();
       _setCtxMap(_withBatch(prevCtx, "default"));
-      renderState.isInitialMount = true;
+      rctx.isInitialMount = true;
       try {
         container.appendChild(buildNode(vnode));
       } finally {
-        renderState.isInitialMount = false;
+        rctx.isInitialMount = false;
         _setCtxMap(prevCtx);
       }
     },

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -39,8 +39,8 @@ import { isPatchActive } from "./patch-queue";
 import { applyProps } from "./props";
 import { reconcileSlots } from "./reconciler";
 import { scheduleUpdate } from "./scheduler";
-import { renderState } from "./state";
-import type { GenInstance, HookState, Slot } from "./types";
+import { _requireActiveCtx, _setActiveCtx } from "./state";
+import type { GenInstance, HookState, RenderContext, Slot } from "./types";
 
 /**
  * Build a single real DOM node from a virtual DOM node (or primitive value).
@@ -137,19 +137,20 @@ export function buildNode(child: Child): Node {
  * **Called by:** `resume` and `executeRerender` in `mountGeneratorComponent`.
  */
 function commitOrDefer(instance: GenInstance, vnode: Child): void {
+  const rctx = instance.renderCtx;
   const parent = instance.endMarker.parentNode as HTMLElement;
   const effectiveBatch = getPatchMode(instance.props) ?? _instanceBatch(instance.capturedCtx);
   const shouldDefer =
-    (renderState.patchDepth > 0 || instance.localPatchRefCount > 0) && effectiveBatch !== "live";
+    (rctx.patchDepth > 0 || instance.localPatchRefCount > 0) && effectiveBatch !== "live";
   if (shouldDefer) {
     instance.pendingVNode = vnode;
-    renderState.dirtyInstances.add(instance);
-    const prevLiveOnly = renderState.liveOnlyMode;
-    renderState.liveOnlyMode = true;
+    rctx.dirtyInstances.add(instance);
+    const prevLiveOnly = rctx.liveOnlyMode;
+    rctx.liveOnlyMode = true;
     try {
       instance.slots = reconcileSlots(parent, instance.slots, [vnode], instance.endMarker);
     } finally {
-      renderState.liveOnlyMode = prevLiveOnly;
+      rctx.liveOnlyMode = prevLiveOnly;
     }
   } else {
     instance.pendingVNode = undefined;
@@ -187,6 +188,9 @@ export function mountGeneratorComponent(
   props: Record<string, unknown>,
 ): { fragment: DocumentFragment; genInstance: GenInstance } {
   const endMarker = document.createComment("");
+
+  /** The per-root render context, captured from the active context at mount time. */
+  const rctx: RenderContext = _requireActiveCtx();
 
   /**
    * The context map captured at mount time, representing the **inherited**
@@ -237,6 +241,7 @@ export function mountGeneratorComponent(
    */
   function resume(): void {
     if (instance.gen === null) return;
+    _setActiveCtx(rctx);
 
     // Restore context: inherited context + own $patch applied for children.
     const prevCtx = _getCtxMap();
@@ -312,8 +317,8 @@ export function mountGeneratorComponent(
 
       let vnode: Child;
       let cancelled = false;
-      const prevRenderingPriority = renderState.renderingPriority;
-      renderState.renderingPriority = instance.priority;
+      const prevRenderingPriority = rctx.renderingPriority;
+      rctx.renderingPriority = instance.priority;
       try {
         const gen = instance.fn(instance.props, rerender);
         const result = runHooks(gen, instance, rerender, resume);
@@ -323,7 +328,7 @@ export function mountGeneratorComponent(
       } finally {
         _setCtxMap(prevCtx);
         instance.isRendering = false;
-        renderState.renderingPriority = prevRenderingPriority;
+        rctx.renderingPriority = prevRenderingPriority;
       }
 
       if (cancelled) {
@@ -349,10 +354,10 @@ export function mountGeneratorComponent(
         // liveOnlyMode guards).
         initialFragment = document.createDocumentFragment();
         initialFragment.appendChild(endMarker);
-        const prevLiveOnly = renderState.liveOnlyMode;
-        renderState.liveOnlyMode = false;
+        const prevLiveOnly = rctx.liveOnlyMode;
+        rctx.liveOnlyMode = false;
         instance.slots = reconcileSlots(initialFragment, [], [vnode], endMarker);
-        renderState.liveOnlyMode = prevLiveOnly;
+        rctx.liveOnlyMode = prevLiveOnly;
         mounted = true;
         flushEffects(instance);
       } else {
@@ -404,6 +409,7 @@ export function mountGeneratorComponent(
         instance.renderResolvers.push(resolve);
       });
     }
+    _setActiveCtx(rctx);
     if (isPatchActive()) {
       // During an active patch (another component is rendering or a
       // $patch batch is in progress), execute synchronously so the DOM
@@ -418,6 +424,7 @@ export function mountGeneratorComponent(
 
   // ── Initial mount ──
   instance = {
+    renderCtx: rctx,
     fn,
     gen: null,
     props,
@@ -485,10 +492,11 @@ export function mountContextProvider(
   try {
     const vnode = fn(props);
     if (vnode != null) {
-      const prevLiveOnly = renderState.liveOnlyMode;
-      renderState.liveOnlyMode = false;
+      const activeCtx = _requireActiveCtx();
+      const prevLiveOnly = activeCtx.liveOnlyMode;
+      activeCtx.liveOnlyMode = false;
       childSlots = reconcileSlots(fragment, [], [vnode], endMarker);
-      renderState.liveOnlyMode = prevLiveOnly;
+      activeCtx.liveOnlyMode = prevLiveOnly;
     }
   } finally {
     _setCtxMap(prevCtxMap);

--- a/src/render/patch-queue.ts
+++ b/src/render/patch-queue.ts
@@ -17,16 +17,13 @@
  *   after reconciliation completes for that priority level.
  */
 
-// ── Queue state ──────────────────────────────────────────────────────────────
-
-/** Collected DOM operations, or `null` when no patch is active. */
-let _ops: (() => void)[] | null = null;
+import { _requireActiveCtx } from "./state";
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
 /** Begin collecting DOM operations for a new priority pass. */
 export function beginPatch(): void {
-  _ops = [];
+  _requireActiveCtx().ops = [];
 }
 
 /**
@@ -38,15 +35,16 @@ export function beginPatch(): void {
  * Resets the queue to `null` (no active patch) after committing.
  */
 export function commitPatch(): void {
-  if (_ops === null) return;
-  const ops = _ops;
-  _ops = null;
+  const ctx = _requireActiveCtx();
+  if (ctx.ops === null) return;
+  const ops = ctx.ops;
+  ctx.ops = null;
   for (let i = 0; i < ops.length; i++) ops[i]!();
 }
 
 /** Returns `true` while a patch is being collected. */
 export function isPatchActive(): boolean {
-  return _ops !== null;
+  return _requireActiveCtx().ops !== null;
 }
 
 /**
@@ -54,8 +52,9 @@ export function isPatchActive(): boolean {
  * Returns the ops array and resets the queue to empty (ready for higher-priority work).
  */
 export function savePatchOps(): (() => void)[] {
-  const ops = _ops ?? [];
-  _ops = [];
+  const ctx = _requireActiveCtx();
+  const ops = ctx.ops ?? [];
+  ctx.ops = [];
   return ops;
 }
 
@@ -64,10 +63,11 @@ export function savePatchOps(): (() => void)[] {
  * The saved ops come first since they were collected before the preemption.
  */
 export function restorePatchOps(saved: (() => void)[]): void {
-  if (_ops === null) {
-    _ops = saved;
+  const ctx = _requireActiveCtx();
+  if (ctx.ops === null) {
+    ctx.ops = saved;
   } else {
-    _ops = [...saved, ..._ops];
+    ctx.ops = [...saved, ...ctx.ops];
   }
 }
 
@@ -82,8 +82,9 @@ export function restorePatchOps(saved: (() => void)[]): void {
  * Defers insertion when the parent is in the live DOM and a patch is active.
  */
 export function domInsertBefore(parent: Node, node: Node, ref: Node | null): void {
-  if (_ops !== null && parent.isConnected) {
-    _ops.push(() => parent.insertBefore(node, ref));
+  const ops = _requireActiveCtx().ops;
+  if (ops !== null && parent.isConnected) {
+    ops.push(() => parent.insertBefore(node, ref));
   } else {
     parent.insertBefore(node, ref);
   }
@@ -94,8 +95,9 @@ export function domInsertBefore(parent: Node, node: Node, ref: Node | null): voi
  * Defers when the parent is in the live DOM and a patch is active.
  */
 export function domAppendChild(parent: Node, node: Node): void {
-  if (_ops !== null && parent.isConnected) {
-    _ops.push(() => parent.appendChild(node));
+  const ops = _requireActiveCtx().ops;
+  if (ops !== null && parent.isConnected) {
+    ops.push(() => parent.appendChild(node));
   } else {
     parent.appendChild(node);
   }
@@ -107,8 +109,9 @@ export function domAppendChild(parent: Node, node: Node): void {
  * Includes a safety check at commit time in case the node was already removed.
  */
 export function domRemoveChild(parent: Node, node: Node): void {
-  if (_ops !== null && node.isConnected) {
-    _ops.push(() => {
+  const ops = _requireActiveCtx().ops;
+  if (ops !== null && node.isConnected) {
+    ops.push(() => {
       if (node.parentNode) node.parentNode.removeChild(node);
     });
   } else {
@@ -121,8 +124,9 @@ export function domRemoveChild(parent: Node, node: Node): void {
  * Defers when the text node is in the live DOM and a patch is active.
  */
 export function domSetText(node: Text, text: string): void {
-  if (_ops !== null && node.isConnected) {
-    _ops.push(() => {
+  const ops = _requireActiveCtx().ops;
+  if (ops !== null && node.isConnected) {
+    ops.push(() => {
       node.textContent = text;
     });
   } else {
@@ -142,8 +146,9 @@ export function domSetText(node: Text, text: string): void {
  *                   is deferred. If not connected (or omitted), the op runs now.
  */
 export function domEnqueue(op: () => void, liveNode?: Node): void {
-  if (_ops !== null && liveNode?.isConnected) {
-    _ops.push(op);
+  const ops = _requireActiveCtx().ops;
+  if (ops !== null && liveNode?.isConnected) {
+    ops.push(op);
   } else {
     op();
   }

--- a/src/render/patch.ts
+++ b/src/render/patch.ts
@@ -2,7 +2,7 @@ import { _getCtxMap, _setCtxMap, _withBatch } from "../context";
 import { getPatchMode } from "./helpers";
 import { flushEffects } from "./hooks-runtime";
 import { reconcileSlots } from "./reconciler";
-import { renderState } from "./state";
+import { _requireActiveCtx } from "./state";
 import type { GenInstance } from "./types";
 
 /**
@@ -18,7 +18,7 @@ import type { GenInstance } from "./types";
  * components see the correct context values during the reconciliation walk.
  *
  * **Called by:**
- * - `commitUIPatch()` below — drains `renderState.dirtyInstances` and
+ * - `commitUIPatch()` below — drains `renderCtx.dirtyInstances` and
  *   flushes all globally-deferred instances.
  * - `useUIPatch`'s `commit()` function (via `processOneDescriptor` in
  *   `hooks-runtime.ts`) — flushes locally-deferred instances when the
@@ -32,7 +32,7 @@ export function _flushPendingVNodes(instances: GenInstance[]): void {
     if (inst.pendingVNode === undefined) continue;
     const vnode = inst.pendingVNode;
     inst.pendingVNode = undefined;
-    renderState.dirtyInstances.delete(inst);
+    inst.renderCtx.dirtyInstances.delete(inst);
 
     const prevCtx = _getCtxMap();
     // Restore inherited context, then apply own $patch for children.
@@ -51,7 +51,7 @@ export function _flushPendingVNodes(instances: GenInstance[]): void {
 /**
  * Begin a global UI patch.
  *
- * While a global patch is active (`renderState.patchDepth > 0`), all
+ * While a global patch is active (`renderCtx.patchDepth > 0`), all
  * `$patch="default"` components (the default) defer their DOM writes:
  * they compute their new VNode but store it as `pendingVNode` instead of
  * reconciling the DOM. Only `$patch="live"` components update immediately.
@@ -70,14 +70,14 @@ export function _flushPendingVNodes(instances: GenInstance[]): void {
  * commitUIPatch();      // both updates applied at once
  */
 export function startUIPatch(): void {
-  renderState.patchDepth++;
+  _requireActiveCtx().patchDepth++;
 }
 
 /**
  * Commit the global UI patch, applying all deferred DOM updates at once.
  *
  * Decrements the reference count. When it reaches 0 (outermost patch),
- * drains `renderState.dirtyInstances` and calls `_flushPendingVNodes`
+ * drains `renderCtx.dirtyInstances` and calls `_flushPendingVNodes`
  * to reconcile every pending VNode.
  *
  * Must be called exactly once for each matching `startUIPatch` call.
@@ -86,11 +86,12 @@ export function startUIPatch(): void {
  * have been triggered.
  */
 export function commitUIPatch(): void {
-  if (renderState.patchDepth === 0) return;
-  renderState.patchDepth--;
-  if (renderState.patchDepth > 0) return; // nested patch still active
+  const rctx = _requireActiveCtx();
+  if (rctx.patchDepth === 0) return;
+  rctx.patchDepth--;
+  if (rctx.patchDepth > 0) return; // nested patch still active
 
-  const pending = [...renderState.dirtyInstances];
-  renderState.dirtyInstances.clear();
+  const pending = [...rctx.dirtyInstances];
+  rctx.dirtyInstances.clear();
   _flushPendingVNodes(pending);
 }

--- a/src/render/reconciler.ts
+++ b/src/render/reconciler.ts
@@ -69,7 +69,7 @@ import {
   domSetText,
 } from "./patch-queue";
 import { applyProps, updateProps } from "./props";
-import { renderState } from "./state";
+import { _requireActiveCtx } from "./state";
 import type { GenInstance, Slot } from "./types";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -410,7 +410,7 @@ function* reconcileOneGen(
   if (nextChild == null || nextChild === false) {
     // In live-only mode, skip removal unless we're in a live context OR the
     // existing slot is a $patch="live" component (it knows it's live).
-    if (renderState.liveOnlyMode && prevSlot) {
+    if (_requireActiveCtx().liveOnlyMode && prevSlot) {
       const prevIsLive = prevSlot.genInstance
         ? (getPatchMode(prevSlot.genInstance.props) ??
             _instanceBatch(prevSlot.genInstance.capturedCtx)) === "live"
@@ -442,7 +442,7 @@ function* reconcileOneGen(
       // Same type (text) → update content in place.
       // In live-only mode, only update when the current batch is live.
       if (
-        (!renderState.liveOnlyMode || _getCurrentBatch() === "live") &&
+        (!_requireActiveCtx().liveOnlyMode || _getCurrentBatch() === "live") &&
         prevSlot.node.textContent !== text
       ) {
         domSetText(prevSlot.node, text);
@@ -451,7 +451,7 @@ function* reconcileOneGen(
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
     }
     // In live-only default mode, don't insert new text nodes.
-    if (renderState.liveOnlyMode && _getCurrentBatch() !== "live" && prevSlot) {
+    if (_requireActiveCtx().liveOnlyMode && _getCurrentBatch() !== "live" && prevSlot) {
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
     }
     // Different type was here → replace with new TextNode.
@@ -474,7 +474,7 @@ function* reconcileOneGen(
   const allPropsForShown = mergedProps(vnode);
   if (!isShown(allPropsForShown)) {
     // In live-only mode, only hide when the effective batch is live.
-    if (renderState.liveOnlyMode) {
+    if (_requireActiveCtx().liveOnlyMode) {
       const effectiveBatch = getPatchMode(allPropsForShown) ?? _getCurrentBatch();
       if (effectiveBatch !== "live" && prevSlot) {
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
@@ -559,7 +559,7 @@ function* reconcileOneGen(
         // ┌─────────────────────────────────────────────────────────────────┐
         // │ Live-only mode: skip non-live components                       │
         // └─────────────────────────────────────────────────────────────────┘
-        if (renderState.liveOnlyMode) {
+        if (_requireActiveCtx().liveOnlyMode) {
           const effectiveBatch = getPatchMode(allProps) ?? _getCurrentBatch();
           if (effectiveBatch !== "live") {
             if (prevSlot.genInstance) {
@@ -630,7 +630,7 @@ function* reconcileOneGen(
       // ┌───────────────────────────────────────────────────────────────────┐
       // │ Live-only mode: structural changes (type mismatch / no prevSlot) │
       // └───────────────────────────────────────────────────────────────────┘
-      if (renderState.liveOnlyMode && prevSlot?.type !== vnode.type) {
+      if (_requireActiveCtx().liveOnlyMode && prevSlot?.type !== vnode.type) {
         const effectiveBatch = getPatchMode(allProps) ?? _getCurrentBatch();
         if (effectiveBatch !== "live") {
           if (prevSlot) return { slot: prevSlot, node: prevSlot.node, replaced: false };
@@ -706,7 +706,7 @@ function* reconcileOneGen(
     try {
       if (prevSlot?.type === vnode.type && prevSlot.node instanceof HTMLElement) {
         // ── Same tag → update props in place and reconcile children ──
-        if (!renderState.liveOnlyMode || _getCurrentBatch() === "live") {
+        if (!_requireActiveCtx().liveOnlyMode || _getCurrentBatch() === "live") {
           const prevProps = prevSlot.props;
           domEnqueue(
             () => updateProps(prevSlot.node as HTMLElement, prevProps, vnode.props),
@@ -722,7 +722,7 @@ function* reconcileOneGen(
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
       }
       // ── Different tag → build fresh element ──
-      if (renderState.liveOnlyMode && _getCurrentBatch() !== "live") {
+      if (_requireActiveCtx().liveOnlyMode && _getCurrentBatch() !== "live") {
         if (prevSlot) return { slot: prevSlot, node: prevSlot.node, replaced: false };
         const empty = document.createTextNode("");
         return {
@@ -735,14 +735,14 @@ function* reconcileOneGen(
       applyProps(el, vnode.props);
       const flatChildren = flattenChildren(vnode.children);
       const childSlots: Slot[] = [];
-      const prevLiveOnly = renderState.liveOnlyMode;
-      renderState.liveOnlyMode = false;
+      const prevLiveOnly = _requireActiveCtx().liveOnlyMode;
+      _requireActiveCtx().liveOnlyMode = false;
       for (const child of flatChildren) {
         const { slot: childSlot, node: childNode } = yield* reconcileOneGen(null, child);
         childSlots.push(childSlot);
         el.appendChild(childNode);
       }
-      renderState.liveOnlyMode = prevLiveOnly;
+      _requireActiveCtx().liveOnlyMode = prevLiveOnly;
       return {
         slot: {
           type: vnode.type,

--- a/src/render/scheduler.ts
+++ b/src/render/scheduler.ts
@@ -2,7 +2,7 @@
  * scheduler.ts — Priority-aware cooperative scheduler for rendering.
  *
  * Work is queued via `scheduleUpdate(instance)` which assigns a priority
- * based on whether we're inside a render (`renderState.renderingPriority`)
+ * based on whether we're inside a render (`renderCtx.renderingPriority`)
  * or idle (`instance.priority`).
  *
  * The scheduler processes work in strict priority order (lower number =
@@ -24,33 +24,9 @@
  * effects or context propagation is processed immediately).
  */
 
-import { _getCtxMap, _setCtxMap } from "../context";
 import { beginPatch, commitPatch, restorePatchOps, savePatchOps } from "./patch-queue";
-import { renderState } from "./state";
-import type { GenInstance } from "./types";
-
-// ── Scheduler state ──────────────────────────────────────────────────────────
-
-/**
- * Priority queue: maps priority level → set of instances needing update.
- * Lower numbers are higher priority (processed first).
- */
-const _pendingUpdates = new Map<number, Set<GenInstance>>();
-
-/** True while the scheduler is actively processing work. */
-let _isProcessing = false;
-
-/**
- * The priority level currently being processed (beginPatch called, not yet
- * committed). `null` when idle or between priority levels.
- *
- * Used to detect resume-after-yield: if non-null when `_runLoop` starts,
- * we're continuing a partially-processed level (don't call `beginPatch` again).
- */
-let _activePriority: number | null = null;
-
-/** When true, the work loop never yields to the browser. */
-let _syncMode = true;
+import { _requireActiveCtx, _setActiveCtx } from "./state";
+import type { GenInstance, RenderContext } from "./types";
 
 /** Time budget per work chunk in milliseconds. */
 const _timeSlice = 5;
@@ -61,7 +37,7 @@ const _timeSlice = 5;
  * Schedule a rerender for `instance` at the appropriate priority.
  *
  * Priority is determined by:
- * - During render (`renderState.renderingPriority !== null`): caller's priority.
+ * - During render (`renderCtx.renderingPriority !== null`): caller's priority.
  * - During idle: the instance's own priority (`instance.priority`).
  *
  * If the scheduler is already processing, the instance is queued and will
@@ -71,18 +47,20 @@ const _timeSlice = 5;
  * @param instance - The GenInstance to rerender.
  */
 export function scheduleUpdate(instance: GenInstance): void {
-  const priority = renderState.renderingPriority ?? instance.priority;
+  const rctx = instance.renderCtx;
+  const priority = rctx.renderingPriority ?? instance.priority;
 
-  let set = _pendingUpdates.get(priority);
+  let set = rctx.pendingUpdates.get(priority);
   if (!set) {
     set = new Set();
-    _pendingUpdates.set(priority, set);
+    rctx.pendingUpdates.set(priority, set);
   }
   set.add(instance);
 
-  if (!_isProcessing) {
-    _isProcessing = true;
-    _runLoop();
+  if (!rctx.isProcessing) {
+    rctx.isProcessing = true;
+    _setActiveCtx(rctx);
+    _runLoop(rctx);
   }
 }
 
@@ -97,33 +75,34 @@ export function scheduleUpdate(instance: GenInstance): void {
  * are batched into a single processing pass.
  */
 export function flushSync(fn?: () => void): void {
-  const prevSync = _syncMode;
-  _syncMode = true;
+  const rctx = _requireActiveCtx();
+  const prevSync = rctx.syncMode;
+  rctx.syncMode = true;
 
   if (fn) {
     // Suppress immediate processing during fn so all setState calls batch.
-    const wasProcessing = _isProcessing;
-    _isProcessing = true;
+    const wasProcessing = rctx.isProcessing;
+    rctx.isProcessing = true;
     try {
       fn();
     } finally {
-      _isProcessing = wasProcessing;
+      rctx.isProcessing = wasProcessing;
     }
   }
 
-  if (!_isProcessing && _hasPendingWork()) {
-    _isProcessing = true;
-    _runLoop();
+  if (!rctx.isProcessing && _hasPendingWork(rctx)) {
+    rctx.isProcessing = true;
+    _runLoop(rctx);
   }
 
-  _syncMode = prevSync;
+  rctx.syncMode = prevSync;
 }
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 /** Returns true if any priority level has pending instances. */
-function _hasPendingWork(): boolean {
-  for (const [, set] of _pendingUpdates) {
+function _hasPendingWork(rctx: RenderContext): boolean {
+  for (const [, set] of rctx.pendingUpdates) {
     if (set.size > 0) return true;
   }
   return false;
@@ -133,9 +112,9 @@ function _hasPendingWork(): boolean {
  * Returns the lowest priority number (= highest urgency) that has pending
  * work, or `null` if all queues are empty.
  */
-function _getLowestPriority(): number | null {
+function _getLowestPriority(rctx: RenderContext): number | null {
   let min: number | null = null;
-  for (const [p, set] of _pendingUpdates) {
+  for (const [p, set] of rctx.pendingUpdates) {
     if (set.size > 0 && (min === null || p < min)) min = p;
   }
   return min;
@@ -145,9 +124,9 @@ function _getLowestPriority(): number | null {
  * Returns the lowest priority number that is strictly less than `ceiling`
  * and has pending work. Used for preemption detection.
  */
-function _getHigherPriorityThan(ceiling: number): number | null {
+function _getHigherPriorityThan(rctx: RenderContext, ceiling: number): number | null {
   let min: number | null = null;
-  for (const [p, set] of _pendingUpdates) {
+  for (const [p, set] of rctx.pendingUpdates) {
     if (p < ceiling && set.size > 0 && (min === null || p < min)) min = p;
   }
   return min;
@@ -165,27 +144,27 @@ function _getHigherPriorityThan(ceiling: number): number | null {
  * - Preemption (higher-priority work processed inline).
  * - Time-slicing (yields to browser in async mode).
  */
-function _runLoop(): void {
+function _runLoop(rctx: RenderContext): void {
   let deadline = performance.now() + _timeSlice;
 
   while (true) {
     let priority: number;
 
-    if (_activePriority !== null) {
+    if (rctx.activePriority !== null) {
       // Resuming a partially-processed priority level (after yield-to-browser).
-      priority = _activePriority;
+      priority = rctx.activePriority;
     } else {
-      const p = _getLowestPriority();
+      const p = _getLowestPriority(rctx);
       if (p === null) {
-        _isProcessing = false;
+        rctx.isProcessing = false;
         return;
       }
       priority = p;
-      _activePriority = priority;
+      rctx.activePriority = priority;
       beginPatch();
     }
 
-    const set = _pendingUpdates.get(priority)!;
+    const set = rctx.pendingUpdates.get(priority)!;
 
     while (set.size > 0) {
       const instance = set.values().next().value!;
@@ -194,19 +173,19 @@ function _runLoop(): void {
       instance._executeRerender();
 
       // Preemption: process any higher-priority work that arrived during rerender.
-      _handlePreemption(priority);
+      _handlePreemption(rctx, priority);
 
       // Time-slicing (async mode only): yield to browser if deadline exceeded.
-      if (!_syncMode && set.size > 0 && performance.now() >= deadline) {
-        _yieldToBrowser();
+      if (!rctx.syncMode && set.size > 0 && performance.now() >= deadline) {
+        _yieldToBrowser(rctx);
         return; // exit — the MessageChannel callback resumes via _runLoop
       }
     }
 
     // All instances at this priority level processed — commit the batch.
     commitPatch();
-    _pendingUpdates.delete(priority);
-    _activePriority = null;
+    rctx.pendingUpdates.delete(priority);
+    rctx.activePriority = null;
     deadline = performance.now() + _timeSlice;
   }
 }
@@ -220,16 +199,16 @@ function _runLoop(): void {
  * Recurses to handle nested preemption (e.g., priority 0 work arrives
  * while processing priority 1 which preempted priority 2).
  */
-function _handlePreemption(currentPriority: number): void {
+function _handlePreemption(rctx: RenderContext, currentPriority: number): void {
   while (true) {
-    const hp = _getHigherPriorityThan(currentPriority);
+    const hp = _getHigherPriorityThan(rctx, currentPriority);
     if (hp === null) return;
 
     // Save current priority's partial patch ops.
     const savedOps = savePatchOps();
 
     // Process the higher-priority level fully.
-    const set = _pendingUpdates.get(hp)!;
+    const set = rctx.pendingUpdates.get(hp)!;
     beginPatch();
 
     while (set.size > 0) {
@@ -238,11 +217,11 @@ function _handlePreemption(currentPriority: number): void {
       inst._executeRerender();
 
       // Recursive preemption: even higher priority may have arrived.
-      _handlePreemption(hp);
+      _handlePreemption(rctx, hp);
     }
 
     commitPatch();
-    _pendingUpdates.delete(hp);
+    rctx.pendingUpdates.delete(hp);
 
     // Restore current priority's partial patch ops.
     restorePatchOps(savedOps);
@@ -253,31 +232,33 @@ function _handlePreemption(currentPriority: number): void {
  * Yield to the browser, then resume the work loop.
  *
  * Uses `MessageChannel` for minimal-latency scheduling (same technique
- * as React's scheduler). Saves and restores global render state around
+ * as React's scheduler). Saves and restores render state around
  * the yield so event handlers during the pause don't corrupt it.
  *
- * `_activePriority` remains set so `_runLoop` knows to resume the
+ * `rctx.activePriority` remains set so `_runLoop` knows to resume the
  * partially-processed priority level on callback.
  */
-function _yieldToBrowser(): void {
-  // Save global state that event handlers might disturb.
-  const savedCtxMap = _getCtxMap();
-  const savedLiveOnlyMode = renderState.liveOnlyMode;
+function _yieldToBrowser(rctx: RenderContext): void {
+  // Save state that event handlers might disturb during the yield.
+  const savedCtxMap = rctx.ctxMap;
+  const savedLiveOnlyMode = rctx.liveOnlyMode;
 
   if (typeof MessageChannel !== "undefined") {
     const mc = new MessageChannel();
     mc.port1.onmessage = () => {
-      _setCtxMap(savedCtxMap);
-      renderState.liveOnlyMode = savedLiveOnlyMode;
-      _runLoop();
+      _setActiveCtx(rctx);
+      rctx.ctxMap = savedCtxMap;
+      rctx.liveOnlyMode = savedLiveOnlyMode;
+      _runLoop(rctx);
     };
     mc.port2.postMessage(null);
   } else {
     // Fallback for environments without MessageChannel.
     setTimeout(() => {
-      _setCtxMap(savedCtxMap);
-      renderState.liveOnlyMode = savedLiveOnlyMode;
-      _runLoop();
+      _setActiveCtx(rctx);
+      rctx.ctxMap = savedCtxMap;
+      rctx.liveOnlyMode = savedLiveOnlyMode;
+      _runLoop(rctx);
     }, 0);
   }
 }

--- a/src/render/state.ts
+++ b/src/render/state.ts
@@ -1,98 +1,89 @@
-import type { GenInstance } from "./types";
+import type { RenderContext } from "./types";
 
 /**
- * Shared mutable render state.
+ * Create a fresh per-root render context.
  *
- * All render modules read and write properties on this single object instead
- * of module-level `let` variables.  This is necessary because ES modules
- * cannot re-export reassignable bindings across files — a mutable object
- * with properties is the simplest way to share state.
+ * Each `render()` or `createRoot()` call creates its own context so that
+ * independent roots do not share mutable state.
+ *
+ * **Called by:** `render()` and `createRoot()` in `index.ts`.
  */
-export const renderState = {
-  /**
-   * Reference-counted global patch depth.
-   *
-   * While > 0, all `$patch="default"` components defer their DOM writes
-   * (store a `pendingVNode` instead of calling `reconcileSlots` normally).
-   *
-   * **Incremented by:** `startUIPatch()` in `patch.ts`.
-   * **Decremented by:** `commitUIPatch()` in `patch.ts`.
-   * **Read by:** `executeRerender` and `resume` in `mount.ts` — part of
-   *   the `shouldDefer` check:
-   *   `(patchDepth > 0 || localPatchRefCount > 0) && effectiveBatch !== 'live'`.
-   */
-  patchDepth: 0,
+export function createRenderContext(): RenderContext {
+  return {
+    patchDepth: 0,
+    dirtyInstances: new Set(),
+    isInitialMount: false,
+    liveOnlyMode: false,
+    renderingPriority: null,
+    ctxMap: new Map(),
+    ops: null,
+    pendingUpdates: new Map(),
+    isProcessing: false,
+    activePriority: null,
+    syncMode: true,
+  };
+}
 
-  /**
-   * When true, `reconcileOne` only updates `$patch="live"` subtrees and
-   * skips everything else (text updates, prop updates, component rerenders,
-   * structural changes).
-   *
-   * This mode is activated temporarily by `executeRerender` and `resume`
-   * when a component needs to defer its own DOM writes (`shouldDefer`)
-   * but still must flush its `$patch="live"` descendants immediately.
-   * The pattern is:
-   * ```
-   *   liveOnlyMode = true;
-   *   reconcileSlots(host, slots, [vnode]);  // only live subtrees touched
-   *   liveOnlyMode = false;
-   * ```
-   *
-   * **Set to `true` by:** `executeRerender` / `resume` in `mount.ts`.
-   * **Restored by:** the same functions in a `finally` block.
-   * **Read by:** `reconcileOne` in `reconciler.ts` — guards every section
-   *   (null, text, $shown, function component, HTML element).
-   */
-  liveOnlyMode: false,
+// ── Active render context pointer ─────────────────────────────────────────
+//
+// During any rendering work (mount, rerender, reconciliation, effect flush),
+// the "active" context is set to the root's `RenderContext`. All internal
+// modules read/write through this pointer instead of module-level variables.
 
-  /**
-   * Set of `GenInstance`s that have a `pendingVNode` waiting to be committed.
-   *
-   * When a global patch is active (`patchDepth > 0`), deferred components
-   * add themselves here. When `commitUIPatch()` runs, it drains this set
-   * and calls `_flushPendingVNodes` to reconcile all pending VNodes.
-   *
-   * **Added to by:** `executeRerender` / `resume` when `shouldDefer` is true.
-   * **Drained by:** `commitUIPatch()` in `patch.ts`.
-   * **Deleted from by:** `unmountSlot` — removes unmounted instances so
-   *   `commitUIPatch` doesn't try to reconcile a dead component.
-   */
-  dirtyInstances: new Set<GenInstance>(),
+let _activeCtx: RenderContext | null = null;
 
-  /**
-   * Auto-incrementing counter for stable unique IDs produced by `useId`.
-   *
-   * **Incremented by:** `processOneDescriptor($ID)` in `hooks-runtime.ts`.
-   * Each `useId()` call gets `":r<N>:"` where N is the counter value at
-   * first mount. The ID is stored in `hookStates` and reused on rerenders.
-   */
-  idCounter: 0,
+/**
+ * Return the currently active render context, or `null` if none is active.
+ *
+ * Most call sites use this during a render pass (where the return is
+ * guaranteed non-null). The nullable return is needed for save/restore
+ * patterns at entry points (`render()`, `createRoot().render()`).
+ * @internal
+ */
+export function _getActiveCtx(): RenderContext | null {
+  return _activeCtx;
+}
 
-  /**
-   * The priority level of the component currently being rendered, or `null`
-   * when no render is in progress.
-   *
-   * Used to determine the priority of `setState` calls during render:
-   * if component B (priority 2) calls setState on component A (priority 0)
-   * during B's render, the update is assigned priority 2 (the caller's).
-   *
-   * **Set by:** `executeRerender` in `mount.ts` — before calling `runHooks`.
-   * **Cleared by:** `executeRerender` — in the `finally` block.
-   * **Read by:** `processOneDescriptor($STATE)` — to tag the setState
-   *   call with the correct priority.
-   */
-  renderingPriority: null as number | null,
+/**
+ * Return the currently active render context.
+ *
+ * **Precondition:** Must only be called while a rendering operation is in
+ * progress (i.e. `_setActiveCtx` was called with a non-null context).
+ * @internal
+ */
+export function _requireActiveCtx(): RenderContext {
+  return _activeCtx!;
+}
 
-  /**
-   * True while performing the initial mount (before the root tree is
-   * attached to the live DOM).
-   *
-   * During initial mount, priority levels do not apply — the full tree
-   * mounts as a single patch. This flag prevents `$deferred` from splitting
-   * work into multiple priority passes during the first render.
-   *
-   * **Set by:** `render()` / `createRoot().render()` in `index.ts`.
-   * **Read by:** the scheduler — to skip priority splitting during mount.
-   */
-  isInitialMount: false,
-};
+/**
+ * Set (or clear) the active render context.
+ *
+ * **Called by:**
+ * - `render()` / `createRoot().render()` — before initial mount.
+ * - `scheduleUpdate` / `_runLoop` in `scheduler.ts` — before processing work.
+ * - `_yieldToBrowser` in `scheduler.ts` — on resume after yield.
+ * - `rerender()` / `resume()` closures in `mount.ts` — before accessing
+ *   context-dependent state from event handlers.
+ * @internal
+ */
+export function _setActiveCtx(ctx: RenderContext | null): void {
+  _activeCtx = ctx;
+}
+
+// ── Global ID counter ─────────────────────────────────────────────────────
+//
+// Unique IDs must be globally unique across all roots, so the counter stays
+// module-level rather than per-root.
+
+/**
+ * Auto-incrementing counter for stable unique IDs produced by `$id`.
+ *
+ * Incremented by `_processId` in `hooks/$id.ts`. Each `$id()` call gets
+ * `":r<N>:"` where N is the counter value at first mount.
+ */
+export let idCounter = 0;
+
+/** Allocate the next unique ID string. @internal */
+export function nextId(): string {
+  return `:r${idCounter++}:`;
+}

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -2,6 +2,45 @@ import type { Context, UseContextState } from "../context";
 import type { UseRenderState } from "../hooks/$render";
 import type { Child, GeneratorComponentFn, VNode } from "../jsx";
 
+// ── Render context ─────────────────────────────────────────────────────────
+//
+// Per-root mutable state. Each `createRoot()` (or `render()`) creates its
+// own `RenderContext`. During rendering the "active" context is set so that
+// all internal modules can read/write the correct root's state.
+
+/**
+ * Per-root render state.
+ *
+ * Replaces the previous module-level singletons (`renderState`, `_ctxMap`,
+ * `_ops`, scheduler variables). Stored on each `GenInstance.renderCtx` so
+ * that closures and hook handlers can reach it without global lookups.
+ *
+ * **Created by:** `createRenderContext()` in `state.ts`, called from
+ * `render()` and `createRoot()` in `index.ts`.
+ */
+export interface RenderContext {
+  // ── From state.ts (persistent per-root) ──
+  patchDepth: number;
+  dirtyInstances: Set<GenInstance>;
+  isInitialMount: boolean;
+
+  // ── From state.ts (rendering-phase temporary) ──
+  liveOnlyMode: boolean;
+  renderingPriority: number | null;
+
+  // ── From context.ts ──
+  ctxMap: ReadonlyMap<Context<unknown>, unknown>;
+
+  // ── From patch-queue.ts ──
+  ops: (() => void)[] | null;
+
+  // ── From scheduler.ts ──
+  pendingUpdates: Map<number, Set<GenInstance>>;
+  isProcessing: boolean;
+  activePriority: number | null;
+  syncMode: boolean;
+}
+
 // ── Hook state discriminated union ──────────────────────────────────────────
 //
 // Each hook stores a tagged object in `GenInstance.hookStates`. The `kind`
@@ -154,7 +193,7 @@ export interface Slot {
  * Persistent state for one mounted generator component instance.
  *
  * **Created by:** `mountGeneratorComponent` in `mount.ts` — once per
- * component mount. Stored in `renderState.genInstanceMap` (keyed by host
+ * component mount. Referenced by the component's `Slot.genInstance` (keyed by host
  * element) and referenced by the component's `Slot.genInstance`.
  *
  * **Survives across re-renders** — props, capturedCtx, and hookStates are
@@ -162,9 +201,22 @@ export interface Slot {
  * cleanup functions persist.
  *
  * **Destroyed by:** `unmountSlot` in `hooks-runtime.ts` — calls all
- * `cleanupFns`, removes from `renderState.dirtyInstances`.
+ * `cleanupFns`, removes from `renderCtx.dirtyInstances`.
  */
 export interface GenInstance {
+  /**
+   * The per-root render context this instance belongs to.
+   *
+   * All rendering state (patch depth, dirty instances, context map,
+   * scheduler queues, etc.) lives here instead of in module-level globals.
+   *
+   * **Set by:** `mountGeneratorComponent` — from the active render context
+   * at the time the component is first mounted.
+   * **Read by:** closures (`rerender`, `executeRerender`, `resume`), hook
+   * handlers, the scheduler, and `unmountSlot`.
+   */
+  renderCtx: RenderContext;
+
   /**
    * The generator-function component that produced this instance.
    * Called by `executeRerender` to create a fresh generator on each render:


### PR DESCRIPTION
## Summary

Replace all module-level mutable state (`renderState`, `_ctxMap`, `_ops`, scheduler variables) with a per-root `RenderContext` object. Each `render()` or `createRoot()` call now creates an independent context, enabling multiple roots to operate without shared mutable state. This is PR 3 of 5 for the codebase cleanup (issue #71).

## Changes

- Add `RenderContext` interface to `types.ts` consolidating all per-root state (patch depth, dirty instances, context map, DOM ops queue, scheduler queues)
- Add `renderCtx: RenderContext` field to `GenInstance` (set at mount time)
- Replace `renderState` singleton in `state.ts` with `createRenderContext()` factory + `_requireActiveCtx()`/`_setActiveCtx()` active-context pointer
- Update `context.ts`: `_getCtxMap()`/`_setCtxMap()` now read/write from the active render context instead of a module-level variable
- Update `patch-queue.ts`: all DOM op queue functions use the active context's `ops` field
- Update `scheduler.ts`: scheduler state (pending updates, processing flag, active priority, sync mode) lives on `instance.renderCtx`
- Update `mount.ts`: closures (`rerender`, `resume`) set the active context before accessing context-dependent state
- Update `reconciler.ts`, `patch.ts`, `hooks-runtime.ts`: replace `renderState` references with active context or `instance.renderCtx`
- Keep `idCounter` as the only true global (unique IDs must be globally unique across roots)
- Add multi-root isolation test proving two `createRoot()` calls don't share state
- Update `CLAUDE.md` Core Module Map to reflect current file structure

## Closes

Closes #71 (PR 3 of 5)

## Verification

- `npm run build` — passes
- `npm test` — 198 tests pass (197 existing + 1 new multi-root test)
- `npm run test:visual` — 57 tests pass
- `npm run format` — no issues

## CLAUDE.md Update

Yes — updated Core Module Map table to reflect the actual file structure, added multi-root architecture note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)