### PR TITLE
feat: implement React 19-style event delegation system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,9 @@ function* Counter(_props: object) {
 | `render/scheduler.ts`    | Priority-aware cooperative scheduler                  |
 | `render/patch-queue.ts`  | Atomic DOM commit queue                               |
 | `render/patch.ts`        | Global/local UI patch (`startUIPatch`/`commitUIPatch`)|
+| `render/delegation.ts`   | Handler registry, `DelegationRoot`, prop→event mapping|
+| `render/dispatch.ts`     | Delegated event dispatch (capture→bubble phases)      |
+| `render/events.ts`       | Per-element listeners for non-delegated events        |
 | `context.ts`             | `createContext`, `$context`, context map helpers       |
 | `hooks/*.ts`             | Individual hook implementations                       |
 | `jsx-runtime.ts`         | Automatic JSX transform                               |

--- a/src/__tests__/event-delegation.test.ts
+++ b/src/__tests__/event-delegation.test.ts
@@ -1,0 +1,426 @@
+import { $state } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
+
+describe("event delegation", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  // ── Basic delegation ──────────────────────────────────────────────────────
+
+  it("only one native listener per event type on root", () => {
+    const addSpy = jest.spyOn(container, "addEventListener");
+
+    render(
+      createElement(
+        "div",
+        null,
+        createElement("button", { onClick: () => {} }, "A"),
+        createElement("button", { onClick: () => {} }, "B"),
+        createElement("button", { onClick: () => {} }, "C"),
+      ),
+      container,
+    );
+
+    // Only one "click" listener should be on the container
+    const clickCalls = addSpy.mock.calls.filter(([type]) => type === "click");
+    expect(clickCalls).toHaveLength(1);
+
+    addSpy.mockRestore();
+  });
+
+  it("dispatches click events through delegation", () => {
+    const onClick = jest.fn();
+    render(createElement("button", { onClick }, "click me"), container);
+    container.querySelector("button")!.click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps events in SyntheticEvent with correct properties", () => {
+    const onClick = jest.fn();
+    render(createElement("button", { onClick }, "click me"), container);
+    container.querySelector("button")!.click();
+
+    const syntheticEvent = onClick.mock.calls[0]![0];
+    expect(syntheticEvent).toHaveProperty("nativeEvent");
+    expect(syntheticEvent).toHaveProperty("type", "click");
+    expect(typeof syntheticEvent.preventDefault).toBe("function");
+    expect(typeof syntheticEvent.stopPropagation).toBe("function");
+    expect(typeof syntheticEvent.stopImmediatePropagation).toBe("function");
+    expect(typeof syntheticEvent.isPropagationStopped).toBe("function");
+    expect(typeof syntheticEvent.isDefaultPrevented).toBe("function");
+  });
+
+  // ── Capture → bubble order ────────────────────────────────────────────────
+
+  it("fires capture handlers before bubble handlers (root→target→root)", () => {
+    const order: string[] = [];
+
+    render(
+      createElement(
+        "div",
+        {
+          onClickCapture: () => order.push("outer-capture"),
+          onClick: () => order.push("outer-bubble"),
+        },
+        createElement(
+          "button",
+          {
+            onClickCapture: () => order.push("inner-capture"),
+            onClick: () => order.push("inner-bubble"),
+          },
+          "click",
+        ),
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+
+    expect(order).toEqual(["outer-capture", "inner-capture", "inner-bubble", "outer-bubble"]);
+  });
+
+  // ── stopPropagation ──────────────────────────────────────────────────────
+
+  it("stopPropagation halts synthetic bubble dispatch", () => {
+    const outerClick = jest.fn();
+    const innerClick = jest.fn((e: { stopPropagation(): void }) => {
+      e.stopPropagation();
+    });
+
+    render(
+      createElement(
+        "div",
+        { onClick: outerClick },
+        createElement("button", { onClick: innerClick }, "click"),
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+
+    expect(innerClick).toHaveBeenCalledTimes(1);
+    expect(outerClick).not.toHaveBeenCalled();
+  });
+
+  it("stopPropagation in capture phase stops bubble phase", () => {
+    const outerCapture = jest.fn((e: { stopPropagation(): void }) => {
+      e.stopPropagation();
+    });
+    const innerCapture = jest.fn();
+    const innerBubble = jest.fn();
+    const outerBubble = jest.fn();
+
+    render(
+      createElement(
+        "div",
+        { onClickCapture: outerCapture, onClick: outerBubble },
+        createElement("button", { onClickCapture: innerCapture, onClick: innerBubble }, "click"),
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+
+    expect(outerCapture).toHaveBeenCalledTimes(1);
+    expect(innerCapture).not.toHaveBeenCalled();
+    expect(innerBubble).not.toHaveBeenCalled();
+    expect(outerBubble).not.toHaveBeenCalled();
+  });
+
+  // ── stopImmediatePropagation ──────────────────────────────────────────────
+
+  it("stopImmediatePropagation stops all further dispatch", () => {
+    const order: string[] = [];
+
+    // We'll use capture on outer and bubble on inner to test cross-phase
+    render(
+      createElement(
+        "div",
+        {
+          onClickCapture: (e: { stopImmediatePropagation(): void }) => {
+            order.push("outer-capture");
+            e.stopImmediatePropagation();
+          },
+          onClick: () => order.push("outer-bubble"),
+        },
+        createElement("button", { onClick: () => order.push("inner-bubble") }, "click"),
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+
+    expect(order).toEqual(["outer-capture"]);
+  });
+
+  // ── preventDefault ──────────────────────────────────────────────────────
+
+  it("preventDefault calls native preventDefault", () => {
+    let defaultPrevented = false;
+
+    render(
+      createElement(
+        "button",
+        {
+          onClick: (e: { preventDefault(): void; isDefaultPrevented(): boolean }) => {
+            e.preventDefault();
+            defaultPrevented = e.isDefaultPrevented();
+          },
+        },
+        "click",
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+    expect(defaultPrevented).toBe(true);
+  });
+
+  // ── currentTarget ───────────────────────────────────────────────────────
+
+  it("currentTarget is correct at each step in the dispatch", () => {
+    const targets: Array<EventTarget | null> = [];
+
+    render(
+      createElement(
+        "div",
+        {
+          id: "outer",
+          onClick: (e: { currentTarget: EventTarget | null }) => {
+            targets.push(e.currentTarget);
+          },
+        },
+        createElement(
+          "button",
+          {
+            id: "inner",
+            onClick: (e: { currentTarget: EventTarget | null }) => {
+              targets.push(e.currentTarget);
+            },
+          },
+          "click",
+        ),
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+
+    // Bubble phase: button first, then outer div
+    expect(targets).toHaveLength(2);
+    expect((targets[0] as HTMLElement).id).toBe("inner");
+    expect((targets[1] as HTMLElement).id).toBe("outer");
+  });
+
+  // ── Batching ──────────────────────────────────────────────────────────
+
+  it("batches multiple setState calls during one event into one render", () => {
+    let renderCount = 0;
+
+    function* Multi() {
+      const [a, setA] = yield* $state(0);
+      const [b, setB] = yield* $state(0);
+      renderCount++;
+      return createElement(
+        "button",
+        {
+          onClick: () => {
+            setA(a + 1);
+            setB(b + 1);
+          },
+        },
+        `${a}-${b}`,
+      );
+    }
+
+    render(createElement(Multi as never, {}), container);
+    expect(renderCount).toBe(1);
+    expect(container.querySelector("button")!.textContent).toBe("0-0");
+
+    container.querySelector("button")!.click();
+    // After click, both state updates should have been processed
+    expect(container.querySelector("button")!.textContent).toBe("1-1");
+    // Should have rendered only twice total (initial + one batched rerender)
+    expect(renderCount).toBe(2);
+  });
+
+  // ── Non-delegated events ──────────────────────────────────────────────
+
+  it("scroll event is attached per-element (non-delegated)", () => {
+    const onScroll = jest.fn();
+    render(createElement("div", { onScroll }, "content"), container);
+
+    const div = container.querySelector("div")!;
+    const addSpy = jest.spyOn(div, "addEventListener");
+
+    // The scroll listener should have been added directly to the element,
+    // NOT to the root container. We can verify by checking the container
+    // doesn't have a scroll listener.
+    const containerAddSpy = jest.spyOn(container, "addEventListener");
+
+    // Re-render to check that additional scroll elements don't add root listeners
+    render(createElement("div", { onScroll: jest.fn() }, "content2"), container);
+
+    // Container should not get a "scroll" listener
+    const scrollOnContainer = containerAddSpy.mock.calls.filter(([type]) => type === "scroll");
+    expect(scrollOnContainer).toHaveLength(0);
+
+    addSpy.mockRestore();
+    containerAddSpy.mockRestore();
+  });
+
+  // ── Proxy: native properties accessible ──────────────────────────────
+
+  it("native event properties are accessible through SyntheticEvent proxy", () => {
+    let receivedEvent: Record<string, unknown> | null = null;
+
+    render(
+      createElement(
+        "button",
+        {
+          onClick: (e: Record<string, unknown>) => {
+            receivedEvent = e;
+          },
+        },
+        "click",
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+
+    expect(receivedEvent).not.toBeNull();
+    // bubbles is a standard property that our proxy should forward
+    expect(receivedEvent!["bubbles"]).toBe(true);
+    // type should be accessible
+    expect(receivedEvent!["type"]).toBe("click");
+  });
+
+  // ── Event prop mapping ────────────────────────────────────────────────
+
+  it("onDoubleClick maps to dblclick DOM event", () => {
+    const onDoubleClick = jest.fn();
+    render(createElement("button", { onDoubleClick }, "dblclick me"), container);
+
+    const btn = container.querySelector("button")!;
+    btn.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
+
+    expect(onDoubleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("onFocus maps to focusin DOM event (delegated)", () => {
+    const onFocus = jest.fn();
+    render(createElement("input", { onFocus }), container);
+
+    const input = container.querySelector("input")!;
+    input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("onBlur maps to focusout DOM event (delegated)", () => {
+    const onBlur = jest.fn();
+    render(createElement("input", { onBlur }), container);
+
+    const input = container.querySelector("input")!;
+    input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Delegation with nested components ─────────────────────────────────
+
+  it("works with generator components that rerender on click", () => {
+    function* Counter() {
+      const [count, setCount] = yield* $state(0);
+      return createElement("button", { onClick: () => setCount(count + 1) }, String(count));
+    }
+
+    render(createElement(Counter as never, {}), container);
+    expect(container.querySelector("button")!.textContent).toBe("0");
+
+    container.querySelector("button")!.click();
+    expect(container.querySelector("button")!.textContent).toBe("1");
+
+    container.querySelector("button")!.click();
+    expect(container.querySelector("button")!.textContent).toBe("2");
+  });
+
+  it("handles handler changes across rerenders", () => {
+    const handlers: Array<() => void> = [];
+
+    function* HandlerChanger() {
+      const [count, setCount] = yield* $state(0);
+      const handler = () => {
+        handlers.push(handler);
+        setCount(count + 1);
+      };
+      return createElement("button", { onClick: handler }, String(count));
+    }
+
+    render(createElement(HandlerChanger as never, {}), container);
+    const btn = container.querySelector("button")!;
+
+    btn.click();
+    expect(btn.textContent).toBe("1");
+
+    btn.click();
+    expect(btn.textContent).toBe("2");
+
+    // Each click should have used a different handler (new closure each render)
+    expect(handlers).toHaveLength(2);
+    expect(handlers[0]).not.toBe(handlers[1]);
+  });
+
+  // ── Deep nesting ──────────────────────────────────────────────────────
+
+  it("dispatches through deeply nested elements", () => {
+    const order: string[] = [];
+
+    render(
+      createElement(
+        "div",
+        {
+          id: "level1",
+          onClick: () => order.push("level1"),
+        },
+        createElement(
+          "div",
+          {
+            id: "level2",
+            onClick: () => order.push("level2"),
+          },
+          createElement(
+            "div",
+            {
+              id: "level3",
+              onClick: () => order.push("level3"),
+            },
+            createElement(
+              "button",
+              {
+                id: "target",
+                onClick: () => order.push("target"),
+              },
+              "click",
+            ),
+          ),
+        ),
+      ),
+      container,
+    );
+
+    container.querySelector("button")!.click();
+
+    expect(order).toEqual(["target", "level3", "level2", "level1"]);
+  });
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -3,9 +3,13 @@
  *
  * Every browser DOM event received by an event handler is automatically
  * wrapped in a `SyntheticEvent` before being passed to the JSX handler prop.
- * This provides a stable, cross-browser-consistent interface – similar to
- * React's SyntheticEvent – while still giving full access to the underlying
+ * This provides a stable, cross-browser-consistent interface -- similar to
+ * React's SyntheticEvent -- while still giving full access to the underlying
  * native event via `nativeEvent`.
+ *
+ * Uses a Proxy under the hood so that native event properties (e.g. `clientX`,
+ * `key`, `touches`) are accessible directly on the SyntheticEvent without
+ * explicit copying.
  */
 
 // ---------------------------------------------------------------------------
@@ -41,10 +45,10 @@ export interface SyntheticEvent<E extends Event = Event, T extends EventTarget =
   /** The DOM node that triggered the event (same as `nativeEvent.target`). */
   readonly target: EventTarget | null;
   /**
-   * The DOM node whose event-listener prop was matched
-   * (same as `nativeEvent.currentTarget`).
-   * Typed as `T` so element-specific properties (e.g. `.value` on
-   * `HTMLInputElement`) are accessible without casting.
+   * The DOM node whose event-listener prop was matched.
+   * For delegated events this is set by the dispatch algorithm as it walks
+   * the capture/bubble path. Typed as `T` so element-specific properties
+   * (e.g. `.value` on `HTMLInputElement`) are accessible without casting.
    */
   readonly currentTarget: T | null;
   /** Lowercase name of the event, e.g. `"click"`. */
@@ -63,6 +67,10 @@ export interface SyntheticEvent<E extends Event = Event, T extends EventTarget =
   stopPropagation(): void;
   /** Stop the event from reaching other listeners on the same element. */
   stopImmediatePropagation(): void;
+  /** Whether `stopPropagation()` has been called on this event. */
+  isPropagationStopped(): boolean;
+  /** Whether `preventDefault()` has been called on this event. */
+  isDefaultPrevented(): boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -86,26 +94,106 @@ export interface SyntheticEvent<E extends Event = Event, T extends EventTarget =
 export type SEvent<K extends keyof HTMLElementEventMap> = SyntheticEvent<HTMLElementEventMap[K]>;
 
 // ---------------------------------------------------------------------------
+// Internal type for dispatch algorithm
+// ---------------------------------------------------------------------------
+
+/**
+ * Extended SyntheticEvent with internal methods used by the dispatch
+ * algorithm to control `currentTarget` and query propagation state.
+ *
+ * @internal
+ */
+export interface _DelegatableEvent<E extends Event = Event> extends SyntheticEvent<E> {
+  /** Set `currentTarget` during the dispatch walk. @internal */
+  _setCurrentTarget(el: EventTarget | null): void;
+  /** Query whether `stopPropagation()` was called. @internal */
+  _isPropagationStopped(): boolean;
+  /** Query whether `stopImmediatePropagation()` was called. @internal */
+  _isImmediatePropagationStopped(): boolean;
+}
+
+// ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
 
 /**
- * Wrap a native DOM event in a `SyntheticEvent` object.
- * Called automatically by the renderer in `applyProps`; you do not normally
- * need to call this yourself.
+ * Wrap a native DOM event in a `SyntheticEvent` backed by a Proxy.
+ *
+ * Unknown property reads (e.g. `clientX`, `key`, `touches`) are proxied
+ * through to the native event, so all event-type-specific data is
+ * accessible without explicit copying.
+ *
+ * @param nativeEvent - The native browser event to wrap.
+ * @param delegated   - `true` for events dispatched via the delegation root
+ *   (stopPropagation does NOT call `nativeEvent.stopPropagation()` since
+ *   the native event already reached the root). `false` for per-element
+ *   non-delegated events (stopPropagation calls native method).
  */
-export function createSyntheticEvent<E extends Event>(nativeEvent: E): SyntheticEvent<E> {
-  return {
+export function createSyntheticEvent<E extends Event>(
+  nativeEvent: E,
+  delegated = false,
+): _DelegatableEvent<E> {
+  let _propagationStopped = false;
+  let _immediatePropagationStopped = false;
+  let _currentTarget: EventTarget | null = nativeEvent.currentTarget;
+
+  // Object with all known properties — the Proxy falls through to
+  // nativeEvent for anything not listed here.
+  const overrides: Record<string, unknown> = {
     nativeEvent,
     target: nativeEvent.target,
-    currentTarget: nativeEvent.currentTarget,
     type: nativeEvent.type,
     bubbles: nativeEvent.bubbles,
     cancelable: nativeEvent.cancelable,
-    defaultPrevented: nativeEvent.defaultPrevented,
     timeStamp: nativeEvent.timeStamp,
-    preventDefault: () => nativeEvent.preventDefault(),
-    stopPropagation: () => nativeEvent.stopPropagation(),
-    stopImmediatePropagation: () => nativeEvent.stopImmediatePropagation(),
   };
+
+  // Pre-bound methods so the same function reference is returned on
+  // every property access (prevents unnecessary allocations in hot paths).
+  const preventDefaultFn = () => nativeEvent.preventDefault();
+  const stopPropagationFn = () => {
+    _propagationStopped = true;
+    if (!delegated) nativeEvent.stopPropagation();
+  };
+  const stopImmediatePropagationFn = () => {
+    _propagationStopped = true;
+    _immediatePropagationStopped = true;
+    if (!delegated) nativeEvent.stopImmediatePropagation();
+  };
+  const isPropagationStoppedFn = () => _propagationStopped;
+  const isDefaultPreventedFn = () => nativeEvent.defaultPrevented;
+  const _setCurrentTargetFn = (el: EventTarget | null) => {
+    _currentTarget = el;
+  };
+  const _isPropagationStoppedFn = () => _propagationStopped;
+  const _isImmediatePropagationStoppedFn = () => _immediatePropagationStopped;
+
+  const methods: Record<string, unknown> = {
+    preventDefault: preventDefaultFn,
+    stopPropagation: stopPropagationFn,
+    stopImmediatePropagation: stopImmediatePropagationFn,
+    isPropagationStopped: isPropagationStoppedFn,
+    isDefaultPrevented: isDefaultPreventedFn,
+    _setCurrentTarget: _setCurrentTargetFn,
+    _isPropagationStopped: _isPropagationStoppedFn,
+    _isImmediatePropagationStopped: _isImmediatePropagationStoppedFn,
+  };
+
+  return new Proxy(overrides as unknown as _DelegatableEvent<E>, {
+    get(_target, prop: string | symbol) {
+      // Dynamic properties
+      if (prop === "currentTarget") return _currentTarget;
+      if (prop === "defaultPrevented") return nativeEvent.defaultPrevented;
+
+      // Static overrides
+      const key = prop as string;
+      if (key in methods) return methods[key];
+      if (key in overrides) return overrides[key];
+
+      // Fall through to native event
+      const val: unknown = (nativeEvent as Record<string | symbol, unknown>)[prop];
+      if (typeof val === "function") return (val as (...a: never[]) => unknown).bind(nativeEvent);
+      return val;
+    },
+  });
 }

--- a/src/render/delegation.ts
+++ b/src/render/delegation.ts
@@ -1,0 +1,213 @@
+/**
+ * delegation.ts — Handler registry, prop-to-event mapping, and DelegationRoot.
+ *
+ * The event delegation system attaches a single native listener per event
+ * type on the root container element. When an event fires, the dispatch
+ * algorithm (in `dispatch.ts`) walks the DOM path from target to root,
+ * looking up handlers in the registry at each element.
+ *
+ * **Handler registry:** `WeakMap<Element, Map<string, HandlerEntry>>` — maps
+ * each DOM element to its event handlers by lowercase DOM event name.
+ * Uses `WeakMap` so entries are garbage-collected when elements are removed.
+ *
+ * **DelegationRoot:** Lazily attaches root listeners the first time an event
+ * type is encountered. Created by `render()` / `createRoot()`.
+ */
+
+import type { SyntheticEvent } from "../events";
+
+// ---------------------------------------------------------------------------
+// Handler registry
+// ---------------------------------------------------------------------------
+
+/** Stores bubble and/or capture handlers for one DOM event on one element. */
+export interface HandlerEntry {
+  bubble?: (e: SyntheticEvent) => void;
+  capture?: (e: SyntheticEvent) => void;
+}
+
+/**
+ * Maps each DOM element to its registered event handlers.
+ *
+ * Outer key: DOM element. Inner key: lowercase DOM event name (e.g. `"click"`).
+ * Inner value: handlers for that event (bubble and/or capture).
+ */
+const _handlerRegistry = new WeakMap<Element, Map<string, HandlerEntry>>();
+
+/**
+ * Register a handler for a DOM event on an element.
+ *
+ * Called by `applyProps` / `updateProps` for delegated events.
+ */
+export function registerHandler(
+  el: Element,
+  domEvent: string,
+  handler: (e: SyntheticEvent) => void,
+  isCapture: boolean,
+): void {
+  let map = _handlerRegistry.get(el);
+  if (!map) {
+    map = new Map();
+    _handlerRegistry.set(el, map);
+  }
+  let entry = map.get(domEvent);
+  if (!entry) {
+    entry = {};
+    map.set(domEvent, entry);
+  }
+  if (isCapture) {
+    entry.capture = handler;
+  } else {
+    entry.bubble = handler;
+  }
+}
+
+/**
+ * Remove a handler for a DOM event from an element.
+ *
+ * Called by `updateProps` when a handler is removed or replaced.
+ */
+export function unregisterHandler(el: Element, domEvent: string, isCapture: boolean): void {
+  const map = _handlerRegistry.get(el);
+  if (!map) return;
+  const entry = map.get(domEvent);
+  if (!entry) return;
+  if (isCapture) {
+    delete entry.capture;
+  } else {
+    delete entry.bubble;
+  }
+  if (!entry.capture && !entry.bubble) {
+    map.delete(domEvent);
+  }
+}
+
+/**
+ * Look up the handler entry for a DOM event on an element.
+ *
+ * Called by the dispatch algorithm during the capture/bubble walk.
+ */
+export function getHandlers(el: Element, domEvent: string): HandlerEntry | undefined {
+  return _handlerRegistry.get(el)?.get(domEvent);
+}
+
+// ---------------------------------------------------------------------------
+// Non-delegated events
+// ---------------------------------------------------------------------------
+
+/**
+ * Events that bypass delegation and are attached per-element.
+ *
+ * These events either don't bubble naturally or have semantics that
+ * make delegation impractical (e.g. `scroll` fires on the scrolling
+ * element only, `load`/`error` on the resource element).
+ *
+ * `mouseenter`/`mouseleave` and `pointerenter`/`pointerleave` don't
+ * bubble, so they must be per-element in PR 1. PR 2 will convert them
+ * to delegated `mouseover`/`mouseout` simulation.
+ */
+export const NON_DELEGATED_EVENTS = new Set([
+  "scroll",
+  "scrollend",
+  "cancel",
+  "close",
+  "invalid",
+  "load",
+  "error",
+  "toggle",
+  "mouseenter",
+  "mouseleave",
+  "pointerenter",
+  "pointerleave",
+]);
+
+// ---------------------------------------------------------------------------
+// Prop name → DOM event mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Special prop-to-DOM-event mappings for props whose DOM event name
+ * doesn't follow the default `propKey.slice(2).toLowerCase()` rule.
+ */
+const PROP_TO_DOM_EVENT: Record<string, string> = {
+  onDoubleClick: "dblclick",
+  onFocus: "focusin",
+  onBlur: "focusout",
+};
+
+/**
+ * Resolve a JSX event prop name to a DOM event name and capture flag.
+ *
+ * - Detects `Capture` suffix (e.g. `onClickCapture` → `click`, capture).
+ * - Applies special mapping (e.g. `onDoubleClick` → `dblclick`).
+ * - Falls back to `propKey.slice(2).toLowerCase()` for standard events.
+ */
+export function resolveEventProp(propKey: string): { domEvent: string; isCapture: boolean } {
+  let isCapture = false;
+  let baseProp = propKey;
+
+  // Detect Capture suffix: "on" (2) + at least 1 char + "Capture" (7) = min 10
+  if (propKey.endsWith("Capture") && propKey.length >= 10) {
+    const withoutCapture = propKey.slice(0, -7);
+    if (withoutCapture.length > 2) {
+      isCapture = true;
+      baseProp = withoutCapture;
+    }
+  }
+
+  // Special mapping
+  const mapped = PROP_TO_DOM_EVENT[baseProp];
+  if (mapped) {
+    return { domEvent: mapped, isCapture };
+  }
+
+  // Default: strip "on" and lowercase
+  return { domEvent: baseProp.slice(2).toLowerCase(), isCapture };
+}
+
+// ---------------------------------------------------------------------------
+// DelegationRoot
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages root-level native event listeners for one render root.
+ *
+ * Lazily attaches a root listener the first time an event type is
+ * encountered via `ensureListening()`. The listener delegates to a
+ * dispatch callback (provided at construction) which walks the DOM
+ * path and invokes registered handlers.
+ *
+ * Created by `render()` / `createRoot()` and stored on `RenderContext`.
+ */
+export class DelegationRoot {
+  private _root: Element;
+  private _registeredTypes = new Set<string>();
+  private _listeners = new Map<string, EventListener>();
+  private _dispatch: (nativeEvent: Event, domEvent: string) => void;
+
+  constructor(root: Element, dispatch: (nativeEvent: Event, domEvent: string) => void) {
+    this._root = root;
+    this._dispatch = dispatch;
+  }
+
+  /** Lazily attach a root listener for the given DOM event type. */
+  ensureListening(domEvent: string): void {
+    if (this._registeredTypes.has(domEvent)) return;
+    this._registeredTypes.add(domEvent);
+
+    const listener: EventListener = (nativeEvent: Event) => {
+      this._dispatch(nativeEvent, domEvent);
+    };
+    this._listeners.set(domEvent, listener);
+    this._root.addEventListener(domEvent, listener);
+  }
+
+  /** Remove all root listeners. For future cleanup / unmount support. */
+  dispose(): void {
+    for (const [domEvent, listener] of this._listeners) {
+      this._root.removeEventListener(domEvent, listener);
+    }
+    this._listeners.clear();
+    this._registeredTypes.clear();
+  }
+}

--- a/src/render/dispatch.ts
+++ b/src/render/dispatch.ts
@@ -1,0 +1,101 @@
+/**
+ * dispatch.ts — Delegated event dispatch algorithm.
+ *
+ * When a native event reaches the delegation root, this module:
+ * 1. Builds a DOM path from `event.target` up to the root container.
+ * 2. Creates a Proxy-based SyntheticEvent.
+ * 3. Walks the path in capture phase (root → target), then bubble phase
+ *    (target → root), calling registered handlers at each element.
+ * 4. Wraps the entire dispatch in a batching context so multiple
+ *    `setState` calls during one event are processed in a single pass.
+ */
+
+import { createSyntheticEvent } from "../events";
+import { getHandlers } from "./delegation";
+import { _flushPendingWork } from "./scheduler";
+import { _setActiveCtx } from "./state";
+import type { RenderContext } from "./types";
+
+/**
+ * Dispatch a delegated event through the synthetic capture → bubble phases.
+ *
+ * Called by the `DelegationRoot`'s native listener when an event reaches
+ * the root container element.
+ *
+ * @param nativeEvent - The native DOM event.
+ * @param rootElement - The delegation root container element.
+ * @param domEvent    - The lowercase DOM event name (e.g. `"click"`).
+ * @param rctx        - The render context for this root.
+ */
+export function dispatchDelegatedEvent(
+  nativeEvent: Event,
+  rootElement: Element,
+  domEvent: string,
+  rctx: RenderContext,
+): void {
+  // 1. Build path: walk from target up to (but not including) root.
+  //    Collect only Element nodes (skip Text/Comment nodes).
+  const path: Element[] = [];
+  let node: Node | null = nativeEvent.target as Node | null;
+  while (node && node !== rootElement) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      path.push(node as Element);
+    }
+    node = node.parentNode;
+  }
+  // path[0] = target element, path[length-1] = child of root
+
+  if (path.length === 0) return;
+
+  // 2. Create SyntheticEvent (delegated = true: stopPropagation only
+  //    affects the synthetic dispatch, not the native event).
+  const syntheticEvent = createSyntheticEvent(nativeEvent, true);
+
+  // 3. Batching: suppress immediate scheduling during dispatch so
+  //    multiple setState calls are batched into a single render pass.
+  _setActiveCtx(rctx);
+  const wasProcessing = rctx.isProcessing;
+  rctx.isProcessing = true;
+
+  try {
+    // 4. Capture phase (root → target): walk path from outermost to innermost.
+    for (let i = path.length - 1; i >= 0; i--) {
+      const el = path[i]!;
+      const entry = getHandlers(el, domEvent);
+      if (entry?.capture) {
+        syntheticEvent._setCurrentTarget(el);
+        entry.capture(syntheticEvent);
+        if (
+          syntheticEvent._isImmediatePropagationStopped() ||
+          syntheticEvent._isPropagationStopped()
+        ) {
+          break;
+        }
+      }
+    }
+
+    // 5. Bubble phase (target → root): walk path from innermost to outermost.
+    if (!syntheticEvent._isPropagationStopped()) {
+      for (let i = 0; i < path.length; i++) {
+        const el = path[i]!;
+        const entry = getHandlers(el, domEvent);
+        if (entry?.bubble) {
+          syntheticEvent._setCurrentTarget(el);
+          entry.bubble(syntheticEvent);
+          if (
+            syntheticEvent._isImmediatePropagationStopped() ||
+            syntheticEvent._isPropagationStopped()
+          ) {
+            break;
+          }
+        }
+      }
+    }
+  } finally {
+    // 6. Restore batching state and flush any queued work.
+    rctx.isProcessing = wasProcessing;
+    if (!wasProcessing) {
+      _flushPendingWork(rctx);
+    }
+  }
+}

--- a/src/render/events.ts
+++ b/src/render/events.ts
@@ -1,40 +1,41 @@
+/**
+ * Per-element event listener management for non-delegated events.
+ *
+ * Events in `NON_DELEGATED_EVENTS` (scroll, load, error, etc.) bypass
+ * the delegation system and are attached directly on the target element.
+ * This module tracks the wrapper functions so they can be removed when
+ * props change or the element is unmounted.
+ *
+ * For delegated events, see `delegation.ts` and `dispatch.ts`.
+ */
+
 import { createSyntheticEvent, type SyntheticEvent } from "../events";
 
 /**
- * Maps each DOM element to its currently-registered synthetic event wrappers.
- *
- * Outer key: the DOM element. Inner key: lowercase event name (e.g. `"click"`).
- * Inner value: the wrapper `EventListener` that was passed to `addEventListener`.
- *
- * This tracking is necessary because yielderact wraps user handlers in a
- * synthetic-event adapter. When a handler changes (e.g. the parent re-renders
- * with a new `onClick`), `updateProps` must remove the *exact wrapper* that
- * was previously added — not the user's handler, which is a different function.
- *
- * Uses a `WeakMap` so entries are garbage-collected when elements are removed.
+ * Maps each DOM element to its currently-registered non-delegated event
+ * wrappers. Uses a `WeakMap` so entries are garbage-collected when
+ * elements are removed.
  */
-const listenerWrappers = new WeakMap<HTMLElement, Map<string, EventListener>>();
+const listenerWrappers = new WeakMap<Element, Map<string, EventListener>>();
 
 /**
- * Attach a synthetic event listener to a DOM element.
+ * Attach a non-delegated event listener to a DOM element.
  *
  * Wraps the user-provided `handler` so it receives a `SyntheticEvent`
- * instead of a native `Event`. Stores the wrapper in `listenerWrappers`
- * so it can be removed later by `removeSyntheticListener`.
- *
- * **Called by:** `applyProps` (initial mount) and `updateProps` (when an
- * `onXxx` handler is added or replaced) in `props.ts`.
+ * (with `delegated=false`, meaning `stopPropagation` calls the native
+ * method). Stores the wrapper for later removal.
  *
  * @param el        - The DOM element to listen on.
- * @param eventName - Lowercase event name (e.g. `"click"`, `"input"`).
- * @param handler   - The user's event handler that receives a SyntheticEvent.
+ * @param eventName - Lowercase event name (e.g. `"scroll"`, `"load"`).
+ * @param handler   - The user's event handler.
  */
-export function addSyntheticListener(
-  el: HTMLElement,
+export function addNonDelegatedListener(
+  el: Element,
   eventName: string,
   handler: (e: SyntheticEvent) => void,
 ): void {
-  const wrapper: EventListener = (nativeEvent: Event) => handler(createSyntheticEvent(nativeEvent));
+  const wrapper: EventListener = (nativeEvent: Event) =>
+    handler(createSyntheticEvent(nativeEvent, false));
   el.addEventListener(eventName, wrapper);
   let map = listenerWrappers.get(el);
   if (!map) {
@@ -45,18 +46,13 @@ export function addSyntheticListener(
 }
 
 /**
- * Remove a previously-attached synthetic event listener from a DOM element.
- *
- * Looks up the wrapper in `listenerWrappers` and calls `removeEventListener`
- * with the exact same function reference that was originally added.
- *
- * **Called by:** `updateProps` in `props.ts` — when an `onXxx` handler is
- * removed or replaced with a new handler.
+ * Remove a previously-attached non-delegated event listener.
  *
  * @param el        - The DOM element to remove the listener from.
- * @param eventName - Lowercase event name (must match the name used in `addSyntheticListener`).
+ * @param eventName - Lowercase event name (must match the name used in
+ *   `addNonDelegatedListener`).
  */
-export function removeSyntheticListener(el: HTMLElement, eventName: string): void {
+export function removeNonDelegatedListener(el: Element, eventName: string): void {
   const wrapper = listenerWrappers.get(el)?.get(eventName);
   if (wrapper) {
     el.removeEventListener(eventName, wrapper);

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,5 +1,7 @@
 import { _getCtxMap, _setCtxMap, _withBatch } from "../context";
 import type { VNode } from "../jsx";
+import { DelegationRoot } from "./delegation";
+import { dispatchDelegatedEvent } from "./dispatch";
 import { buildNode } from "./mount";
 import { _setActiveCtx, createRenderContext } from "./state";
 
@@ -25,6 +27,9 @@ export { flushSync, scheduleUpdate } from "./scheduler";
  */
 export function render(vnode: VNode, container: Element): void {
   const rctx = createRenderContext();
+  rctx.delegationRoot = new DelegationRoot(container, (nativeEvent, domEvent) =>
+    dispatchDelegatedEvent(nativeEvent, container, domEvent, rctx),
+  );
   _setActiveCtx(rctx);
   rctx.isInitialMount = true;
   try {
@@ -64,6 +69,9 @@ export interface Root {
  */
 export function createRoot(container: Element): Root {
   const rctx = createRenderContext();
+  rctx.delegationRoot = new DelegationRoot(container, (nativeEvent, domEvent) =>
+    dispatchDelegatedEvent(nativeEvent, container, domEvent, rctx),
+  );
   return {
     render(vnode: VNode): void {
       _setActiveCtx(rctx);

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -1,5 +1,12 @@
 import type { SyntheticEvent } from "../events";
-import { addSyntheticListener, removeSyntheticListener } from "./events";
+import {
+  NON_DELEGATED_EVENTS,
+  registerHandler,
+  resolveEventProp,
+  unregisterHandler,
+} from "./delegation";
+import { addNonDelegatedListener, removeNonDelegatedListener } from "./events";
+import { _requireActiveCtx } from "./state";
 
 // ── Ref helpers ─────────────────────────────────────────────────────────────
 
@@ -23,6 +30,38 @@ export function clearRef(ref: unknown): void {
   }
 }
 
+// ── Event registration helpers ─────────────────────────────────────────────
+
+/**
+ * Register an event handler for an element, using either delegation or
+ * per-element attachment depending on the event type.
+ */
+function _registerEvent(
+  el: HTMLElement,
+  propKey: string,
+  handler: (e: SyntheticEvent) => void,
+): void {
+  const { domEvent, isCapture } = resolveEventProp(propKey);
+  if (NON_DELEGATED_EVENTS.has(domEvent)) {
+    addNonDelegatedListener(el, domEvent, handler);
+  } else {
+    registerHandler(el, domEvent, handler, isCapture);
+    _requireActiveCtx().delegationRoot!.ensureListening(domEvent);
+  }
+}
+
+/**
+ * Unregister an event handler from an element.
+ */
+function _unregisterEvent(el: HTMLElement, propKey: string): void {
+  const { domEvent, isCapture } = resolveEventProp(propKey);
+  if (NON_DELEGATED_EVENTS.has(domEvent)) {
+    removeNonDelegatedListener(el, domEvent);
+  } else {
+    unregisterHandler(el, domEvent, isCapture);
+  }
+}
+
 // ── Prop application ────────────────────────────────────────────────────────
 
 /**
@@ -40,7 +79,7 @@ export function clearRef(ref: unknown): void {
  *
  * **Prop handling rules:**
  * - All `$`-prefixed props are skipped (framework-internal special props).
- * - `onXxx` props → `addSyntheticListener(el, eventName, handler)`.
+ * - `onXxx` props → delegated or per-element via `_registerEvent`.
  * - `className` → `el.className`.
  * - `htmlFor` → `el.setAttribute('for', …)`.
  * - `style` (object) → `Object.assign(el.style, …)`.
@@ -60,7 +99,7 @@ export function applyProps(el: HTMLElement, props: Record<string, unknown>): voi
   for (const [key, value] of Object.entries(props)) {
     if (key.startsWith("$")) continue;
     if (key.startsWith("on") && typeof value === "function") {
-      addSyntheticListener(el, key.slice(2).toLowerCase(), value as (e: SyntheticEvent) => void);
+      _registerEvent(el, key, value as (e: SyntheticEvent) => void);
     } else if (key === "className") {
       el.className = String(value);
     } else if (key === "htmlFor") {
@@ -137,7 +176,7 @@ export function updateProps(
     if (key.startsWith("$")) continue;
     if (key in nextProps) continue;
     if (key.startsWith("on") && typeof prevProps[key] === "function") {
-      removeSyntheticListener(el, key.slice(2).toLowerCase());
+      _unregisterEvent(el, key);
     } else if (key === "className") {
       el.className = "";
     } else if (key === "htmlFor") {
@@ -157,8 +196,8 @@ export function updateProps(
     if (Object.is(next, prev)) continue;
 
     if (key.startsWith("on") && typeof next === "function") {
-      if (typeof prev === "function") removeSyntheticListener(el, key.slice(2).toLowerCase());
-      addSyntheticListener(el, key.slice(2).toLowerCase(), next as (e: SyntheticEvent) => void);
+      if (typeof prev === "function") _unregisterEvent(el, key);
+      _registerEvent(el, key, next as (e: SyntheticEvent) => void);
     } else if (key === "style" && typeof next === "object" && next !== null) {
       // Clear removed style properties, then apply current ones
       if (typeof prev === "object" && prev !== null) {

--- a/src/render/scheduler.ts
+++ b/src/render/scheduler.ts
@@ -98,6 +98,25 @@ export function flushSync(fn?: () => void): void {
   rctx.syncMode = prevSync;
 }
 
+/**
+ * Flush any pending work for a specific render context.
+ *
+ * Called by the event dispatch system after a delegated event has been
+ * fully dispatched. Unlike `flushSync()`, this takes an explicit
+ * `RenderContext` rather than reading the active context pointer, which
+ * is important when an event handler in root A might have changed the
+ * active context to root B.
+ *
+ * @internal
+ */
+export function _flushPendingWork(rctx: RenderContext): void {
+  if (_hasPendingWork(rctx)) {
+    _setActiveCtx(rctx);
+    rctx.isProcessing = true;
+    _runLoop(rctx);
+  }
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 /** Returns true if any priority level has pending instances. */

--- a/src/render/state.ts
+++ b/src/render/state.ts
@@ -21,6 +21,7 @@ export function createRenderContext(): RenderContext {
     isProcessing: false,
     activePriority: null,
     syncMode: true,
+    delegationRoot: null,
   };
 }
 

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -1,6 +1,7 @@
 import type { Context, UseContextState } from "../context";
 import type { UseRenderState } from "../hooks/$render";
 import type { Child, GeneratorComponentFn, VNode } from "../jsx";
+import type { DelegationRoot } from "./delegation";
 
 // ── Render context ─────────────────────────────────────────────────────────
 //
@@ -39,6 +40,15 @@ export interface RenderContext {
   isProcessing: boolean;
   activePriority: number | null;
   syncMode: boolean;
+
+  // ── From delegation.ts ──
+  /**
+   * The delegation root for this render context, or `null` before the
+   * root has been mounted. Created by `render()` / `createRoot()` and
+   * used by `applyProps` / `updateProps` to register handlers and
+   * lazily attach root listeners.
+   */
+  delegationRoot: DelegationRoot | null;
 }
 
 // ── Hook state discriminated union ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements a React 19-style event delegation system that replaces per-element event listeners with root-level delegation. A single native listener per event type is lazily attached to the root container, and a dispatch algorithm walks the DOM path through capture→bubble phases using a WeakMap handler registry.

## Changes

- **`src/events.ts`** — Rewrite `createSyntheticEvent` to use a Proxy-based approach; native event properties (clientX, key, etc.) are accessible without copying; adds `isPropagationStopped()`/`isDefaultPrevented()` query methods; factory accepts `delegated` flag to control `stopPropagation` behavior
- **`src/render/delegation.ts`** (new) — Handler registry (`WeakMap<Element, Map<string, HandlerEntry>>`), `DelegationRoot` class with lazy root listener registration, `resolveEventProp()` for prop→DOM event mapping (Capture suffix, onDoubleClick→dblclick, onFocus→focusin, onBlur→focusout), `NON_DELEGATED_EVENTS` set
- **`src/render/dispatch.ts`** (new) — `dispatchDelegatedEvent()` builds DOM path from target to root, walks capture phase (root→target) then bubble phase (target→root), wraps dispatch in batching context (`isProcessing=true`) so multiple `setState` calls are processed in one pass
- **`src/render/events.ts`** — Simplified to only handle non-delegated events (`addNonDelegatedListener`/`removeNonDelegatedListener`)
- **`src/render/props.ts`** — Replaced `addSyntheticListener`/`removeSyntheticListener` calls with `registerHandler`/`unregisterHandler` for delegated events and `addNonDelegatedListener`/`removeNonDelegatedListener` for non-delegated events
- **`src/render/index.ts`** — Creates `DelegationRoot` in both `render()` and `createRoot()`
- **`src/render/types.ts`** — Added `delegationRoot: DelegationRoot | null` to `RenderContext`
- **`src/render/state.ts`** — Initialize `delegationRoot: null`
- **`src/render/scheduler.ts`** — Export `_flushPendingWork(rctx)` for post-dispatch flush
- **`CLAUDE.md`** — Added `delegation.ts`, `dispatch.ts`, `events.ts` to Core Module Map
- **18 new tests** covering delegation, capture/bubble order, stopPropagation, batching, currentTarget, non-delegated events, proxy property access, prop mapping, and nested components

## Closes #70

## Verification

- `npm run lint:fix` — passes (warnings are pre-existing)
- `npm run build` — passes
- `npm test` — 216/216 pass (198 existing + 18 new)
- `npm run test:visual` — 57/57 pass

## CLAUDE.md Update

Updated Core Module Map to include `render/delegation.ts`, `render/dispatch.ts`, and `render/events.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)