### PR TITLE
fix: resolve all Biome lint warnings and enable --error-on-warnings

### DIFF
--- a/examples/src/main.tsx
+++ b/examples/src/main.tsx
@@ -111,5 +111,7 @@ function* App() {
   );
 }
 
-const root = createRoot(document.getElementById("root")!);
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("Missing #root element");
+const root = createRoot(rootEl);
 root.render(<App />);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "tsc",
     "test": "jest",
     "test:visual": "playwright test",
-    "lint": "biome check .",
+    "lint": "biome check --error-on-warnings .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome check --linter-enabled=false ."

--- a/playwright-tests/visual.test.ts
+++ b/playwright-tests/visual.test.ts
@@ -58,7 +58,7 @@ test("renders a plain HTML element", async ({ page }) => {
     ).Yielderact;
     render(
       createElement("h1", { id: "heading", className: "title" }, "Hello yielderact"),
-      document.getElementById("root")!,
+      document.getElementById("root") as HTMLElement,
     );
   });
 
@@ -82,7 +82,7 @@ test("renders nested elements", async ({ page }) => {
         createElement("li", null, "Item 2"),
         createElement("li", null, "Item 3"),
       ),
-      document.getElementById("root")!,
+      document.getElementById("root") as HTMLElement,
     );
   });
 
@@ -117,7 +117,7 @@ test("generator counter increments on click", async ({ page }) => {
       );
     }
 
-    render(createElement(Counter as never, {}), document.getElementById("root")!);
+    render(createElement(Counter as never, {}), document.getElementById("root") as HTMLElement);
   });
 
   await expect(page.locator("#btn")).toHaveText("0");
@@ -151,7 +151,7 @@ test("plain function component renders correctly", async ({ page }) => {
 
     render(
       createElement(Greeting as never, { name: "Playwright" }),
-      document.getElementById("root")!,
+      document.getElementById("root") as HTMLElement,
     );
   });
 
@@ -184,7 +184,7 @@ test("generator renders child generator component", async ({ page }) => {
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
   });
 
   await expect(page.locator("#app h2")).toHaveText("App");
@@ -215,7 +215,7 @@ test("parent re-render preserves child generator state (memoization)", async ({ 
       return createElement("div", null, createElement(Child as never, {}));
     }
 
-    render(createElement(Parent as never, {}), document.getElementById("root")!);
+    render(createElement(Parent as never, {}), document.getElementById("root") as HTMLElement);
   });
 
   await expect(page.locator("#child-count")).toHaveText("0");
@@ -260,7 +260,7 @@ test("context Provider supplies value to deeply nested consumer", async ({ page 
         { value: "dark" },
         createElement(Section as never, {}),
       ),
-      document.getElementById("root")!,
+      document.getElementById("root") as HTMLElement,
     );
   });
 
@@ -289,7 +289,7 @@ test("Fragment renders multiple children without a wrapper", async ({ page }) =>
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
   });
 
   await expect(page.locator("#p1")).toHaveText("First");
@@ -338,10 +338,10 @@ test("$context selector: consumer skips rerender when selected dep is unchanged"
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
 
     // Expose setter on window for Playwright to call
-    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
+    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt?.(v);
   });
 
   // Initial state
@@ -397,8 +397,8 @@ test("$context selector: consumer rerenders in-place ($ref preserved) when selec
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
-    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
+    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt?.(v);
   });
 
   await expect(page.locator("#name")).toHaveText("Alice");
@@ -464,8 +464,8 @@ test("$context transform: suppresses rerender when dep stable; updates transform
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
-    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
+    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt?.(v);
   });
 
   // Initial: ALICE, rendered once
@@ -538,8 +538,8 @@ test("$context no-selector vs selector: no-selector updates on any field change,
       ]);
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
-    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt!(v);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
+    (window as unknown as Record<string, unknown>).__setSt = (v: State) => setSt?.(v);
   });
 
   await expect(page.locator("#no-sel-count")).toHaveText("0");
@@ -592,9 +592,9 @@ test("$context selector: hook state preserved when rerender suppressed", async (
       );
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
-    (window as unknown as Record<string, unknown>).__setCtx = (v: State) => setCtx!(v);
-    (window as unknown as Record<string, unknown>).__setLocal = (v: number) => setLocal!(v);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
+    (window as unknown as Record<string, unknown>).__setCtx = (v: State) => setCtx?.(v);
+    (window as unknown as Record<string, unknown>).__setLocal = (v: number) => setLocal?.(v);
   });
 
   // Set local state to 100
@@ -636,7 +636,7 @@ test("inline styles are applied correctly", async ({ page }) => {
         },
         "Styled",
       ),
-      document.getElementById("root")!,
+      document.getElementById("root") as HTMLElement,
     );
   });
 
@@ -680,16 +680,16 @@ test("global patch: child prop change before patch survives to commit (disabled 
       return createElement("div", null, createElement(Nav as never, { isPending }));
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
 
     // Step 1: set isPending=true BEFORE the patch (immediate DOM update)
-    setPending!(true);
+    setPending?.(true);
 
     // Step 2: start the patch
     startUIPatch();
 
     // Step 3: clear isPending INSIDE the patch (deferred — DOM still shows disabled)
-    setPending!(false);
+    setPending?.(false);
 
     // Expose a commit handle for the test to call after asserting frozen state
     doCommit = commitUIPatch;
@@ -734,16 +734,16 @@ test("local patch: child prop change before patch survives to commit (disabled b
       return createElement("div", null, createElement(Nav as never, { isPending }));
     }
 
-    render(createElement(App as never, {}), document.getElementById("root")!);
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
 
     // Step 1: set isPending=true BEFORE the patch (immediate DOM update)
-    setPending!(true);
+    setPending?.(true);
 
     // Step 2: start the local patch and capture the commit fn
-    const commit = capturedStartPatch!();
+    const commit = capturedStartPatch?.();
 
     // Step 3: clear isPending inside the patch (deferred)
-    setPending!(false);
+    setPending?.(false);
 
     // Expose the commit fn for the test to call after asserting the frozen state
     (window as unknown as { doCommit: () => void }).doCommit = commit;
@@ -820,7 +820,7 @@ test("$effect: AbortSignal abort count increments when deps change", async ({ pa
       );
     }
 
-    render(createElement(App, {}), document.getElementById("root")!);
+    render(createElement(App, {}), document.getElementById("root") as HTMLElement);
   });
 
   // Initial: user 1 is polling, others inactive, all abort counts 0
@@ -911,7 +911,7 @@ test("$effect: AbortSignal is aborted on component unmount", async ({ page }) =>
       );
     }
 
-    render(createElement(App, {}), document.getElementById("root")!);
+    render(createElement(App, {}), document.getElementById("root") as HTMLElement);
   });
 
   // Ticker should be running
@@ -983,7 +983,7 @@ test("$effect: AbortSignal aborts async work (fetch-like) on deps change", async
       );
     }
 
-    render(createElement(App, {}), document.getElementById("root")!);
+    render(createElement(App, {}), document.getElementById("root") as HTMLElement);
   });
 
   // Initial: pending then resolves to done-1

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -28,7 +28,7 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Consumer as never, {}), container);
-    expect(container.querySelector("span")!.textContent).toBe("default");
+    expect(container.querySelector("span")?.textContent).toBe("default");
   });
 
   it("passes a value through Context.Provider to a consumer component", () => {
@@ -47,7 +47,7 @@ describe("createContext / $context", () => {
       ),
       container,
     );
-    expect(container.querySelector("span")!.textContent).toBe("provided");
+    expect(container.querySelector("span")?.textContent).toBe("provided");
   });
 
   it("nested Providers shadow the outer value", () => {
@@ -74,7 +74,7 @@ describe("createContext / $context", () => {
       ),
       container,
     );
-    expect(container.querySelector("span")!.textContent).toBe("inner");
+    expect(container.querySelector("span")?.textContent).toBe("inner");
   });
 
   it("consumer outside Provider still gets default value", () => {
@@ -105,7 +105,7 @@ describe("createContext / $context", () => {
 
   it("generator component reads context on every re-render", () => {
     const Ctx = createContext(0);
-    let setTheme: ((v: number) => void) | null = null;
+    let setTheme: (v: number) => void = () => {};
 
     function* Consumer() {
       const val = yield* $context(Ctx);
@@ -123,10 +123,10 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector("span")!.textContent).toBe("7");
+    expect(container.querySelector("span")?.textContent).toBe("7");
 
-    setTheme!(99);
-    expect(container.querySelector("span")!.textContent).toBe("99");
+    setTheme(99);
+    expect(container.querySelector("span")?.textContent).toBe("99");
   });
 
   // ── Scoping correctness tests (expose the "global ctxMap" bug) ──────────────
@@ -135,8 +135,8 @@ describe("createContext / $context", () => {
     // When the provider value changes the child component must NOT be remounted –
     // any local state it holds should survive the context update.
     const Ctx = createContext("initial");
-    let setCtxValue: ((v: string) => void) | null = null;
-    let setChildCount: ((v: number) => void) | null = null;
+    let setCtxValue: (v: string) => void = () => {};
+    let setChildCount: (v: number) => void = () => {};
 
     function* Child() {
       const [count, setCount] = yield* $state(0);
@@ -156,22 +156,22 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("A:0");
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe("A:0");
 
     // Build up state in the child component
-    setChildCount!(5);
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("A:5");
+    setChildCount(5);
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe("A:5");
 
     // Change the context value – child state must NOT be reset
-    setCtxValue!("B");
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("B:5");
+    setCtxValue("B");
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe("B:5");
   });
 
   it("context update propagates through non-consuming intermediate components", () => {
     // A component that does NOT consume the context must still pass context
     // changes through to a deeply nested consumer.
     const Ctx = createContext("default");
-    let setCtxValue: ((v: string) => void) | null = null;
+    let setCtxValue: (v: string) => void = () => {};
 
     function* Consumer() {
       const val = yield* $context(Ctx);
@@ -194,18 +194,18 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("first");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("first");
 
-    setCtxValue!("second");
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("second");
+    setCtxValue("second");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("second");
   });
 
   it("two sibling providers of the same context are isolated", () => {
     // Two independent Provider subtrees for the same context must not interfere
     // with each other when either re-renders.
     const Ctx = createContext("default");
-    let setA: ((v: string) => void) | null = null;
-    let setB: ((v: string) => void) | null = null;
+    let setA: (v: string) => void = () => {};
+    let setB: (v: string) => void = () => {};
 
     function* ConsumerA() {
       const val = yield* $context(Ctx);
@@ -239,23 +239,23 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe("A1");
-    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe("B1");
+    expect(container.querySelector('[data-testid="a"]')?.textContent).toBe("A1");
+    expect(container.querySelector('[data-testid="b"]')?.textContent).toBe("B1");
 
-    setA!("A2");
-    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe("A2");
-    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe("B1");
+    setA("A2");
+    expect(container.querySelector('[data-testid="a"]')?.textContent).toBe("A2");
+    expect(container.querySelector('[data-testid="b"]')?.textContent).toBe("B1");
 
-    setB!("B2");
-    expect(container.querySelector('[data-testid="a"]')!.textContent).toBe("A2");
-    expect(container.querySelector('[data-testid="b"]')!.textContent).toBe("B2");
+    setB("B2");
+    expect(container.querySelector('[data-testid="a"]')?.textContent).toBe("A2");
+    expect(container.querySelector('[data-testid="b"]')?.textContent).toBe("B2");
   });
 
   it("inner Provider overrides outer Provider for the same context", () => {
     // A component that re-provides the same context must shadow the outer value
     // for all its descendants, even after the outer value changes.
     const Ctx = createContext("default");
-    let setOuter: ((v: string) => void) | null = null;
+    let setOuter: (v: string) => void = () => {};
 
     function* Consumer() {
       const val = yield* $context(Ctx);
@@ -283,18 +283,18 @@ describe("createContext / $context", () => {
 
     render(createElement(Root as never, {}), container);
     // Consumer is inside Middle's inner provider → sees "inner"
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("inner");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("inner");
 
     // Change outer value – Consumer must still see "inner" (not the outer value)
-    setOuter!("outer-2");
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("inner");
+    setOuter("outer-2");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("inner");
   });
 
   it("parent reads outer context while child reads overridden inner context", () => {
     // A generator that both consumes an outer context value AND re-provides it
     // must receive the outer value itself while descendants receive the inner value.
     const Ctx = createContext("default");
-    let setOuter: ((v: string) => void) | null = null;
+    let setOuter: (v: string) => void = () => {};
 
     function* Child() {
       const val = yield* $context(Ctx);
@@ -322,22 +322,22 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="middle"]')!.textContent).toBe("outer");
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("inner");
+    expect(container.querySelector('[data-testid="middle"]')?.textContent).toBe("outer");
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe("inner");
 
-    setOuter!("outer-2");
+    setOuter("outer-2");
     // Middle should see the new outer value
-    expect(container.querySelector('[data-testid="middle"]')!.textContent).toBe("outer-2");
+    expect(container.querySelector('[data-testid="middle"]')?.textContent).toBe("outer-2");
     // Child must still see "inner" (provided by Middle's inner Provider)
-    expect(container.querySelector('[data-testid="child"]')!.textContent).toBe("inner");
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe("inner");
   });
 
   it("non-consuming intermediate component state survives context update", () => {
     // A component that does NOT consume the context must keep its own state
     // when an ancestor provider value changes.
     const Ctx = createContext("initial");
-    let setCtxValue: ((v: string) => void) | null = null;
-    let setMiddleCount: ((v: number) => void) | null = null;
+    let setCtxValue: (v: string) => void = () => {};
+    let setMiddleCount: (v: number) => void = () => {};
 
     function* Consumer() {
       const val = yield* $context(Ctx);
@@ -366,17 +366,17 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("v1");
-    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe("0");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("v1");
+    expect(container.querySelector('[data-testid="middle-count"]')?.textContent).toBe("0");
 
     // Build state in the intermediate (non-consuming) component
-    setMiddleCount!(7);
-    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe("7");
+    setMiddleCount(7);
+    expect(container.querySelector('[data-testid="middle-count"]')?.textContent).toBe("7");
 
     // Context changes – Middle's state (count=7) must be preserved
-    setCtxValue!("v2");
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("v2");
-    expect(container.querySelector('[data-testid="middle-count"]')!.textContent).toBe("7");
+    setCtxValue("v2");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("v2");
+    expect(container.querySelector('[data-testid="middle-count"]')?.textContent).toBe("7");
   });
 
   it("multiple different contexts are independently scoped", () => {
@@ -384,8 +384,8 @@ describe("createContext / $context", () => {
     // not affect the other.
     const CtxA = createContext("a-default");
     const CtxB = createContext("b-default");
-    let setA: ((v: string) => void) | null = null;
-    let setB: ((v: string) => void) | null = null;
+    let setA: (v: string) => void = () => {};
+    let setB: (v: string) => void = () => {};
 
     function* Consumer() {
       const a = yield* $context(CtxA);
@@ -410,13 +410,13 @@ describe("createContext / $context", () => {
     }
 
     render(createElement(Root as never, {}), container);
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("A1|B1");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("A1|B1");
 
-    setA!("A2");
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("A2|B1");
+    setA("A2");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("A2|B1");
 
-    setB!("B2");
-    expect(container.querySelector('[data-testid="consumer"]')!.textContent).toBe("A2|B2");
+    setB("B2");
+    expect(container.querySelector('[data-testid="consumer"]')?.textContent).toBe("A2|B2");
   });
 
   describe("$context with selector", () => {
@@ -436,12 +436,12 @@ describe("createContext / $context", () => {
         ),
         container,
       );
-      expect(container.querySelector("span")!.textContent).toBe("1:2");
+      expect(container.querySelector("span")?.textContent).toBe("1:2");
     });
 
     it("selector-only: suppresses rerender when selected deps are stable", () => {
       const Ctx = createContext({ a: 0, b: 0 });
-      let setVal: ((v: { a: number; b: number }) => void) | null = null;
+      let setVal: (v: { a: number; b: number }) => void = () => {};
       let renderCount = 0;
 
       function* Consumer() {
@@ -464,14 +464,14 @@ describe("createContext / $context", () => {
       expect(renderCount).toBe(1);
 
       // Change only `b` — selector selects `a`, so Consumer should NOT rerender.
-      setVal!({ a: 1, b: 99 });
+      setVal({ a: 1, b: 99 });
       expect(renderCount).toBe(1);
-      expect(container.querySelector("span")!.textContent).toBe("1");
+      expect(container.querySelector("span")?.textContent).toBe("1");
     });
 
     it("selector-only: rerenders when selected dep changes", () => {
       const Ctx = createContext({ a: 0, b: 0 });
-      let setVal: ((v: { a: number; b: number }) => void) | null = null;
+      let setVal: (v: { a: number; b: number }) => void = () => {};
       let renderCount = 0;
 
       function* Consumer() {
@@ -494,9 +494,9 @@ describe("createContext / $context", () => {
       expect(renderCount).toBe(1);
 
       // Change `a` — selector selects `a`, so Consumer SHOULD rerender.
-      setVal!({ a: 99, b: 1 });
+      setVal({ a: 99, b: 1 });
       expect(renderCount).toBe(2);
-      expect(container.querySelector("span")!.textContent).toBe("99");
+      expect(container.querySelector("span")?.textContent).toBe("99");
     });
 
     it("selector + transform: returns transformed value", () => {
@@ -519,12 +519,12 @@ describe("createContext / $context", () => {
         ),
         container,
       );
-      expect(container.querySelector("span")!.textContent).toBe("ALICE");
+      expect(container.querySelector("span")?.textContent).toBe("ALICE");
     });
 
     it("selector + transform: suppresses rerender when deps stable", () => {
       const Ctx = createContext({ name: "Alice", count: 0 });
-      let setVal: ((v: { name: string; count: number }) => void) | null = null;
+      let setVal: (v: { name: string; count: number }) => void = () => {};
       let renderCount = 0;
 
       function* Consumer() {
@@ -551,14 +551,14 @@ describe("createContext / $context", () => {
       expect(renderCount).toBe(1);
 
       // Change only `count` — selector tracks `name`, so no rerender.
-      setVal!({ name: "Alice", count: 99 });
+      setVal({ name: "Alice", count: 99 });
       expect(renderCount).toBe(1);
     });
 
     it("selector: hook state ($state) is preserved across suppressed rerenders", () => {
       const Ctx = createContext({ a: 0, b: 0 });
-      let setVal: ((v: { a: number; b: number }) => void) | null = null;
-      let setLocal: ((v: number) => void) | null = null;
+      let setVal: (v: { a: number; b: number }) => void = () => {};
+      let setLocal: (v: number) => void = () => {};
 
       function* Consumer() {
         yield* $context(Ctx, (c) => [c.a]);
@@ -579,18 +579,18 @@ describe("createContext / $context", () => {
 
       render(createElement(Parent as never, {}), container);
       // Update local state in Consumer.
-      setLocal!(100);
-      expect(container.querySelector("span")!.textContent).toBe("100");
+      setLocal(100);
+      expect(container.querySelector("span")?.textContent).toBe("100");
 
       // Trigger a context change that should be suppressed (b changes, a stable).
-      setVal!({ a: 1, b: 99 });
+      setVal({ a: 1, b: 99 });
       // Consumer should NOT have remounted — local state preserved.
-      expect(container.querySelector("span")!.textContent).toBe("100");
+      expect(container.querySelector("span")?.textContent).toBe("100");
     });
 
     it("no-selector consumer rerenders in-place when Provider value changes", () => {
       const Ctx = createContext({ a: 0, b: 0 });
-      let setVal: ((v: { a: number; b: number }) => void) | null = null;
+      let setVal: (v: { a: number; b: number }) => void = () => {};
       let renderCount = 0;
 
       function* Consumer() {
@@ -613,9 +613,9 @@ describe("createContext / $context", () => {
       expect(renderCount).toBe(1);
 
       // Change only `b` — Consumer has no selector so it always rerenders.
-      setVal!({ a: 1, b: 99 });
+      setVal({ a: 1, b: 99 });
       expect(renderCount).toBe(2);
-      expect(container.querySelector("span")!.textContent).toBe("1:99");
+      expect(container.querySelector("span")?.textContent).toBe("1:99");
     });
   });
 });

--- a/src/__tests__/create-root.test.ts
+++ b/src/__tests__/create-root.test.ts
@@ -23,7 +23,7 @@ describe("createRoot", () => {
     }
     const root = createRoot(container);
     root.render(createElement(Greeting as never, { name: "World" }));
-    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
+    expect(container.querySelector("h1")?.textContent).toBe("Hello, World!");
   });
 
   it("renders a generator component into the container", () => {
@@ -62,8 +62,8 @@ describe("createRoot", () => {
     const container2 = document.createElement("div");
     document.body.appendChild(container2);
 
-    let setCount1: ((v: number | ((p: number) => number)) => void) | null = null;
-    let setCount2: ((v: number | ((p: number) => number)) => void) | null = null;
+    let setCount1: (v: number | ((p: number) => number)) => void = () => {};
+    let setCount2: (v: number | ((p: number) => number)) => void = () => {};
 
     function* Counter1() {
       const [count, set] = yield* $state(0);
@@ -82,18 +82,18 @@ describe("createRoot", () => {
     root1.render(createElement(Counter1 as never, {}));
     root2.render(createElement(Counter2 as never, {}));
 
-    expect(container.querySelector("#c1")!.textContent).toBe("0");
-    expect(container2.querySelector("#c2")!.textContent).toBe("100");
+    expect(container.querySelector("#c1")?.textContent).toBe("0");
+    expect(container2.querySelector("#c2")?.textContent).toBe("100");
 
     // Update root 1 — root 2 must not be affected.
-    setCount1!(5);
-    expect(container.querySelector("#c1")!.textContent).toBe("5");
-    expect(container2.querySelector("#c2")!.textContent).toBe("100");
+    setCount1(5);
+    expect(container.querySelector("#c1")?.textContent).toBe("5");
+    expect(container2.querySelector("#c2")?.textContent).toBe("100");
 
     // Update root 2 — root 1 must not be affected.
-    setCount2!(200);
-    expect(container.querySelector("#c1")!.textContent).toBe("5");
-    expect(container2.querySelector("#c2")!.textContent).toBe("200");
+    setCount2(200);
+    expect(container.querySelector("#c1")?.textContent).toBe("5");
+    expect(container2.querySelector("#c2")?.textContent).toBe("200");
 
     document.body.removeChild(container2);
   });
@@ -151,7 +151,7 @@ describe("$patchContext", () => {
   });
 
   it("rerenders when inherited batch changes", () => {
-    let setLive: ((v: boolean) => void) | null = null;
+    let setLive: (v: boolean) => void = () => {};
     let patchValue: "live" | "default" | undefined;
 
     function* Child() {
@@ -171,11 +171,11 @@ describe("$patchContext", () => {
 
     render(createElement(Parent as never, {}), container);
     expect(patchValue).toBe("default");
-    expect(container.querySelector("#patch")!.textContent).toBe("default");
+    expect(container.querySelector("#patch")?.textContent).toBe("default");
 
-    setLive!(true);
+    setLive(true);
     expect(patchValue).toBe("live");
-    expect(container.querySelector("#patch")!.textContent).toBe("live");
+    expect(container.querySelector("#patch")?.textContent).toBe("live");
   });
 
   it("works the same as $context(ThemeContext) pattern", () => {
@@ -197,7 +197,7 @@ describe("$patchContext", () => {
 
   it("does not rerender when only $patch prop changes (no $patchContext)", () => {
     let renderCount = 0;
-    let setPatch: ((v: "live" | "default") => void) | null = null;
+    let setPatch: (v: "live" | "default") => void = () => {};
 
     function* Child({ label }: { label: string; $patch?: string }) {
       yield* $state(0); // just to make it a stateful generator component
@@ -213,17 +213,17 @@ describe("$patchContext", () => {
 
     render(createElement(Parent as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(container.querySelector("#child")!.textContent).toBe("hello");
+    expect(container.querySelector("#child")?.textContent).toBe("hello");
 
     // Change only $patch — Child should NOT rerender
-    setPatch!("live");
+    setPatch("live");
     expect(renderCount).toBe(1);
-    expect(container.querySelector("#child")!.textContent).toBe("hello");
+    expect(container.querySelector("#child")?.textContent).toBe("hello");
   });
 
   it("rerenders when $patch changes and component consumes $patchContext", () => {
     let renderCount = 0;
-    let setPatch: ((v: "live" | "default") => void) | null = null;
+    let setPatch: (v: "live" | "default") => void = () => {};
     let patchValue: "live" | "default" | undefined;
 
     function* Child(_props: { $patch?: string }) {
@@ -243,9 +243,9 @@ describe("$patchContext", () => {
     expect(patchValue).toBe("default");
 
     // Change $patch — Child SHOULD rerender because it consumes $patchContext
-    setPatch!("live");
+    setPatch("live");
     expect(renderCount).toBe(2);
     expect(patchValue).toBe("live");
-    expect(container.querySelector("#child")!.textContent).toBe("live");
+    expect(container.querySelector("#child")?.textContent).toBe("live");
   });
 });

--- a/src/__tests__/event-delegation.test.ts
+++ b/src/__tests__/event-delegation.test.ts
@@ -40,16 +40,16 @@ describe("event delegation", () => {
   it("dispatches click events through delegation", () => {
     const onClick = jest.fn();
     render(createElement("button", { onClick }, "click me"), container);
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it("wraps events in SyntheticEvent with correct properties", () => {
     const onClick = jest.fn();
     render(createElement("button", { onClick }, "click me"), container);
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
-    const syntheticEvent = onClick.mock.calls[0]![0];
+    const syntheticEvent = onClick.mock.calls[0]?.[0];
     expect(syntheticEvent).toHaveProperty("nativeEvent");
     expect(syntheticEvent).toHaveProperty("type", "click");
     expect(typeof syntheticEvent.preventDefault).toBe("function");
@@ -83,7 +83,7 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
     expect(order).toEqual(["outer-capture", "inner-capture", "inner-bubble", "outer-bubble"]);
   });
@@ -105,7 +105,7 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
     expect(innerClick).toHaveBeenCalledTimes(1);
     expect(outerClick).not.toHaveBeenCalled();
@@ -128,7 +128,7 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
     expect(outerCapture).toHaveBeenCalledTimes(1);
     expect(innerCapture).not.toHaveBeenCalled();
@@ -157,7 +157,7 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
     expect(order).toEqual(["outer-capture"]);
   });
@@ -181,7 +181,7 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
     expect(defaultPrevented).toBe(true);
   });
 
@@ -213,7 +213,7 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
     // Bubble phase: button first, then outer div
     expect(targets).toHaveLength(2);
@@ -244,11 +244,11 @@ describe("event delegation", () => {
 
     render(createElement(Multi as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(container.querySelector("button")!.textContent).toBe("0-0");
+    expect(container.querySelector("button")?.textContent).toBe("0-0");
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
     // After click, both state updates should have been processed
-    expect(container.querySelector("button")!.textContent).toBe("1-1");
+    expect(container.querySelector("button")?.textContent).toBe("1-1");
     // Should have rendered only twice total (initial + one batched rerender)
     expect(renderCount).toBe(2);
   });
@@ -259,7 +259,7 @@ describe("event delegation", () => {
     const onScroll = jest.fn();
     render(createElement("div", { onScroll }, "content"), container);
 
-    const div = container.querySelector("div")!;
+    const div = container.querySelector("div") as HTMLElement;
     const addSpy = jest.spyOn(div, "addEventListener");
 
     // The scroll listener should have been added directly to the element,
@@ -296,13 +296,13 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
     expect(receivedEvent).not.toBeNull();
     // bubbles is a standard property that our proxy should forward
-    expect(receivedEvent!["bubbles"]).toBe(true);
+    expect(receivedEvent?.["bubbles"]).toBe(true);
     // type should be accessible
-    expect(receivedEvent!["type"]).toBe("click");
+    expect(receivedEvent?.["type"]).toBe("click");
   });
 
   // ── Event prop mapping ────────────────────────────────────────────────
@@ -311,7 +311,7 @@ describe("event delegation", () => {
     const onDoubleClick = jest.fn();
     render(createElement("button", { onDoubleClick }, "dblclick me"), container);
 
-    const btn = container.querySelector("button")!;
+    const btn = container.querySelector("button") as HTMLButtonElement;
     btn.dispatchEvent(new MouseEvent("dblclick", { bubbles: true }));
 
     expect(onDoubleClick).toHaveBeenCalledTimes(1);
@@ -321,7 +321,7 @@ describe("event delegation", () => {
     const onFocus = jest.fn();
     render(createElement("input", { onFocus }), container);
 
-    const input = container.querySelector("input")!;
+    const input = container.querySelector("input") as HTMLInputElement;
     input.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
 
     expect(onFocus).toHaveBeenCalledTimes(1);
@@ -331,7 +331,7 @@ describe("event delegation", () => {
     const onBlur = jest.fn();
     render(createElement("input", { onBlur }), container);
 
-    const input = container.querySelector("input")!;
+    const input = container.querySelector("input") as HTMLInputElement;
     input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
 
     expect(onBlur).toHaveBeenCalledTimes(1);
@@ -346,13 +346,13 @@ describe("event delegation", () => {
     }
 
     render(createElement(Counter as never, {}), container);
-    expect(container.querySelector("button")!.textContent).toBe("0");
+    expect(container.querySelector("button")?.textContent).toBe("0");
 
-    container.querySelector("button")!.click();
-    expect(container.querySelector("button")!.textContent).toBe("1");
+    container.querySelector("button")?.click();
+    expect(container.querySelector("button")?.textContent).toBe("1");
 
-    container.querySelector("button")!.click();
-    expect(container.querySelector("button")!.textContent).toBe("2");
+    container.querySelector("button")?.click();
+    expect(container.querySelector("button")?.textContent).toBe("2");
   });
 
   it("handles handler changes across rerenders", () => {
@@ -368,7 +368,7 @@ describe("event delegation", () => {
     }
 
     render(createElement(HandlerChanger as never, {}), container);
-    const btn = container.querySelector("button")!;
+    const btn = container.querySelector("button") as HTMLButtonElement;
 
     btn.click();
     expect(btn.textContent).toBe("1");
@@ -419,7 +419,7 @@ describe("event delegation", () => {
       container,
     );
 
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
 
     expect(order).toEqual(["target", "level3", "level2", "level1"]);
   });

--- a/src/__tests__/key-prop.test.ts
+++ b/src/__tests__/key-prop.test.ts
@@ -20,7 +20,7 @@ describe("$key prop – keyed reconciliation", () => {
     let renderCountA = 0;
     let renderCountB = 0;
     let renderCountC = 0;
-    let setOrder: ((v: string[]) => void) | null = null;
+    let setOrder: (v: string[]) => void = () => {};
 
     function* ItemA() {
       renderCountA++;
@@ -50,16 +50,16 @@ describe("$key prop – keyed reconciliation", () => {
       return createElement(
         "div",
         { id: "list" },
-        ...order.map((k) => createElement(components[k]!, { $key: k })),
+        ...order.map((k) => createElement(components[k] as never, { $key: k })),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    const list = container.querySelector("#list")!;
+    const list = container.querySelector("#list") as HTMLElement;
     expect(list.children).toHaveLength(3);
-    expect(list.children[0]!.textContent).toBe("A:10");
-    expect(list.children[1]!.textContent).toBe("B:20");
-    expect(list.children[2]!.textContent).toBe("C:30");
+    expect(list.children[0]?.textContent).toBe("A:10");
+    expect(list.children[1]?.textContent).toBe("B:20");
+    expect(list.children[2]?.textContent).toBe("C:30");
 
     // Save references to original DOM nodes
     const nodeA = list.children[0];
@@ -71,13 +71,13 @@ describe("$key prop – keyed reconciliation", () => {
     renderCountC = 0;
 
     // Reverse order
-    setOrder!(["c", "b", "a"]);
+    setOrder(["c", "b", "a"]);
 
     // DOM nodes should be MOVED, not recreated
     expect(list.children).toHaveLength(3);
-    expect(list.children[0]!.textContent).toBe("C:30");
-    expect(list.children[1]!.textContent).toBe("B:20");
-    expect(list.children[2]!.textContent).toBe("A:10");
+    expect(list.children[0]?.textContent).toBe("C:30");
+    expect(list.children[1]?.textContent).toBe("B:20");
+    expect(list.children[2]?.textContent).toBe("A:10");
 
     // Same DOM nodes, just reordered
     expect(list.children[0]).toBe(nodeC);
@@ -91,7 +91,7 @@ describe("$key prop – keyed reconciliation", () => {
   });
 
   it("generator components with keys mixed with falsy values", () => {
-    let setItems: ((v: (string | null)[]) => void) | null = null;
+    let setItems: (v: (string | null)[]) => void = () => {};
 
     function* Item({ label }: { label: string }) {
       return createElement("span", null, label);
@@ -110,25 +110,25 @@ describe("$key prop – keyed reconciliation", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    const div = container.querySelector("div")!;
+    const div = container.querySelector("div") as HTMLElement;
     const spans = div.querySelectorAll("span");
     expect(spans).toHaveLength(3);
-    expect(spans[0]!.textContent).toBe("a");
-    expect(spans[1]!.textContent).toBe("b");
-    expect(spans[2]!.textContent).toBe("c");
+    expect(spans[0]?.textContent).toBe("a");
+    expect(spans[1]?.textContent).toBe("b");
+    expect(spans[2]?.textContent).toBe("c");
 
     const spanA = spans[0];
     const spanB = spans[1];
     const spanC = spans[2];
 
     // Reorder with different falsy positions
-    setItems!([null, "c", "a", null, "b"]);
+    setItems([null, "c", "a", null, "b"]);
 
     const newSpans = div.querySelectorAll("span");
     expect(newSpans).toHaveLength(3);
-    expect(newSpans[0]!.textContent).toBe("c");
-    expect(newSpans[1]!.textContent).toBe("a");
-    expect(newSpans[2]!.textContent).toBe("b");
+    expect(newSpans[0]?.textContent).toBe("c");
+    expect(newSpans[1]?.textContent).toBe("a");
+    expect(newSpans[2]?.textContent).toBe("b");
 
     // DOM nodes moved, not recreated
     expect(newSpans[0]).toBe(spanC);
@@ -139,7 +139,7 @@ describe("$key prop – keyed reconciliation", () => {
   // ─── Plain function components mixed with falsy values ───
 
   it("reorders plain function components by key without recreating DOM", () => {
-    let setOrder: ((v: string[]) => void) | null = null;
+    let setOrder: (v: string[]) => void = () => {};
 
     function ItemX() {
       return createElement("li", null, "X");
@@ -159,29 +159,29 @@ describe("$key prop – keyed reconciliation", () => {
       return createElement(
         "ul",
         null,
-        ...order.map((k) => createElement(components[k]!, { $key: k })),
+        ...order.map((k) => createElement(components[k] as never, { $key: k })),
       );
     }
 
     render(createElement(Parent as never, {}), container);
-    const ul = container.querySelector("ul")!;
-    expect(ul.children[0]!.textContent).toBe("X");
-    expect(ul.children[1]!.textContent).toBe("Y");
+    const ul = container.querySelector("ul") as HTMLElement;
+    expect(ul.children[0]?.textContent).toBe("X");
+    expect(ul.children[1]?.textContent).toBe("Y");
 
     const nodeX = ul.children[0];
     const nodeY = ul.children[1];
 
     // Reverse
-    setOrder!(["y", "x"]);
+    setOrder(["y", "x"]);
 
-    expect(ul.children[0]!.textContent).toBe("Y");
-    expect(ul.children[1]!.textContent).toBe("X");
+    expect(ul.children[0]?.textContent).toBe("Y");
+    expect(ul.children[1]?.textContent).toBe("X");
     expect(ul.children[0]).toBe(nodeY);
     expect(ul.children[1]).toBe(nodeX);
   });
 
   it("plain function components with keys mixed with falsy values", () => {
-    let setItems: ((v: (string | null)[]) => void) | null = null;
+    let setItems: (v: (string | null)[]) => void = () => {};
 
     function Tag({ label }: { label: string }) {
       return createElement("b", null, label);
@@ -200,13 +200,13 @@ describe("$key prop – keyed reconciliation", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    const div = container.querySelector("div")!;
+    const div = container.querySelector("div") as HTMLElement;
     const bs = div.querySelectorAll("b");
     expect(bs).toHaveLength(2);
     const bP = bs[0];
     const bQ = bs[1];
 
-    setItems!([null, "q", null, "p"]);
+    setItems([null, "q", null, "p"]);
     const newBs = div.querySelectorAll("b");
     expect(newBs).toHaveLength(2);
     expect(newBs[0]).toBe(bQ);
@@ -216,7 +216,7 @@ describe("$key prop – keyed reconciliation", () => {
   // ─── HTML elements mixed with falsy values ───
 
   it("reorders keyed HTML elements without recreating DOM", () => {
-    let setOrder: ((v: string[]) => void) | null = null;
+    let setOrder: (v: string[]) => void = () => {};
 
     function* Parent() {
       const [order, so] = yield* $state(["first", "second", "third"]);
@@ -229,7 +229,7 @@ describe("$key prop – keyed reconciliation", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    const ul = container.querySelector("ul")!;
+    const ul = container.querySelector("ul") as HTMLElement;
     expect(ul.children).toHaveLength(3);
 
     const li1 = ul.children[0];
@@ -237,18 +237,18 @@ describe("$key prop – keyed reconciliation", () => {
     const li3 = ul.children[2];
 
     // Reverse
-    setOrder!(["third", "second", "first"]);
+    setOrder(["third", "second", "first"]);
 
-    expect(ul.children[0]!.textContent).toBe("third");
-    expect(ul.children[1]!.textContent).toBe("second");
-    expect(ul.children[2]!.textContent).toBe("first");
+    expect(ul.children[0]?.textContent).toBe("third");
+    expect(ul.children[1]?.textContent).toBe("second");
+    expect(ul.children[2]?.textContent).toBe("first");
     expect(ul.children[0]).toBe(li3);
     expect(ul.children[1]).toBe(li2);
     expect(ul.children[2]).toBe(li1);
   });
 
   it("keyed HTML elements mixed with falsy values", () => {
-    let setItems: ((v: (string | null)[]) => void) | null = null;
+    let setItems: (v: (string | null)[]) => void = () => {};
 
     function* Parent() {
       const [items, si] = yield* $state<(string | null)[]>(["a", null, "b"]);
@@ -261,12 +261,12 @@ describe("$key prop – keyed reconciliation", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    const div = container.querySelector("div")!;
+    const div = container.querySelector("div") as HTMLElement;
     const spans = div.querySelectorAll("span");
     const spanA = spans[0];
     const spanB = spans[1];
 
-    setItems!(["b", null, null, "a"]);
+    setItems(["b", null, null, "a"]);
     const newSpans = div.querySelectorAll("span");
     expect(newSpans).toHaveLength(2);
     expect(newSpans[0]).toBe(spanB);
@@ -276,7 +276,7 @@ describe("$key prop – keyed reconciliation", () => {
   // ─── Component keeps working after key-based reorder ───
 
   it("generator component preserves state and continues working after reorder", () => {
-    let setOrder: ((v: string[]) => void) | null = null;
+    let setOrder: (v: string[]) => void = () => {};
     const setters: Record<string, (v: number) => void> = {};
 
     function* Counter({ id }: { id: string }) {
@@ -298,35 +298,35 @@ describe("$key prop – keyed reconciliation", () => {
     render(createElement(Parent as never, {}), container);
 
     // Increment x to 5
-    setters["x"]!(5);
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:5");
+    setters["x"]?.(5);
+    expect(container.querySelector('[data-id="x"]')?.textContent).toBe("x:5");
 
     // Increment y to 3
-    setters["y"]!(3);
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:3");
+    setters["y"]?.(3);
+    expect(container.querySelector('[data-id="y"]')?.textContent).toBe("y:3");
 
     // Reorder: z, x, y
-    setOrder!(["z", "x", "y"]);
+    setOrder(["z", "x", "y"]);
 
     // State preserved after reorder
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:5");
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:3");
-    expect(container.querySelector('[data-id="z"]')!.textContent).toBe("z:0");
+    expect(container.querySelector('[data-id="x"]')?.textContent).toBe("x:5");
+    expect(container.querySelector('[data-id="y"]')?.textContent).toBe("y:3");
+    expect(container.querySelector('[data-id="z"]')?.textContent).toBe("z:0");
 
     // Components still work after reorder (can update state)
-    setters["z"]!(99);
-    expect(container.querySelector('[data-id="z"]')!.textContent).toBe("z:99");
+    setters["z"]?.(99);
+    expect(container.querySelector('[data-id="z"]')?.textContent).toBe("z:99");
 
-    setters["x"]!(10);
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:10");
+    setters["x"]?.(10);
+    expect(container.querySelector('[data-id="x"]')?.textContent).toBe("x:10");
   });
 
   // ─── Key change alone does NOT cause rerender ───
 
   it("does not rerender generator component when only key changes", () => {
     let renderCount = 0;
-    let setKey: ((v: string) => void) | null = null;
-    let setLabel: ((v: string) => void) | null = null;
+    let setKey: (v: string) => void = () => {};
+    let setLabel: (v: string) => void = () => {};
 
     function* Child({ label }: { label: string }) {
       renderCount++;
@@ -343,11 +343,11 @@ describe("$key prop – keyed reconciliation", () => {
 
     render(createElement(Parent as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(container.querySelector("span")!.textContent).toBe("hello");
+    expect(container.querySelector("span")?.textContent).toBe("hello");
 
     // Change only the key — content props unchanged
     renderCount = 0;
-    setKey!("key-2");
+    setKey("key-2");
 
     // The child should NOT rerender since label didn't change
     // (key change means it's a "new" slot, but same type + same props = skip)
@@ -355,12 +355,12 @@ describe("$key prop – keyed reconciliation", () => {
     // component function + same props appear at the same position with a
     // different key, it may be treated as a new mount or reuse depending on
     // implementation. What matters is the component still works.
-    const span = container.querySelector("span")!;
+    const span = container.querySelector("span") as HTMLElement;
     expect(span.textContent).toBe("hello");
 
     // Verify it still works: changing label causes update
-    setLabel!("world");
-    expect(container.querySelector("span")!.textContent).toBe("world");
+    setLabel("world");
+    expect(container.querySelector("span")?.textContent).toBe("world");
   });
 
   // ─── Props update after reorder causes rerender ───
@@ -368,7 +368,7 @@ describe("$key prop – keyed reconciliation", () => {
   // ─── Non-keyed siblings preserve state when keyed children reorder ───
 
   it("non-keyed siblings preserve state when keyed children shuffle", () => {
-    let setOrder: ((v: string[]) => void) | null = null;
+    let setOrder: (v: string[]) => void = () => {};
     const setters: Record<string, (v: number) => void> = {};
 
     function* Counter({ id }: { id: string }) {
@@ -392,46 +392,46 @@ describe("$key prop – keyed reconciliation", () => {
     render(createElement(Parent as never, {}), container);
 
     // Build up state on all components
-    setters["before"]!(10);
-    setters["x"]!(20);
-    setters["y"]!(30);
-    setters["after"]!(40);
+    setters["before"]?.(10);
+    setters["x"]?.(20);
+    setters["y"]?.(30);
+    setters["after"]?.(40);
 
-    expect(container.querySelector('[data-id="before"]')!.textContent).toBe("before:10");
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:20");
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:30");
-    expect(container.querySelector('[data-id="after"]')!.textContent).toBe("after:40");
+    expect(container.querySelector('[data-id="before"]')?.textContent).toBe("before:10");
+    expect(container.querySelector('[data-id="x"]')?.textContent).toBe("x:20");
+    expect(container.querySelector('[data-id="y"]')?.textContent).toBe("y:30");
+    expect(container.querySelector('[data-id="after"]')?.textContent).toBe("after:40");
 
     // Reverse keyed children
-    setOrder!(["y", "x"]);
+    setOrder(["y", "x"]);
 
     // All state must be preserved — keyed and non-keyed alike
-    expect(container.querySelector('[data-id="before"]')!.textContent).toBe("before:10");
-    expect(container.querySelector('[data-id="y"]')!.textContent).toBe("y:30");
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:20");
-    expect(container.querySelector('[data-id="after"]')!.textContent).toBe("after:40");
+    expect(container.querySelector('[data-id="before"]')?.textContent).toBe("before:10");
+    expect(container.querySelector('[data-id="y"]')?.textContent).toBe("y:30");
+    expect(container.querySelector('[data-id="x"]')?.textContent).toBe("x:20");
+    expect(container.querySelector('[data-id="after"]')?.textContent).toBe("after:40");
 
     // Verify DOM order: before, y, x, after
-    const div = container.querySelector("div")!;
-    expect(div.children[0]!.getAttribute("data-id")).toBe("before");
-    expect(div.children[1]!.getAttribute("data-id")).toBe("y");
-    expect(div.children[2]!.getAttribute("data-id")).toBe("x");
-    expect(div.children[3]!.getAttribute("data-id")).toBe("after");
+    const div = container.querySelector("div") as HTMLElement;
+    expect(div.children[0]?.getAttribute("data-id")).toBe("before");
+    expect(div.children[1]?.getAttribute("data-id")).toBe("y");
+    expect(div.children[2]?.getAttribute("data-id")).toBe("x");
+    expect(div.children[3]?.getAttribute("data-id")).toBe("after");
 
     // All components still work after reorder
-    setters["before"]!(11);
-    setters["after"]!(41);
-    setters["x"]!(21);
-    expect(container.querySelector('[data-id="before"]')!.textContent).toBe("before:11");
-    expect(container.querySelector('[data-id="after"]')!.textContent).toBe("after:41");
-    expect(container.querySelector('[data-id="x"]')!.textContent).toBe("x:21");
+    setters["before"]?.(11);
+    setters["after"]?.(41);
+    setters["x"]?.(21);
+    expect(container.querySelector('[data-id="before"]')?.textContent).toBe("before:11");
+    expect(container.querySelector('[data-id="after"]')?.textContent).toBe("after:41");
+    expect(container.querySelector('[data-id="x"]')?.textContent).toBe("x:21");
   });
 
   // ─── Props update after reorder causes rerender ───
 
   it("props update on keyed generator component triggers rerender after reorder", () => {
-    let setOrder: ((v: string[]) => void) | null = null;
-    let setLabelFor: ((id: string, label: string) => void) | null = null;
+    let setOrder: (v: string[]) => void = () => {};
+    let setLabelFor: (id: string, label: string) => void = () => {};
 
     function* Item({ id, label }: { id: string; label: string }) {
       return createElement("span", { "data-id": id }, label);
@@ -453,16 +453,16 @@ describe("$key prop – keyed reconciliation", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector('[data-id="a"]')!.textContent).toBe("Alpha");
-    expect(container.querySelector('[data-id="b"]')!.textContent).toBe("Beta");
+    expect(container.querySelector('[data-id="a"]')?.textContent).toBe("Alpha");
+    expect(container.querySelector('[data-id="b"]')?.textContent).toBe("Beta");
 
     // Reorder
-    setOrder!(["b", "a"]);
-    expect(container.querySelector("div")!.children[0]!.getAttribute("data-id")).toBe("b");
-    expect(container.querySelector("div")!.children[1]!.getAttribute("data-id")).toBe("a");
+    setOrder(["b", "a"]);
+    expect(container.querySelector("div")?.children[0]?.getAttribute("data-id")).toBe("b");
+    expect(container.querySelector("div")?.children[1]?.getAttribute("data-id")).toBe("a");
 
     // Update label after reorder
-    setLabelFor!("a", "Alpha Updated");
-    expect(container.querySelector('[data-id="a"]')!.textContent).toBe("Alpha Updated");
+    setLabelFor("a", "Alpha Updated");
+    expect(container.querySelector('[data-id="a"]')?.textContent).toBe("Alpha Updated");
   });
 });

--- a/src/__tests__/no-wrapper-spans.test.ts
+++ b/src/__tests__/no-wrapper-spans.test.ts
@@ -39,7 +39,7 @@ describe("no wrapper spans in rendered output", () => {
       return createElement("h1", null, `Hello, ${name}!`);
     }
     render(createElement(Greeting as never, { name: "World" }), container);
-    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
+    expect(container.querySelector("h1")?.textContent).toBe("Hello, World!");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -59,7 +59,7 @@ describe("no wrapper spans in rendered output", () => {
       return createElement("div", null, createElement(Inner as never, {}));
     }
     render(createElement(Outer as never, {}), container);
-    expect(container.querySelector("span")!.textContent).toBe("inner");
+    expect(container.querySelector("span")?.textContent).toBe("inner");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -70,12 +70,12 @@ describe("no wrapper spans in rendered output", () => {
       return createElement("div", { className: "card" }, "content");
     }
     render(createElement(Card as never, {}), container);
-    expect(container.querySelector(".card")!.textContent).toBe("content");
+    expect(container.querySelector(".card")?.textContent).toBe("content");
     expectNoDisplayContentsSpans(container);
   });
 
   it("generator component with $state", () => {
-    let setCount: ((v: number) => void) | null = null;
+    let setCount: (v: number) => void = () => {};
 
     function* Counter() {
       const [count, sc] = yield* $state(0);
@@ -84,11 +84,11 @@ describe("no wrapper spans in rendered output", () => {
     }
 
     render(createElement(Counter as never, {}), container);
-    expect(container.querySelector("button")!.textContent).toBe("0");
+    expect(container.querySelector("button")?.textContent).toBe("0");
     expectNoDisplayContentsSpans(container);
 
-    setCount!(5);
-    expect(container.querySelector("button")!.textContent).toBe("5");
+    setCount(5);
+    expect(container.querySelector("button")?.textContent).toBe("5");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -100,7 +100,7 @@ describe("no wrapper spans in rendered output", () => {
       return createElement("div", null, createElement(Inner as never, {}));
     }
     render(createElement(Outer as never, {}), container);
-    expect(container.querySelector("span")!.textContent).toBe("hello");
+    expect(container.querySelector("span")?.textContent).toBe("hello");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -112,7 +112,7 @@ describe("no wrapper spans in rendered output", () => {
       createElement("div", { className: "wrapper" }, createElement(Label as never, { text: "hi" })),
       container,
     );
-    expect(container.querySelector("span")!.textContent).toBe("hi");
+    expect(container.querySelector("span")?.textContent).toBe("hi");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -131,8 +131,8 @@ describe("no wrapper spans in rendered output", () => {
     );
     const ps = container.querySelectorAll("p");
     expect(ps).toHaveLength(2);
-    expect(ps[0]!.textContent).toBe("A");
-    expect(ps[1]!.textContent).toBe("B");
+    expect(ps[0]?.textContent).toBe("A");
+    expect(ps[1]?.textContent).toBe("B");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -154,9 +154,9 @@ describe("no wrapper spans in rendered output", () => {
       ),
       container,
     );
-    expect(container.querySelector("p")!.textContent).toBe("text");
-    expect(container.querySelector("em")!.textContent).toBe("gen");
-    expect(container.querySelector("strong")!.textContent).toBe("plain");
+    expect(container.querySelector("p")?.textContent).toBe("text");
+    expect(container.querySelector("em")?.textContent).toBe("gen");
+    expect(container.querySelector("strong")?.textContent).toBe("plain");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -174,8 +174,8 @@ describe("no wrapper spans in rendered output", () => {
     render(createElement("div", null, createElement(Multi as never, {})), container);
     const ps = container.querySelectorAll("p");
     expect(ps).toHaveLength(2);
-    expect(ps[0]!.textContent).toBe("one");
-    expect(ps[1]!.textContent).toBe("two");
+    expect(ps[0]?.textContent).toBe("one");
+    expect(ps[1]?.textContent).toBe("two");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -197,7 +197,7 @@ describe("no wrapper spans in rendered output", () => {
       ),
       container,
     );
-    expect(container.querySelector("span")!.textContent).toBe("provided");
+    expect(container.querySelector("span")?.textContent).toBe("provided");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -221,7 +221,7 @@ describe("no wrapper spans in rendered output", () => {
       ),
       container,
     );
-    expect(container.querySelector("span")!.textContent).toBe("inner");
+    expect(container.querySelector("span")?.textContent).toBe("inner");
     expectNoDisplayContentsSpans(container);
   });
 
@@ -255,14 +255,14 @@ describe("no wrapper spans in rendered output", () => {
       ),
       container,
     );
-    expect(container.querySelector("b")!.textContent).toBe("deep");
+    expect(container.querySelector("b")?.textContent).toBe("deep");
     expectNoDisplayContentsSpans(container);
   });
 
   // ── After rerender ──
 
   it("no wrappers after state-driven rerender with children swap", () => {
-    let toggle: (() => void) | null = null;
+    let toggle: () => void = () => {};
 
     function* Child({ label }: { label: string }) {
       return createElement("span", null, label);
@@ -277,11 +277,11 @@ describe("no wrapper spans in rendered output", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector("span")!.textContent).toBe("A");
+    expect(container.querySelector("span")?.textContent).toBe("A");
     expectNoDisplayContentsSpans(container);
 
-    toggle!();
-    expect(container.querySelector("span")!.textContent).toBe("B");
+    toggle();
+    expect(container.querySelector("span")?.textContent).toBe("B");
     expectNoDisplayContentsSpans(container);
   });
 });

--- a/src/__tests__/reconciler.test.ts
+++ b/src/__tests__/reconciler.test.ts
@@ -22,7 +22,7 @@ describe("prop memoization", () => {
 
   it("does not re-mount a child component when the parent re-renders with unchanged child props", () => {
     let mountCount = 0;
-    let parentRerender: (() => void) | null = null;
+    let parentRerender: () => void = () => {};
 
     function* Child({ label }: { label: string }) {
       mountCount++;
@@ -36,17 +36,17 @@ describe("prop memoization", () => {
 
     render(createElement(Parent as never, {}), container);
     expect(mountCount).toBe(1);
-    expect(container.querySelector("span")!.textContent).toBe("hello");
+    expect(container.querySelector("span")?.textContent).toBe("hello");
 
     // Trigger parent re-render with same child props
-    parentRerender!();
+    parentRerender();
     // Child was NOT remounted (same props)
     expect(mountCount).toBe(1);
   });
 
   it("remounts a child component when props change", () => {
     let mountCount = 0;
-    let setPhase: ((v: number) => void) | null = null;
+    let setPhase: (v: number) => void = () => {};
 
     function* Child({ label }: { label: string }) {
       mountCount++;
@@ -65,11 +65,11 @@ describe("prop memoization", () => {
 
     render(createElement(Parent as never, {}), container);
     expect(mountCount).toBe(1);
-    expect(container.querySelector("span")!.textContent).toBe("first");
+    expect(container.querySelector("span")?.textContent).toBe("first");
 
-    setPhase!(1);
+    setPhase(1);
     expect(mountCount).toBe(2);
-    expect(container.querySelector("span")!.textContent).toBe("second");
+    expect(container.querySelector("span")?.textContent).toBe("second");
   });
 });
 
@@ -99,7 +99,7 @@ describe("component renders component", () => {
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
+    expect(container.querySelector("h1")?.textContent).toBe("Hello, World!");
   });
 
   it("generator renders a generator component child", () => {
@@ -112,12 +112,12 @@ describe("component renders component", () => {
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("em")!.textContent).toBe("from-child");
+    expect(container.querySelector("em")?.textContent).toBe("from-child");
   });
 
   it("child generator component maintains its own state across parent re-renders", () => {
-    let incrementCounter: (() => void) | null = null;
-    let parentRerender: (() => void) | null = null;
+    let incrementCounter: () => void = () => {};
+    let parentRerender: () => void = () => {};
 
     function* Counter() {
       const [count, setCount] = yield* $state(0);
@@ -131,20 +131,20 @@ describe("component renders component", () => {
     }
 
     render(createElement(Wrapper as never, {}), container);
-    expect(container.querySelector("#counter")!.textContent).toBe("0");
+    expect(container.querySelector("#counter")?.textContent).toBe("0");
 
     // Increment child
-    incrementCounter!();
-    expect(container.querySelector("#counter")!.textContent).toBe("1");
+    incrementCounter();
+    expect(container.querySelector("#counter")?.textContent).toBe("1");
 
     // Parent re-renders with SAME Counter props → child is reused (not remounted)
-    parentRerender!();
+    parentRerender();
     // Counter state is preserved (still at 1)
-    expect(container.querySelector("#counter")!.textContent).toBe("1");
+    expect(container.querySelector("#counter")?.textContent).toBe("1");
   });
 
   it("parent switching child component type unmounts old and mounts new", () => {
-    let setPhase: ((v: number) => void) | null = null;
+    let setPhase: (v: number) => void = () => {};
 
     function* CompA() {
       return createElement("span", { id: "a" }, "A");
@@ -167,13 +167,13 @@ describe("component renders component", () => {
     expect(container.querySelector("#a")).not.toBeNull();
     expect(container.querySelector("#b")).toBeNull();
 
-    setPhase!(1);
+    setPhase(1);
     expect(container.querySelector("#a")).toBeNull();
     expect(container.querySelector("#b")).not.toBeNull();
   });
 
   it("reconciles HTML element children in place across re-renders", () => {
-    let setStep: ((v: number) => void) | null = null;
+    let setStep: (v: number) => void = () => {};
 
     function* App() {
       const [step, ss] = yield* $state(0);
@@ -184,11 +184,11 @@ describe("component renders component", () => {
     }
 
     render(createElement(App as never, {}), container);
-    const p = container.querySelector("p")!;
+    const p = container.querySelector("p") as HTMLParagraphElement;
     expect(p.className).toBe("first");
     expect(p.textContent).toBe("hello");
 
-    setStep!(1);
+    setStep(1);
     // Same <p> element is reused (updated in place)
     expect(container.querySelector("p")).toBe(p);
     expect(p.className).toBe("second");
@@ -213,7 +213,7 @@ describe("component renders component", () => {
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("#a")!.textContent).toBe("A");
-    expect(container.querySelector("#b")!.textContent).toBe("B");
+    expect(container.querySelector("#a")?.textContent).toBe("A");
+    expect(container.querySelector("#b")?.textContent).toBe("B");
   });
 });

--- a/src/__tests__/render-components.test.ts
+++ b/src/__tests__/render-components.test.ts
@@ -21,7 +21,7 @@ describe("render – plain function components", () => {
       return createElement("h1", null, `Hello, ${name}!`);
     }
     render(createElement(Greeting as never, { name: "World" }), container);
-    expect(container.querySelector("h1")!.textContent).toBe("Hello, World!");
+    expect(container.querySelector("h1")?.textContent).toBe("Hello, World!");
   });
 
   it("renders an empty text node when the component returns null", () => {
@@ -29,7 +29,7 @@ describe("render – plain function components", () => {
       return null;
     }
     render(createElement(Empty as never, {}), container);
-    const node = container.firstChild!;
+    const node = container.firstChild as ChildNode;
     expect(node.nodeType).toBe(Node.TEXT_NODE);
     expect(node.textContent).toBe("");
   });
@@ -39,7 +39,7 @@ describe("render – plain function components", () => {
       return undefined;
     }
     render(createElement(Empty as never, {}), container);
-    const node = container.firstChild!;
+    const node = container.firstChild as ChildNode;
     expect(node.nodeType).toBe(Node.TEXT_NODE);
     expect(node.textContent).toBe("");
   });
@@ -62,11 +62,11 @@ describe("render – generator components", () => {
       return createElement("h2", null, `Hi, ${name}!`);
     }
     render(createElement(Greeting as never, { name: "Alice" }), container);
-    expect(container.querySelector("h2")!.textContent).toBe("Hi, Alice!");
+    expect(container.querySelector("h2")?.textContent).toBe("Hi, Alice!");
   });
 
   it("rerenders via $state setter", () => {
-    let setCount: ((v: number) => void) | null = null;
+    let setCount: (v: number) => void = () => {};
 
     function* Counter() {
       const [count, sc] = yield* $state(0);
@@ -75,13 +75,13 @@ describe("render – generator components", () => {
     }
 
     render(createElement(Counter as never, {}), container);
-    expect(container.querySelector("button")!.textContent).toBe("0");
+    expect(container.querySelector("button")?.textContent).toBe("0");
 
-    setCount!(1);
-    expect(container.querySelector("button")!.textContent).toBe("1");
+    setCount(1);
+    expect(container.querySelector("button")?.textContent).toBe("1");
 
-    setCount!(5);
-    expect(container.querySelector("button")!.textContent).toBe("5");
+    setCount(5);
+    expect(container.querySelector("button")?.textContent).toBe("5");
   });
 
   it("rerenders when rerender() is called directly from an event handler", () => {
@@ -100,11 +100,11 @@ describe("render – generator components", () => {
 
     render(createElement(Counter as never, {}), container);
 
-    expect(container.querySelector("button")!.textContent).toBe("0");
-    container.querySelector("button")!.click();
-    expect(container.querySelector("button")!.textContent).toBe("1");
-    container.querySelector("button")!.click();
-    expect(container.querySelector("button")!.textContent).toBe("2");
+    expect(container.querySelector("button")?.textContent).toBe("0");
+    container.querySelector("button")?.click();
+    expect(container.querySelector("button")?.textContent).toBe("1");
+    container.querySelector("button")?.click();
+    expect(container.querySelector("button")?.textContent).toBe("2");
   });
 
   it("renders generator components nested inside HTML elements", () => {
@@ -121,7 +121,7 @@ describe("render – generator components", () => {
       container,
     );
 
-    expect(container.querySelector("span")!.textContent).toBe("nested");
+    expect(container.querySelector("span")?.textContent).toBe("nested");
   });
 
   it("passes children in props", () => {
@@ -134,7 +134,7 @@ describe("render – generator components", () => {
       container,
     );
 
-    expect(container.querySelector("p")!.textContent).toBe("child content");
+    expect(container.querySelector("p")?.textContent).toBe("child content");
   });
 });
 
@@ -151,7 +151,7 @@ describe("render – generator components with $state", () => {
   });
 
   it("$state persists value across re-renders", () => {
-    let setLabel: ((v: string) => void) | null = null;
+    let setLabel: (v: string) => void = () => {};
 
     function* Label() {
       const [text, st] = yield* $state("initial");
@@ -160,18 +160,18 @@ describe("render – generator components with $state", () => {
     }
 
     render(createElement(Label as never, {}), container);
-    expect(container.querySelector("p")!.textContent).toBe("initial");
+    expect(container.querySelector("p")?.textContent).toBe("initial");
 
-    setLabel!("updated");
-    expect(container.querySelector("p")!.textContent).toBe("updated");
+    setLabel("updated");
+    expect(container.querySelector("p")?.textContent).toBe("updated");
 
-    setLabel!("again");
-    expect(container.querySelector("p")!.textContent).toBe("again");
+    setLabel("again");
+    expect(container.querySelector("p")?.textContent).toBe("again");
   });
 
   it("multiple $state calls maintain independent state", () => {
-    let setA: ((v: string) => void) | null = null;
-    let setB: ((v: number) => void) | null = null;
+    let setA: (v: string) => void = () => {};
+    let setB: (v: number) => void = () => {};
 
     function* Multi() {
       const [a, sa] = yield* $state("hello");
@@ -182,12 +182,12 @@ describe("render – generator components with $state", () => {
     }
 
     render(createElement(Multi as never, {}), container);
-    expect(container.querySelector("p")!.textContent).toBe("hello-0");
+    expect(container.querySelector("p")?.textContent).toBe("hello-0");
 
-    setA!("world");
-    expect(container.querySelector("p")!.textContent).toBe("world-0");
+    setA("world");
+    expect(container.querySelector("p")?.textContent).toBe("world-0");
 
-    setB!(42);
-    expect(container.querySelector("p")!.textContent).toBe("world-42");
+    setB(42);
+    expect(container.querySelector("p")?.textContent).toBe("world-42");
   });
 });

--- a/src/__tests__/render-html.test.ts
+++ b/src/__tests__/render-html.test.ts
@@ -23,12 +23,12 @@ describe("render – HTML elements", () => {
 
   it("renders a text child", () => {
     render(createElement("p", null, "Hello World"), container);
-    expect(container.querySelector("p")!.textContent).toBe("Hello World");
+    expect(container.querySelector("p")?.textContent).toBe("Hello World");
   });
 
   it("renders nested elements", () => {
     render(createElement("div", null, createElement("span", null, "inner")), container);
-    expect(container.querySelector("span")!.textContent).toBe("inner");
+    expect(container.querySelector("span")?.textContent).toBe("inner");
   });
 
   it("applies className", () => {
@@ -38,7 +38,7 @@ describe("render – HTML elements", () => {
 
   it("applies arbitrary attributes", () => {
     render(createElement("input", { type: "text", placeholder: "name" }), container);
-    const input = container.querySelector("input")!;
+    const input = container.querySelector("input") as HTMLInputElement;
     expect(input.getAttribute("type")).toBe("text");
     expect(input.getAttribute("placeholder")).toBe("name");
   });
@@ -46,7 +46,7 @@ describe("render – HTML elements", () => {
   it("applies event listeners and wraps in SyntheticEvent", () => {
     const onClick = jest.fn();
     render(createElement("button", { onClick }, "click me"), container);
-    container.querySelector("button")!.click();
+    container.querySelector("button")?.click();
     expect(onClick).toHaveBeenCalledTimes(1);
     // The handler receives a SyntheticEvent, not the raw native event
     const syntheticEvent = onClick.mock.calls[0][0];
@@ -64,7 +64,7 @@ describe("render – HTML elements", () => {
   });
 
   it("updates changed style properties on rerender", () => {
-    let setStyle: ((s: Record<string, string>) => void) | null = null;
+    let setStyle: (s: Record<string, string>) => void = () => {};
 
     function* Styled() {
       const [style, ss] = yield* $state<Record<string, string>>({ color: "red" });
@@ -76,12 +76,12 @@ describe("render – HTML elements", () => {
     const el = container.querySelector("div") as HTMLElement;
     expect(el.style.color).toBe("red");
 
-    setStyle!({ color: "blue" });
+    setStyle({ color: "blue" });
     expect(el.style.color).toBe("blue");
   });
 
   it("removes style properties that are no longer present on rerender", () => {
-    let setStyle: ((s: Record<string, string>) => void) | null = null;
+    let setStyle: (s: Record<string, string>) => void = () => {};
 
     function* Styled() {
       const [style, ss] = yield* $state<Record<string, string>>({
@@ -97,13 +97,13 @@ describe("render – HTML elements", () => {
     expect(el.style.color).toBe("red");
     expect(el.style.fontSize).toBe("14px");
 
-    setStyle!({ color: "blue" });
+    setStyle({ color: "blue" });
     expect(el.style.color).toBe("blue");
     expect(el.style.fontSize).toBe("");
   });
 
   it("clears all styles when style prop is removed", () => {
-    let setProps: ((p: Record<string, unknown>) => void) | null = null;
+    let setProps: (p: Record<string, unknown>) => void = () => {};
 
     function* Styled() {
       const [props, sp] = yield* $state<Record<string, unknown>>({
@@ -118,7 +118,7 @@ describe("render – HTML elements", () => {
     expect(el.style.color).toBe("red");
     expect(el.style.fontWeight).toBe("bold");
 
-    setProps!({});
+    setProps({});
     expect(el.style.color).toBe("");
     expect(el.style.fontWeight).toBe("");
   });
@@ -139,17 +139,17 @@ describe("render – HTML elements", () => {
     );
     const items = container.querySelectorAll("li");
     expect(items).toHaveLength(2);
-    expect(items[0]!.textContent).toBe("one");
-    expect(items[1]!.textContent).toBe("two");
+    expect(items[0]?.textContent).toBe("one");
+    expect(items[1]?.textContent).toBe("two");
   });
 
   it("skips null and undefined children", () => {
     render(createElement("div", null, null, undefined, "visible"), container);
-    expect(container.querySelector("div")!.textContent).toBe("visible");
+    expect(container.querySelector("div")?.textContent).toBe("visible");
   });
 
   it("sets input value as DOM property (not just attribute)", () => {
-    let setValue: ((v: string) => void) | null = null;
+    let setValue: (v: string) => void = () => {};
 
     function* Controlled() {
       const [val, sv] = yield* $state("initial");
@@ -161,15 +161,15 @@ describe("render – HTML elements", () => {
     const input = container.querySelector("input") as HTMLInputElement;
     expect(input.value).toBe("initial");
 
-    setValue!("updated");
+    setValue("updated");
     expect(input.value).toBe("updated");
 
-    setValue!("");
+    setValue("");
     expect(input.value).toBe("");
   });
 
   it("sets checkbox checked as DOM property", () => {
-    let setChecked: ((v: boolean) => void) | null = null;
+    let setChecked: (v: boolean) => void = () => {};
 
     function* CheckBox() {
       const [checked, sc] = yield* $state(false);
@@ -181,10 +181,10 @@ describe("render – HTML elements", () => {
     const cb = container.querySelector("input") as HTMLInputElement;
     expect(cb.checked).toBe(false);
 
-    setChecked!(true);
+    setChecked(true);
     expect(cb.checked).toBe(true);
 
-    setChecked!(false);
+    setChecked(false);
     expect(cb.checked).toBe(false);
   });
 });

--- a/src/__tests__/shown-prop.test.ts
+++ b/src/__tests__/shown-prop.test.ts
@@ -19,7 +19,7 @@ describe("shown prop", () => {
   it("renders an HTML element when shown is true", () => {
     render(createElement("div", { $shown: true }, "visible"), container);
     expect(container.querySelector("div")).not.toBeNull();
-    expect(container.querySelector("div")!.textContent).toBe("visible");
+    expect(container.querySelector("div")?.textContent).toBe("visible");
   });
 
   it("does not render an HTML element when shown is false", () => {
@@ -34,7 +34,7 @@ describe("shown prop", () => {
 
   it("does not set shown as a DOM attribute", () => {
     render(createElement("div", { $shown: true }, "visible"), container);
-    const el = container.querySelector("div")!;
+    const el = container.querySelector("div") as HTMLElement;
     expect(el.hasAttribute("$shown")).toBe(false);
   });
 
@@ -83,7 +83,7 @@ describe("shown prop", () => {
   });
 
   it("unmounts an HTML element when shown changes from true to false", () => {
-    let setShown: ((v: boolean) => void) | null = null;
+    let setShown: (v: boolean) => void = () => {};
 
     function* Wrapper() {
       const [$shown, setS] = yield* $state(true);
@@ -94,12 +94,12 @@ describe("shown prop", () => {
     render(createElement(Wrapper as never, {}), container);
     expect(container.querySelector("div")).not.toBeNull();
 
-    setShown!(false);
+    setShown(false);
     expect(container.querySelector("div")).toBeNull();
   });
 
   it("mounts an HTML element when shown changes from false to true", () => {
-    let setShown: ((v: boolean) => void) | null = null;
+    let setShown: (v: boolean) => void = () => {};
 
     function* Wrapper() {
       const [$shown, setS] = yield* $state(false);
@@ -110,13 +110,13 @@ describe("shown prop", () => {
     render(createElement(Wrapper as never, {}), container);
     expect(container.querySelector("div")).toBeNull();
 
-    setShown!(true);
+    setShown(true);
     expect(container.querySelector("div")).not.toBeNull();
-    expect(container.querySelector("div")!.textContent).toBe("content");
+    expect(container.querySelector("div")?.textContent).toBe("content");
   });
 
   it("unmounts a component when shown changes from true to false", () => {
-    let setShown: ((v: boolean) => void) | null = null;
+    let setShown: (v: boolean) => void = () => {};
 
     function* Inner() {
       return createElement("p", null, "inner");
@@ -131,12 +131,12 @@ describe("shown prop", () => {
     render(createElement(Wrapper as never, {}), container);
     expect(container.querySelector("p")).not.toBeNull();
 
-    setShown!(false);
+    setShown(false);
     expect(container.querySelector("p")).toBeNull();
   });
 
   it("mounts a component when shown changes from false to true", () => {
-    let setShown: ((v: boolean) => void) | null = null;
+    let setShown: (v: boolean) => void = () => {};
 
     function* Inner() {
       return createElement("p", null, "inner");
@@ -151,8 +151,8 @@ describe("shown prop", () => {
     render(createElement(Wrapper as never, {}), container);
     expect(container.querySelector("p")).toBeNull();
 
-    setShown!(true);
+    setShown(true);
     expect(container.querySelector("p")).not.toBeNull();
-    expect(container.querySelector("p")!.textContent).toBe("inner");
+    expect(container.querySelector("p")?.textContent).toBe("inner");
   });
 });

--- a/src/__tests__/stop-render-on-update.test.ts
+++ b/src/__tests__/stop-render-on-update.test.ts
@@ -15,7 +15,7 @@ describe("stop-render-on-update", () => {
   });
 
   it("setState returns Promise<void> that resolves after the rerender commits", async () => {
-    let setter: ((v: number) => Promise<void>) | null = null;
+    let setter: (v: number) => Promise<void> = () => Promise.resolve();
     let renderCount = 0;
 
     function* Comp() {
@@ -27,13 +27,13 @@ describe("stop-render-on-update", () => {
 
     render(createElement(Comp as never, {}), container);
     expect(renderCount).toBe(1);
-    expect(container.querySelector("span")!.textContent).toBe("0");
+    expect(container.querySelector("span")?.textContent).toBe("0");
 
-    const p = setter!(42);
+    const p = setter(42);
     // After the promise resolves the DOM must reflect the new state
     await p;
     expect(renderCount).toBe(2);
-    expect(container.querySelector("span")!.textContent).toBe("42");
+    expect(container.querySelector("span")?.textContent).toBe("42");
   });
 
   it("setState called during synchronous $memo queues the rerender instead of running recursively", () => {
@@ -71,7 +71,7 @@ describe("stop-render-on-update", () => {
     // - Run 1 (cancelled): n=0, deps=[0], memoRuns++, setN(1) → pendingRerender
     // - Run 2 (committed): n=1, deps=[1], memoRuns++ (deps changed)
     expect(memoRuns).toBe(2);
-    expect(container.querySelector("span")!.textContent).toBe("1");
+    expect(container.querySelector("span")?.textContent).toBe("1");
   });
 
   it("multiple synchronous setState calls during one render collapse into a single follow-up render", () => {
@@ -98,7 +98,7 @@ describe("stop-render-on-update", () => {
     // Initial render: cancelled after first setState
     // Follow-up render: committed with a=10, b=20 (sa(10) and sb(20) both applied)
     // Only ONE follow-up render should happen (both state changes batched)
-    expect(container.querySelector("span")!.textContent).toBe("10:20");
+    expect(container.querySelector("span")?.textContent).toBe("10:20");
     // renderCount is 2: one cancelled, one committed
     expect(renderCount).toBe(2);
   });
@@ -130,7 +130,7 @@ describe("stop-render-on-update", () => {
     // (and therefore its cleanup never runs either).
     // The committed render is n=1.
     expect(renderCount).toBe(2);
-    expect(container.querySelector("span")!.textContent).toBe("1");
+    expect(container.querySelector("span")?.textContent).toBe("1");
 
     // No cleanup should have fired yet — only one effect was committed (n=1)
     expect(cleanupCount).toBe(0);
@@ -160,7 +160,7 @@ describe("stop-render-on-update", () => {
     // (synchronously, before the first await in the async factory), which
     // queued a rerender. The first render was cancelled; the second committed
     // with 'JOONA'. After that the async memo's await resolved.
-    expect(container.querySelector("span")!.textContent).toBe("JOONA");
+    expect(container.querySelector("span")?.textContent).toBe("JOONA");
 
     // Yield to the microtask queue so the async continuation runs
     await Promise.resolve();
@@ -175,7 +175,7 @@ describe("stop-render-on-update", () => {
 
   it("$memo cache is reused across a cancelled + retried render when deps are unchanged", () => {
     let memoRuns = 0;
-    let setter: ((v: string) => Promise<void>) | null = null;
+    let setter: (v: string) => Promise<void> = () => Promise.resolve();
 
     function* Comp() {
       const [label, setLabel] = yield* $state("a");
@@ -202,10 +202,10 @@ describe("stop-render-on-update", () => {
     // Run 1 (cancelled, label='a'): memoRuns++ (→1), setLabel('b') queued
     // Run 2 (committed, label='b'): memoRuns++ (→2) because deps changed
     expect(memoRuns).toBe(2);
-    expect(container.querySelector("span")!.textContent).toBe("B");
+    expect(container.querySelector("span")?.textContent).toBe("B");
 
     // Now trigger an external state change that does NOT change the memo deps
-    setter!("b"); // same value → shallowEqual, no rerender
+    setter("b"); // same value → shallowEqual, no rerender
     // (setter called with same value — $state setter still calls rerender but
     //  since value didn't change the component just re-renders and memo cache hits)
   });
@@ -231,16 +231,16 @@ describe("stop-render-on-update", () => {
     render(createElement(Comp as never, {}), container);
     // Synchronous: val='start', setVal('middle') called → queued, render cancelled
     // Committed: val='middle'
-    expect(container.querySelector("span")!.textContent).toBe("middle");
+    expect(container.querySelector("span")?.textContent).toBe("middle");
 
     // First microtask: await setVal('middle') resolved → setVal('end') called
     await Promise.resolve();
     // setVal('end') runs rerender synchronously (isRendering=false)
-    expect(container.querySelector("span")!.textContent).toBe("end");
+    expect(container.querySelector("span")?.textContent).toBe("end");
 
     // Second microtask: await setVal('end') resolved
     await Promise.resolve();
-    domValues.push(container.querySelector("span")!.textContent!);
+    domValues.push(container.querySelector("span")?.textContent ?? "");
     expect(domValues).toEqual(["end"]);
   });
 });

--- a/src/__tests__/ui-patch.test.ts
+++ b/src/__tests__/ui-patch.test.ts
@@ -23,7 +23,7 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
   });
 
   it("defers DOM updates until commitUIPatch is called", () => {
-    let setValue: ((v: string) => void) | null = null;
+    let setValue: (v: string) => void = () => {};
 
     function* Comp() {
       const [v, sv] = yield* $state("initial");
@@ -35,7 +35,7 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
     expect(container.textContent).toBe("initial");
 
     startUIPatch();
-    setValue!("updated");
+    setValue("updated");
     // DOM not yet changed
     expect(container.textContent).toBe("initial");
 
@@ -45,7 +45,7 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
 
   it("multiple state changes during patch produce exactly one DOM update on commit", () => {
     const renderCalls: string[] = [];
-    let setValue: ((v: string) => void) | null = null;
+    let setValue: (v: string) => void = () => {};
 
     function* Comp() {
       const [v, sv] = yield* $state("a");
@@ -58,8 +58,8 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
     renderCalls.length = 0; // reset after initial mount
 
     startUIPatch();
-    setValue!("b");
-    setValue!("c");
+    setValue("b");
+    setValue("c");
     // Two state changes → two generator runs, but DOM unchanged
     expect(container.textContent).toBe("a");
 
@@ -69,7 +69,7 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
   });
 
   it("nested patches: DOM only flushed when depth reaches zero", () => {
-    let setValue: ((v: string) => void) | null = null;
+    let setValue: (v: string) => void = () => {};
 
     function* Comp() {
       const [v, sv] = yield* $state("a");
@@ -81,7 +81,7 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
 
     startUIPatch();
     startUIPatch();
-    setValue!("b");
+    setValue("b");
     commitUIPatch(); // depth 2→1; not flushed yet
     expect(container.textContent).toBe("a");
     commitUIPatch(); // depth 1→0; flushed now
@@ -89,8 +89,8 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
   });
 
   it('$patch="live" component updates immediately during a global patch', () => {
-    let setLive: ((v: string) => void) | null = null;
-    let setFrozen: ((v: string) => void) | null = null;
+    let setLive: (v: string) => void = () => {};
+    let setFrozen: (v: string) => void = () => {};
 
     function* Live() {
       const [v, sv] = yield* $state("live-a");
@@ -116,20 +116,20 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
     render(createElement(App as never, {}), container);
 
     startUIPatch();
-    setLive!("live-b");
-    setFrozen!("frozen-b");
+    setLive("live-b");
+    setFrozen("frozen-b");
 
     // Live component updated immediately; frozen component not yet
-    expect(container.querySelector("#live")!.textContent).toBe("live-b");
-    expect(container.querySelector("#frozen")!.textContent).toBe("frozen-a");
+    expect(container.querySelector("#live")?.textContent).toBe("live-b");
+    expect(container.querySelector("#frozen")?.textContent).toBe("frozen-a");
 
     commitUIPatch();
-    expect(container.querySelector("#frozen")!.textContent).toBe("frozen-b");
+    expect(container.querySelector("#frozen")?.textContent).toBe("frozen-b");
   });
 
   it("unmounting a dirty component before commit does not throw", () => {
-    let setValue: ((v: string) => void) | null = null;
-    let setShown: ((v: boolean) => void) | null = null;
+    let setValue: (v: string) => void = () => {};
+    let setShown: (v: boolean) => void = () => {};
 
     function* Inner() {
       const [v, sv] = yield* $state("x");
@@ -146,8 +146,8 @@ describe("startUIPatch / commitUIPatch (global patch)", () => {
     render(createElement(Outer as never, {}), container);
 
     startUIPatch();
-    setValue!("y"); // Inner is now dirty
-    setShown!(false); // Inner is unmounted
+    setValue("y"); // Inner is now dirty
+    setShown(false); // Inner is unmounted
 
     expect(() => commitUIPatch()).not.toThrow();
   });
@@ -170,9 +170,9 @@ describe("$uiPatch (local patch)", () => {
   });
 
   it("defers DOM updates in the component and its descendants until commit", () => {
-    let setInner: ((v: string) => void) | null = null;
-    let capturedCommit: (() => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setInner: (v: string) => void = () => {};
+    let capturedCommit: () => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       const [v, sv] = yield* $state("child-a");
@@ -188,19 +188,19 @@ describe("$uiPatch (local patch)", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    capturedCommit = capturedStartPatch!();
-    setInner!("child-b");
+    capturedCommit = capturedStartPatch();
+    setInner("child-b");
 
     // DOM not yet updated
-    expect(container.querySelector("#child")!.textContent).toBe("child-a");
+    expect(container.querySelector("#child")?.textContent).toBe("child-a");
 
     capturedCommit();
-    expect(container.querySelector("#child")!.textContent).toBe("child-b");
+    expect(container.querySelector("#child")?.textContent).toBe("child-b");
   });
 
   it("sibling component outside the patch subtree updates immediately", () => {
-    let setSibling: ((v: string) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setSibling: (v: string) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* PatchedArea() {
       const startPatch = yield* $uiPatch();
@@ -225,11 +225,11 @@ describe("$uiPatch (local patch)", () => {
 
     render(createElement(App as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setSibling!("sib-b");
+    const commit = capturedStartPatch();
+    setSibling("sib-b");
 
     // Sibling is outside the patch scope → updates immediately
-    expect(container.querySelector("#sib")!.textContent).toBe("sib-b");
+    expect(container.querySelector("#sib")?.textContent).toBe("sib-b");
 
     // Committing is a no-op for the sibling but should not throw
     expect(() => commit()).not.toThrow();
@@ -238,9 +238,9 @@ describe("$uiPatch (local patch)", () => {
   it("snapshot is taken at startPatch() call time", () => {
     // A child mounted AFTER startPatch() is called is not in the snapshot
     // and runs normally.
-    let setShow: ((v: boolean) => void) | null = null;
-    let setDynamic: ((v: string) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let setDynamic: (v: string) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Dynamic() {
       const [v, sv] = yield* $state("dyn-a");
@@ -259,16 +259,16 @@ describe("$uiPatch (local patch)", () => {
     render(createElement(Parent as never, {}), container);
 
     // Start patch BEFORE Dynamic is mounted
-    const commit = capturedStartPatch!();
+    const commit = capturedStartPatch();
 
     // Mount Dynamic while patch is active (it's not in the snapshot)
-    setShow!(true); // Parent is in the patch → deferred
+    setShow(true); // Parent is in the patch → deferred
     // DOM not yet updated (Parent itself is deferred)
     expect(container.querySelector("#dyn")).toBeNull();
 
     commit();
     // After commit, Dynamic appears
-    expect(container.querySelector("#dyn")!.textContent).toBe("dyn-a");
+    expect(container.querySelector("#dyn")?.textContent).toBe("dyn-a");
     void setDynamic; // silence unused warning
   });
 });
@@ -293,7 +293,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   // ── Removal ──────────────────────────────────────────────────────────────
 
   it("removed default element stays visible until commit", () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -309,7 +309,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     expect(container.querySelector("#target")).not.toBeNull();
 
     startUIPatch();
-    setShow!(false);
+    setShow(false);
     // Still visible — DOM is frozen
     expect(container.querySelector("#target")).not.toBeNull();
 
@@ -318,7 +318,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it('removed $patch="live" component disappears immediately', () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -338,7 +338,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     expect(container.querySelector("#target")).not.toBeNull();
 
     startUIPatch();
-    setShow!(false);
+    setShow(false);
     // Removed immediately because $patch="live"
     expect(container.querySelector("#target")).toBeNull();
 
@@ -348,7 +348,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it('element inside $patch="live" wrapper removed disappears immediately', () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -367,7 +367,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setShow!(false);
+    setShow(false);
     expect(container.querySelector("#target")).toBeNull();
 
     commitUIPatch();
@@ -375,7 +375,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it('$shown=false with $patch="live" hides element immediately', () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -395,7 +395,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     expect(container.querySelector("#target")).not.toBeNull();
 
     startUIPatch();
-    setShow!(false);
+    setShow(false);
     // Hidden immediately
     expect(container.querySelector("#target")).toBeNull();
 
@@ -404,7 +404,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it('$shown=false without $patch="live" keeps element visible until commit', () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -419,7 +419,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setShow!(false);
+    setShow(false);
     expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
@@ -429,7 +429,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   // ── Addition ─────────────────────────────────────────────────────────────
 
   it("added default element does not appear until commit", () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -445,7 +445,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     expect(container.querySelector("#target")).toBeNull();
 
     startUIPatch();
-    setShow!(true);
+    setShow(true);
     // Not yet visible
     expect(container.querySelector("#target")).toBeNull();
 
@@ -454,7 +454,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it('added $patch="live" component appears immediately', () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -473,7 +473,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setShow!(true);
+    setShow(true);
     // Appears immediately
     expect(container.querySelector("#target")).not.toBeNull();
 
@@ -483,7 +483,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it('element added inside $patch="live" wrapper appears immediately', () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -502,7 +502,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setShow!(true);
+    setShow(true);
     expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
@@ -510,7 +510,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it('$shown=true with $patch="live" shows element immediately', () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -530,7 +530,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     expect(container.querySelector("#target")).toBeNull();
 
     startUIPatch();
-    setShow!(true);
+    setShow(true);
     expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
@@ -540,7 +540,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   // ── Remove then re-add ────────────────────────────────────────────────────
 
   it("default element removed then re-added stays visible throughout and commit preserves it", () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -555,9 +555,9 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setShow!(false); // remove — frozen, stays visible
+    setShow(false); // remove — frozen, stays visible
     expect(container.querySelector("#target")).not.toBeNull();
-    setShow!(true); // re-add — still frozen
+    setShow(true); // re-add — still frozen
     expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
@@ -566,7 +566,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it("live element removed then re-added disappears and reappears immediately", () => {
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -585,9 +585,9 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setShow!(false); // live remove → gone immediately
+    setShow(false); // live remove → gone immediately
     expect(container.querySelector("#target")).toBeNull();
-    setShow!(true); // live re-add → back immediately
+    setShow(true); // live re-add → back immediately
     expect(container.querySelector("#target")).not.toBeNull();
 
     commitUIPatch();
@@ -597,7 +597,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   // ── Text content inside live context ──────────────────────────────────────
 
   it('text inside $patch="live" wrapper updates immediately', () => {
-    let setValue: ((v: string) => void) | null = null;
+    let setValue: (v: string) => void = () => {};
 
     function* Parent() {
       const [v, setV] = yield* $state("a");
@@ -608,7 +608,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setValue!("b");
+    setValue("b");
     expect(container.textContent).toBe("b");
 
     commitUIPatch();
@@ -616,7 +616,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   });
 
   it("text outside live context stays frozen until commit", () => {
-    let setValue: ((v: string) => void) | null = null;
+    let setValue: (v: string) => void = () => {};
 
     function* Parent() {
       const [v, setV] = yield* $state("a");
@@ -627,7 +627,7 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setValue!("b");
+    setValue("b");
     expect(container.textContent).toBe("a");
 
     commitUIPatch();
@@ -637,8 +637,8 @@ describe("live-only reconcile: element add/remove during global patch", () => {
   // ── Dynamic $patch changes mid-patch ─────────────────────────────────────
 
   it("component switches from default to live mid-patch and starts updating immediately", () => {
-    let setLive: ((v: boolean) => void) | null = null;
-    let setValue: ((v: string) => void) | null = null;
+    let setLive: (v: boolean) => void = () => {};
+    let setValue: (v: string) => void = () => {};
 
     function* Child() {
       const [v, setV] = yield* $state("a");
@@ -657,27 +657,27 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     }
 
     render(createElement(Parent as never, {}), container);
-    expect(container.querySelector("#target")!.textContent).toBe("a");
+    expect(container.querySelector("#target")?.textContent).toBe("a");
 
     startUIPatch();
     // First update while Child is still default → deferred
-    setValue!("b");
-    expect(container.querySelector("#target")!.textContent).toBe("a");
+    setValue("b");
+    expect(container.querySelector("#target")?.textContent).toBe("a");
 
     // Switch Child to live (via parent rerender)
-    setLive!(true);
+    setLive(true);
     // Now Child's captured batch context is updated to 'live'
     // Subsequent updates should be immediate
-    setValue!("c");
-    expect(container.querySelector("#target")!.textContent).toBe("c");
+    setValue("c");
+    expect(container.querySelector("#target")?.textContent).toBe("c");
 
     commitUIPatch();
-    expect(container.querySelector("#target")!.textContent).toBe("c");
+    expect(container.querySelector("#target")?.textContent).toBe("c");
   });
 
   it("component switches from live to default mid-patch and stops updating", () => {
-    let setLive: ((v: boolean) => void) | null = null;
-    let setValue: ((v: string) => void) | null = null;
+    let setLive: (v: boolean) => void = () => {};
+    let setValue: (v: string) => void = () => {};
 
     function* Child() {
       const [v, setV] = yield* $state("a");
@@ -699,22 +699,22 @@ describe("live-only reconcile: element add/remove during global patch", () => {
 
     startUIPatch();
     // Child is live → updates immediately
-    setValue!("b");
-    expect(container.querySelector("#target")!.textContent).toBe("b");
+    setValue("b");
+    expect(container.querySelector("#target")?.textContent).toBe("b");
 
     // Switch Child to default → stops updating immediately
-    setLive!(false);
-    setValue!("c");
+    setLive(false);
+    setValue("c");
     // Should still show 'b' — deferred now
-    expect(container.querySelector("#target")!.textContent).toBe("b");
+    expect(container.querySelector("#target")?.textContent).toBe("b");
 
     commitUIPatch();
-    expect(container.querySelector("#target")!.textContent).toBe("c");
+    expect(container.querySelector("#target")?.textContent).toBe("c");
   });
 
   it("live element that becomes default retains its last live state after commit", () => {
-    let setLive: ((v: boolean) => void) | null = null;
-    let setValue: ((v: string) => void) | null = null;
+    let setLive: (v: boolean) => void = () => {};
+    let setValue: (v: string) => void = () => {};
 
     function* Child() {
       const [v, setV] = yield* $state("a");
@@ -735,17 +735,17 @@ describe("live-only reconcile: element add/remove during global patch", () => {
     render(createElement(Parent as never, {}), container);
 
     startUIPatch();
-    setValue!("b"); // live → updates immediately
-    expect(container.querySelector("#target")!.textContent).toBe("b");
+    setValue("b"); // live → updates immediately
+    expect(container.querySelector("#target")?.textContent).toBe("b");
 
-    setLive!(false); // switch to default — 'b' stays in DOM
-    expect(container.querySelector("#target")!.textContent).toBe("b");
+    setLive(false); // switch to default — 'b' stays in DOM
+    expect(container.querySelector("#target")?.textContent).toBe("b");
 
     // No further state updates — commit should apply pendingVNode for Parent
     // (which has $patch="default" for Child now), reconcile from 'b'
     commitUIPatch();
     // State was never changed again — Child remains at 'b'
-    expect(container.querySelector("#target")!.textContent).toBe("b");
+    expect(container.querySelector("#target")?.textContent).toBe("b");
   });
 });
 
@@ -766,8 +766,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it("removed default element stays visible until local commit", () => {
-    let setShow: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -783,8 +783,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setShow!(false);
+    const commit = capturedStartPatch();
+    setShow(false);
     expect(container.querySelector("#target")).not.toBeNull();
 
     commit();
@@ -792,8 +792,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it('removed $patch="live" component disappears immediately during local patch', () => {
-    let setShow: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -813,8 +813,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setShow!(false);
+    const commit = capturedStartPatch();
+    setShow(false);
     expect(container.querySelector("#target")).toBeNull();
 
     commit();
@@ -822,8 +822,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it("added default element does not appear until local commit", () => {
-    let setShow: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -839,8 +839,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setShow!(true);
+    const commit = capturedStartPatch();
+    setShow(true);
     expect(container.querySelector("#target")).toBeNull();
 
     commit();
@@ -848,8 +848,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it('added $patch="live" component appears immediately during local patch', () => {
-    let setShow: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -869,8 +869,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setShow!(true);
+    const commit = capturedStartPatch();
+    setShow(true);
     expect(container.querySelector("#target")).not.toBeNull();
 
     commit();
@@ -878,8 +878,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it("live element added then removed during local patch: not present after commit", () => {
-    let setShow: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -899,10 +899,10 @@ describe("live-only reconcile: element add/remove during local patch", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setShow!(true); // live-add → appears immediately
+    const commit = capturedStartPatch();
+    setShow(true); // live-add → appears immediately
     expect(container.querySelector("#target")).not.toBeNull();
-    setShow!(false); // live-remove → disappears immediately
+    setShow(false); // live-remove → disappears immediately
     expect(container.querySelector("#target")).toBeNull();
 
     commit();
@@ -910,8 +910,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it("default element added then removed during local patch: invisible throughout, absent after commit", () => {
-    let setShow: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -927,10 +927,10 @@ describe("live-only reconcile: element add/remove during local patch", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setShow!(true); // default: still not visible
+    const commit = capturedStartPatch();
+    setShow(true); // default: still not visible
     expect(container.querySelector("#target")).toBeNull();
-    setShow!(false); // default: still not visible
+    setShow(false); // default: still not visible
     expect(container.querySelector("#target")).toBeNull();
 
     commit();
@@ -939,8 +939,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it("default element removed then re-added during local patch: visible throughout and present after commit", () => {
-    let setShow: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "hello");
@@ -956,10 +956,10 @@ describe("live-only reconcile: element add/remove during local patch", () => {
 
     render(createElement(Parent as never, {}), container);
 
-    const commit = capturedStartPatch!();
-    setShow!(false); // frozen: still visible
+    const commit = capturedStartPatch();
+    setShow(false); // frozen: still visible
     expect(container.querySelector("#target")).not.toBeNull();
-    setShow!(true); // frozen: still visible
+    setShow(true); // frozen: still visible
     expect(container.querySelector("#target")).not.toBeNull();
 
     commit();
@@ -967,8 +967,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
   });
 
   it('$shown with $patch="live" inside local patch scope behaves live', () => {
-    let setShown: ((v: boolean) => void) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setShown: (v: boolean) => void = () => {};
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Child() {
       return createElement("span", { id: "target" }, "x");
@@ -989,8 +989,8 @@ describe("live-only reconcile: element add/remove during local patch", () => {
     render(createElement(Parent as never, {}), container);
     expect(container.querySelector("#target")).not.toBeNull();
 
-    const commit = capturedStartPatch!();
-    setShown!(false); // live → hides immediately
+    const commit = capturedStartPatch();
+    setShown(false); // live → hides immediately
     expect(container.querySelector("#target")).toBeNull();
 
     commit();
@@ -1020,7 +1020,7 @@ describe("child component prop updates apply correctly after global patch commit
     // Regression: mirrors the real demo flow where setIsPending(true) fires
     // BEFORE the patch (so the DOM shows disabled/wait), then setIsPending(false)
     // fires INSIDE the patch, and the button must be enabled after commit.
-    let setPending: ((v: boolean) => Promise<void>) | null = null;
+    let setPending: (v: boolean) => Promise<void> = () => Promise.resolve();
 
     function* Nav(props: { isPending: boolean }) {
       return createElement("button", { id: "btn", disabled: props.isPending }, "click");
@@ -1033,24 +1033,24 @@ describe("child component prop updates apply correctly after global patch commit
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(false);
 
     // Set isPending=true BEFORE the patch (immediate DOM update — buttons disabled)
-    setPending!(true);
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
+    setPending(true);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(true);
 
     startUIPatch();
     // Inside patch, clear isPending — DOM frozen (buttons still disabled)
-    setPending!(false);
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
+    setPending(false);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(true);
 
     commitUIPatch();
     // After commit: isPending=false must be applied — button must be enabled
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(false);
   });
 
   it("child receives isPending=true during patch, then isPending=false at commit", () => {
-    let setPending: ((v: boolean) => Promise<void>) | null = null;
+    let setPending: (v: boolean) => Promise<void> = () => Promise.resolve();
     const renderLog: boolean[] = [];
 
     function* Status(props: { pending: boolean }) {
@@ -1065,22 +1065,22 @@ describe("child component prop updates apply correctly after global patch commit
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("#status")!.textContent).toBe("done");
+    expect(container.querySelector("#status")?.textContent).toBe("done");
     renderLog.length = 0;
 
     startUIPatch();
-    setPending!(true); // App rerenders with pending=true; Status deferred
+    setPending(true); // App rerenders with pending=true; Status deferred
     // DOM frozen
-    expect(container.querySelector("#status")!.textContent).toBe("done");
+    expect(container.querySelector("#status")?.textContent).toBe("done");
 
     commitUIPatch();
     // After commit, Status must reflect pending=true
-    expect(container.querySelector("#status")!.textContent).toBe("loading");
+    expect(container.querySelector("#status")?.textContent).toBe("loading");
     expect(renderLog[renderLog.length - 1]).toBe(true);
   });
 
   it("commit applies the FINAL props when child receives multiple prop changes during patch", () => {
-    let setLabel: ((v: string) => Promise<void>) | null = null;
+    let setLabel: (v: string) => Promise<void> = () => Promise.resolve();
 
     function* Label(props: { text: string }) {
       return createElement("span", { id: "label" }, props.text);
@@ -1093,17 +1093,17 @@ describe("child component prop updates apply correctly after global patch commit
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("#label")!.textContent).toBe("a");
+    expect(container.querySelector("#label")?.textContent).toBe("a");
 
     startUIPatch();
-    setLabel!("b");
-    setLabel!("c");
+    setLabel("b");
+    setLabel("c");
     // Frozen during patch
-    expect(container.querySelector("#label")!.textContent).toBe("a");
+    expect(container.querySelector("#label")?.textContent).toBe("a");
 
     commitUIPatch();
     // Final value after commit
-    expect(container.querySelector("#label")!.textContent).toBe("c");
+    expect(container.querySelector("#label")?.textContent).toBe("c");
   });
 });
 
@@ -1122,8 +1122,8 @@ describe("child component prop updates apply correctly after local patch commit"
   it("child reflects changed props after local commit", () => {
     // Regression: mirrors the real demo where isPending=true fires BEFORE the patch,
     // then isPending=false fires inside the patch — button must be enabled after commit.
-    let setPending: ((v: boolean) => Promise<void>) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setPending: (v: boolean) => Promise<void> = () => Promise.resolve();
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Nav(props: { isPending: boolean }) {
       return createElement("button", { id: "btn", disabled: props.isPending }, "click");
@@ -1138,25 +1138,25 @@ describe("child component prop updates apply correctly after local patch commit"
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(false);
 
     // Set isPending=true BEFORE patch (immediate DOM update)
-    setPending!(true);
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
+    setPending(true);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(true);
 
-    const commit = capturedStartPatch!();
+    const commit = capturedStartPatch();
     // Inside patch, clear isPending — DOM frozen (still disabled)
-    setPending!(false);
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(true);
+    setPending(false);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(true);
 
     commit();
     // After commit: isPending=false applied — button must be enabled
-    expect(container.querySelector("#btn")!.hasAttribute("disabled")).toBe(false);
+    expect(container.querySelector("#btn")?.hasAttribute("disabled")).toBe(false);
   });
 
   it("local patch: child isPending=true at commit time shows loading state", () => {
-    let setPending: ((v: boolean) => Promise<void>) | null = null;
-    let capturedStartPatch: (() => () => void) | null = null;
+    let setPending: (v: boolean) => Promise<void> = () => Promise.resolve();
+    let capturedStartPatch: () => () => void = () => () => {};
 
     function* Status(props: { pending: boolean }) {
       return createElement("span", { id: "status" }, props.pending ? "loading" : "done");
@@ -1171,13 +1171,13 @@ describe("child component prop updates apply correctly after local patch commit"
     }
 
     render(createElement(App as never, {}), container);
-    expect(container.querySelector("#status")!.textContent).toBe("done");
+    expect(container.querySelector("#status")?.textContent).toBe("done");
 
-    const commit = capturedStartPatch!();
-    setPending!(true); // App rerenders; Status deferred
-    expect(container.querySelector("#status")!.textContent).toBe("done");
+    const commit = capturedStartPatch();
+    setPending(true); // App rerenders; Status deferred
+    expect(container.querySelector("#status")?.textContent).toBe("done");
 
     commit();
-    expect(container.querySelector("#status")!.textContent).toBe("loading");
+    expect(container.querySelector("#status")?.textContent).toBe("loading");
   });
 });

--- a/src/__tests__/use-effect.test.ts
+++ b/src/__tests__/use-effect.test.ts
@@ -33,7 +33,7 @@ describe("render – $effect", () => {
 
   it("does not re-run effect when deps are unchanged", () => {
     const calls: string[] = [];
-    let setCount: ((v: number) => void) | null = null;
+    let setCount: (v: number) => void = () => {};
 
     function* Comp() {
       const [count, sc] = yield* $state(0);
@@ -48,14 +48,14 @@ describe("render – $effect", () => {
     render(createElement(Comp as never, {}), container);
     expect(calls).toEqual(["effect"]);
 
-    setCount!(1);
-    setCount!(2);
+    setCount(1);
+    setCount(2);
     expect(calls).toEqual(["effect"]); // still only once
   });
 
   it("re-runs effect and calls previous cleanup when deps change", () => {
     const log: string[] = [];
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
 
     function* Comp() {
       const [id, si] = yield* $state(1);
@@ -70,16 +70,16 @@ describe("render – $effect", () => {
     render(createElement(Comp as never, {}), container);
     expect(log).toEqual(["effect:1"]);
 
-    setId!(2);
+    setId(2);
     expect(log).toEqual(["effect:1", "cleanup:1", "effect:2"]);
 
-    setId!(3);
+    setId(3);
     expect(log).toEqual(["effect:1", "cleanup:1", "effect:2", "cleanup:2", "effect:3"]);
   });
 
   it("calls cleanup on unmount", () => {
     const log: string[] = [];
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Inner() {
       yield* $effect(() => {
@@ -98,7 +98,7 @@ describe("render – $effect", () => {
     render(createElement(Outer as never, {}), container);
     expect(log).toEqual(["mount"]);
 
-    setShow!(false);
+    setShow(false);
     expect(log).toEqual(["mount", "unmount"]);
   });
 
@@ -155,7 +155,7 @@ describe("render – $effect", () => {
 
   it("aborts the signal when deps change", () => {
     const signals: AbortSignal[] = [];
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
 
     function* Comp() {
       const [id, si] = yield* $state(1);
@@ -172,18 +172,18 @@ describe("render – $effect", () => {
 
     render(createElement(Comp as never, {}), container);
     expect(signals).toHaveLength(1);
-    expect(signals[0]!.aborted).toBe(false);
+    expect(signals[0]?.aborted).toBe(false);
 
-    setId!(2);
+    setId(2);
     // The first signal should now be aborted.
-    expect(signals[0]!.aborted).toBe(true);
+    expect(signals[0]?.aborted).toBe(true);
     expect(signals).toHaveLength(2);
-    expect(signals[1]!.aborted).toBe(false);
+    expect(signals[1]?.aborted).toBe(false);
   });
 
   it("aborts the signal on unmount", () => {
     let capturedSignal: AbortSignal | null = null;
-    let setShow: ((v: boolean) => void) | null = null;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Inner() {
       yield* $effect((signal) => {
@@ -203,13 +203,13 @@ describe("render – $effect", () => {
     expect(capturedSignal).toBeInstanceOf(AbortSignal);
     expect((capturedSignal as unknown as AbortSignal).aborted).toBe(false);
 
-    setShow!(false);
+    setShow(false);
     expect((capturedSignal as unknown as AbortSignal).aborted).toBe(true);
   });
 
   it("aborts the signal before calling the cleanup function", () => {
     const log: string[] = [];
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
 
     function* Comp() {
       const [id, si] = yield* $state(1);
@@ -226,7 +226,7 @@ describe("render – $effect", () => {
     }
 
     render(createElement(Comp as never, {}), container);
-    setId!(2);
+    setId(2);
     expect(log).toEqual(["cleanup:1:aborted=true"]);
   });
 });

--- a/src/__tests__/use-id.test.ts
+++ b/src/__tests__/use-id.test.ts
@@ -17,7 +17,7 @@ describe("$id", () => {
   });
 
   it("returns a non-empty string", () => {
-    let capturedId: string | null = null;
+    let capturedId = "";
 
     function* Comp() {
       capturedId = yield* $id();
@@ -26,12 +26,12 @@ describe("$id", () => {
 
     render(createElement(Comp as never, {}), container);
     expect(typeof capturedId).toBe("string");
-    expect(capturedId!.length).toBeGreaterThan(0);
+    expect(capturedId.length).toBeGreaterThan(0);
   });
 
   it("returns the same id across re-renders", () => {
     const ids: string[] = [];
-    let setValue: ((v: number) => void) | null = null;
+    let setValue: (v: number) => void = () => {};
 
     function* Comp() {
       const [, sv] = yield* $state(0);
@@ -42,15 +42,15 @@ describe("$id", () => {
     }
 
     render(createElement(Comp as never, {}), container);
-    setValue!(1);
+    setValue(1);
 
     expect(ids).toHaveLength(2);
     expect(ids[0]).toBe(ids[1]);
   });
 
   it("returns distinct ids for different hook call sites", () => {
-    let id1: string | null = null;
-    let id2: string | null = null;
+    let id1 = "";
+    let id2 = "";
 
     function* Comp() {
       id1 = yield* $id();

--- a/src/__tests__/use-memo.test.ts
+++ b/src/__tests__/use-memo.test.ts
@@ -33,7 +33,7 @@ describe("$memo", () => {
 
   it("does not recompute when deps are the same", () => {
     const factory = jest.fn((a: number) => a * 2);
-    let setValue: ((v: number) => void) | null = null;
+    let setValue: (v: number) => void = () => {};
 
     function* Comp() {
       const [v, sv] = yield* $state(10);
@@ -43,14 +43,14 @@ describe("$memo", () => {
     }
 
     render(createElement(Comp as never, {}), container);
-    setValue!(20); // trigger re-render, same dep [5]
+    setValue(20); // trigger re-render, same dep [5]
 
     expect(factory).toHaveBeenCalledTimes(1);
   });
 
   it("recomputes when deps change", () => {
     const factory = jest.fn((a: number) => a * 2);
-    let setValue: ((v: number) => void) | null = null;
+    let setValue: (v: number) => void = () => {};
     let capturedValue: number | null = null;
 
     function* Comp() {
@@ -64,7 +64,7 @@ describe("$memo", () => {
     expect(capturedValue).toBe(2);
     expect(factory).toHaveBeenCalledTimes(1);
 
-    setValue!(3);
+    setValue(3);
     expect(capturedValue).toBe(6);
     expect(factory).toHaveBeenCalledTimes(2);
     expect(factory).toHaveBeenLastCalledWith(3);
@@ -72,7 +72,7 @@ describe("$memo", () => {
 
   it("works with empty deps (zero-arg factory)", () => {
     const factory = jest.fn(() => 42);
-    let setValue: ((v: number) => void) | null = null;
+    let setValue: (v: number) => void = () => {};
     let capturedValue: number | null = null;
 
     function* Comp() {
@@ -86,7 +86,7 @@ describe("$memo", () => {
     expect(capturedValue).toBe(42);
     expect(factory).toHaveBeenCalledTimes(1);
 
-    setValue!(1); // re-render, empty deps never change
+    setValue(1); // re-render, empty deps never change
     expect(capturedValue).toBe(42);
     expect(factory).toHaveBeenCalledTimes(1);
   });

--- a/src/__tests__/use-ref.test.ts
+++ b/src/__tests__/use-ref.test.ts
@@ -17,7 +17,7 @@ describe("$ref", () => {
   });
 
   it("returns an object with the initial value in .current", () => {
-    let capturedRef: { current: number } | null = null;
+    let capturedRef: { current: number } = { current: 0 };
 
     function* Comp() {
       const ref = yield* $ref(42);
@@ -26,13 +26,12 @@ describe("$ref", () => {
     }
 
     render(createElement(Comp as never, {}), container);
-    expect(capturedRef).not.toBeNull();
-    expect(capturedRef!.current).toBe(42);
+    expect(capturedRef.current).toBe(42);
   });
 
   it("persists the same object across re-renders", () => {
     const refInstances: object[] = [];
-    let setValue: ((v: number) => void) | null = null;
+    let setValue: (v: number) => void = () => {};
 
     function* Comp() {
       const [, sv] = yield* $state(0);
@@ -43,7 +42,7 @@ describe("$ref", () => {
     }
 
     render(createElement(Comp as never, {}), container);
-    setValue!(1);
+    setValue(1);
 
     expect(refInstances).toHaveLength(2);
     expect(refInstances[0]).toBe(refInstances[1]);
@@ -51,7 +50,7 @@ describe("$ref", () => {
 
   it("mutations to .current do not trigger a re-render", () => {
     let renderCount = 0;
-    let capturedRef: { current: number } | null = null;
+    let capturedRef: { current: number } = { current: 0 };
 
     function* Comp() {
       renderCount++;
@@ -63,8 +62,8 @@ describe("$ref", () => {
     render(createElement(Comp as never, {}), container);
     expect(renderCount).toBe(1);
 
-    capturedRef!.current = 99;
+    capturedRef.current = 99;
     expect(renderCount).toBe(1);
-    expect(capturedRef!.current).toBe(99);
+    expect(capturedRef.current).toBe(99);
   });
 });

--- a/src/__tests__/use-render.test.ts
+++ b/src/__tests__/use-render.test.ts
@@ -17,7 +17,7 @@ describe("$render (Variant 2 – inline function)", () => {
   });
 
   it("yields JSX while waiting and returns the value passed to resume", () => {
-    let capturedResume: ((v: string) => void) | null = null;
+    let capturedResume: (v: string) => void = () => {};
     let finalText: string | null = null;
 
     function* Comp() {
@@ -36,14 +36,14 @@ describe("$render (Variant 2 – inline function)", () => {
     expect(finalText).toBeNull();
 
     // Resolving unblocks the generator
-    capturedResume!("DONE");
+    capturedResume("DONE");
 
     expect(container.querySelector("p")?.textContent).toBe("DONE");
     expect(finalText).toBe("DONE");
   });
 
   it("resume is idempotent – calling it twice only resolves once", () => {
-    let capturedResume: ((v: number) => void) | null = null;
+    let capturedResume: (v: number) => void = () => {};
     let resolveCount = 0;
     let finalValue: number | null = null;
 
@@ -58,16 +58,16 @@ describe("$render (Variant 2 – inline function)", () => {
     }
 
     render(createElement(Comp as never, {}), container);
-    capturedResume!(1);
-    capturedResume!(2); // second call ignored
+    capturedResume(1);
+    capturedResume(2); // second call ignored
 
     expect(resolveCount).toBe(1);
     expect(finalValue).toBe(1);
   });
 
   it("resets to waiting on parent rerender while waiting", () => {
-    let capturedResume: ((v: boolean) => void) | null = null;
-    let setVal: ((v: number) => void) | null = null;
+    let capturedResume: (v: boolean) => void = () => {};
+    let setVal: (v: number) => void = () => {};
     let renderCount = 0;
 
     function* Comp() {
@@ -85,17 +85,17 @@ describe("$render (Variant 2 – inline function)", () => {
     expect(renderCount).toBe(1);
 
     // Trigger a rerender while waiting
-    setVal!(1);
+    setVal(1);
     expect(renderCount).toBe(2);
 
     // The generator is still waiting – resolve it now
-    capturedResume!(true);
+    capturedResume(true);
     expect(container.querySelector("div")).not.toBeNull();
   });
 
   it("deps change resets the interaction", () => {
-    let setDep: ((v: number) => void) | null = null;
-    let capturedResume: ((v: string) => void) | null = null;
+    let setDep: (v: number) => void = () => {};
+    let capturedResume: (v: string) => void = () => {};
     let resolveCount = 0;
 
     function* Comp() {
@@ -115,14 +115,14 @@ describe("$render (Variant 2 – inline function)", () => {
     render(createElement(Comp as never, {}), container);
 
     // Resolve first interaction
-    capturedResume!("first");
+    capturedResume("first");
     expect(resolveCount).toBe(1);
 
     // Change dep → should reset and show dialog again
-    setDep!(1);
+    setDep(1);
     expect(container.querySelector("span")).not.toBeNull();
 
-    capturedResume!("second");
+    capturedResume("second");
     expect(resolveCount).toBe(2);
   });
 });
@@ -140,7 +140,7 @@ describe("$render (Variant 1 – JSX child with $resume)", () => {
   });
 
   it("child component receives resume via $resume and can resolve the parent", () => {
-    let capturedResume: ((v: string) => void) | null = null;
+    let capturedResume: (v: string) => void = () => {};
     let finalAnswer: string | null = null;
 
     function* Dialog() {
@@ -160,7 +160,7 @@ describe("$render (Variant 1 – JSX child with $resume)", () => {
     expect(container.querySelector("span")?.textContent).toBe("dialog");
     expect(finalAnswer).toBeNull();
 
-    capturedResume!("ACCEPTED");
+    capturedResume("ACCEPTED");
 
     expect(container.querySelector("p")?.textContent).toBe("ACCEPTED");
     expect(finalAnswer).toBe("ACCEPTED");
@@ -168,8 +168,8 @@ describe("$render (Variant 1 – JSX child with $resume)", () => {
 
   it("does not remount the child when the parent rerenders while waiting", () => {
     let mountCount = 0;
-    let capturedResume: ((v: string) => void) | null = null;
-    let setVal: ((v: number) => void) | null = null;
+    let capturedResume: (v: string) => void = () => {};
+    let setVal: (v: number) => void = () => {};
 
     function* Dialog() {
       mountCount++;
@@ -189,11 +189,11 @@ describe("$render (Variant 1 – JSX child with $resume)", () => {
     expect(mountCount).toBe(1);
 
     // Trigger a parent rerender while the dialog is still open
-    setVal!(1);
+    setVal(1);
     expect(mountCount).toBe(1); // Dialog must NOT remount
 
     // Resolve still works after the rerender
-    capturedResume!("OK");
+    capturedResume("OK");
     expect(container.querySelector("div")).not.toBeNull();
   });
 });

--- a/src/__tests__/use-resolve.test.ts
+++ b/src/__tests__/use-resolve.test.ts
@@ -43,7 +43,7 @@ describe("render – generator components with $resolve", () => {
 
     expect(container.querySelector("#loading")).toBeNull();
     expect(container.querySelector("#data")).not.toBeNull();
-    expect(container.querySelector("#data")!.textContent).toBe("Hello World");
+    expect(container.querySelector("#data")?.textContent).toBe("Hello World");
   });
 
   it("shows error state when promise rejects", async () => {
@@ -79,7 +79,7 @@ describe("render – generator components with $resolve", () => {
     const promise = new Promise<string>((res) => {
       resolvePromise = res;
     });
-    let setLabel: ((v: string) => void) | null = null;
+    let setLabel: (v: string) => void = () => {};
 
     function* DataComp() {
       const [label, sl] = yield* $state("prefix");
@@ -101,10 +101,10 @@ describe("render – generator components with $resolve", () => {
     resolvePromise("world");
     await promise;
 
-    expect(container.querySelector("#result")!.textContent).toBe("prefix:world");
+    expect(container.querySelector("#result")?.textContent).toBe("prefix:world");
 
-    setLabel!("updated");
-    expect(container.querySelector("#result")!.textContent).toBe("updated:world");
+    setLabel("updated");
+    expect(container.querySelector("#result")?.textContent).toBe("updated:world");
   });
 
   it("$state change while promise is pending triggers fresh run and shows correct state after resolve", async () => {
@@ -112,7 +112,7 @@ describe("render – generator components with $resolve", () => {
     const promise = new Promise<string>((res) => {
       resolvePromise = res;
     });
-    let setLabel: ((v: string) => void) | null = null;
+    let setLabel: (v: string) => void = () => {};
 
     function* DataComp() {
       const [label, sl] = yield* $state("prefix");
@@ -132,7 +132,7 @@ describe("render – generator components with $resolve", () => {
     expect(container.querySelector("#loading")).not.toBeNull();
 
     // Change state WHILE the promise is still pending
-    setLabel!("updated");
+    setLabel("updated");
     // Still loading, but label should be reflected after resolve
     expect(container.querySelector("#loading")).not.toBeNull();
 
@@ -140,7 +140,7 @@ describe("render – generator components with $resolve", () => {
     await promise;
 
     // The fresh run after setLabel captured 'updated'; resume uses that generator
-    expect(container.querySelector("#result")!.textContent).toBe("updated:world");
+    expect(container.querySelector("#result")?.textContent).toBe("updated:world");
   });
 
   it("$resolve re-runs when deps change", async () => {
@@ -153,7 +153,7 @@ describe("render – generator components with $resolve", () => {
       resolveSecond = res;
     });
 
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
     let fetchCount = 0;
 
     function* DataComp() {
@@ -179,16 +179,16 @@ describe("render – generator components with $resolve", () => {
 
     resolveFirst("user1");
     await firstPromise;
-    expect(container.querySelector("#result")!.textContent).toBe("1:user1");
+    expect(container.querySelector("#result")?.textContent).toBe("1:user1");
 
     // Change the dep – should re-run the promise
-    setId!(2);
+    setId(2);
     expect(fetchCount).toBe(2);
     expect(container.querySelector("#loading")).not.toBeNull();
 
     resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
+    expect(container.querySelector("#result")?.textContent).toBe("2:user2");
   });
 
   it("stale promise result is ignored when deps change before it resolves", async () => {
@@ -201,7 +201,7 @@ describe("render – generator components with $resolve", () => {
       resolveSecond = res;
     });
 
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
 
     function* DataComp() {
       const [id, si] = yield* $state(1);
@@ -221,23 +221,23 @@ describe("render – generator components with $resolve", () => {
     expect(container.querySelector("#loading")).not.toBeNull();
 
     // Change dep before first promise resolves
-    setId!(2);
+    setId(2);
     expect(container.querySelector("#loading")).not.toBeNull();
 
     // Resolve second promise first
     resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
+    expect(container.querySelector("#result")?.textContent).toBe("2:user2");
 
     // Now resolve the stale first promise – should NOT update the DOM
     resolveFirst("user1");
     await firstPromise;
-    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
+    expect(container.querySelector("#result")?.textContent).toBe("2:user2");
   });
 
   it("aborts the previous AbortSignal when deps change", async () => {
     const abortedSignals: AbortSignal[] = [];
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
 
     function* DataComp() {
       const [id, si] = yield* $state(1);
@@ -260,14 +260,14 @@ describe("render – generator components with $resolve", () => {
     expect(abortedSignals).toHaveLength(0);
 
     // Changing deps should abort the first signal and start a new fetch.
-    setId!(2);
+    setId(2);
     expect(abortedSignals).toHaveLength(1);
-    expect(abortedSignals[0]!.aborted).toBe(true);
+    expect(abortedSignals[0]?.aborted).toBe(true);
   });
 
   it("aborts the AbortSignal when the component unmounts", async () => {
-    let capturedSignal: AbortSignal | null = null;
-    let setShow: ((v: boolean) => void) | null = null;
+    let capturedSignal: AbortSignal = new AbortController().signal;
+    let setShow: (v: boolean) => void = () => {};
 
     function* Inner() {
       yield* $resolve(
@@ -291,12 +291,11 @@ describe("render – generator components with $resolve", () => {
     }
 
     render(createElement(Outer as never, {}), container);
-    expect(capturedSignal).not.toBeNull();
-    expect(capturedSignal!.aborted).toBe(false);
+    expect(capturedSignal.aborted).toBe(false);
 
     // Unmount Inner by hiding it – the AbortSignal should be aborted.
-    setShow!(false);
-    expect(capturedSignal!.aborted).toBe(true);
+    setShow(false);
+    expect(capturedSignal.aborted).toBe(true);
   });
 });
 
@@ -334,7 +333,7 @@ describe("render – generator components with $resolveRaw", () => {
 
     expect(container.querySelector("#loading")).toBeNull();
     expect(container.querySelector("#data")).not.toBeNull();
-    expect(container.querySelector("#data")!.textContent).toBe("Hello");
+    expect(container.querySelector("#data")?.textContent).toBe("Hello");
   });
 
   it("renders error state when promise rejects", async () => {
@@ -358,7 +357,7 @@ describe("render – generator components with $resolveRaw", () => {
     await promise.catch(() => {});
 
     expect(container.querySelector("#error")).not.toBeNull();
-    expect(container.querySelector("#error")!.textContent).toBe("network error");
+    expect(container.querySelector("#error")?.textContent).toBe("network error");
     expect(container.querySelector("#data")).toBeNull();
   });
 
@@ -371,7 +370,7 @@ describe("render – generator components with $resolveRaw", () => {
     const secondPromise = new Promise<string>((res) => {
       resolveSecond = res;
     });
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
 
     function* DataComp() {
       const [id, si] = yield* $state(1);
@@ -387,14 +386,14 @@ describe("render – generator components with $resolveRaw", () => {
 
     resolveFirst("user1");
     await firstPromise;
-    expect(container.querySelector("#result")!.textContent).toBe("1:user1");
+    expect(container.querySelector("#result")?.textContent).toBe("1:user1");
 
-    setId!(2);
+    setId(2);
     expect(container.querySelector("#loading")).not.toBeNull();
 
     resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
+    expect(container.querySelector("#result")?.textContent).toBe("2:user2");
   });
 
   it("ignores stale promise result when promise reference changes", async () => {
@@ -406,7 +405,7 @@ describe("render – generator components with $resolveRaw", () => {
     const secondPromise = new Promise<string>((res) => {
       resolveSecond = res;
     });
-    let setId: ((v: number) => void) | null = null;
+    let setId: (v: number) => void = () => {};
 
     function* DataComp() {
       const [id, si] = yield* $state(1);
@@ -419,15 +418,15 @@ describe("render – generator components with $resolveRaw", () => {
 
     render(createElement(DataComp as never, {}), container);
 
-    setId!(2);
+    setId(2);
 
     resolveSecond("user2");
     await secondPromise;
-    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
+    expect(container.querySelector("#result")?.textContent).toBe("2:user2");
 
     resolveFirst("user1");
     await firstPromise;
     // Stale result must not overwrite the current render
-    expect(container.querySelector("#result")!.textContent).toBe("2:user2");
+    expect(container.querySelector("#result")?.textContent).toBe("2:user2");
   });
 });

--- a/src/__tests__/use-state.test.ts
+++ b/src/__tests__/use-state.test.ts
@@ -19,7 +19,7 @@ describe("$state", () => {
   it("accepts a lazy initializer function called only once", () => {
     const init = jest.fn(() => 42);
     let capturedValue: number | null = null;
-    let setValue: ((v: number) => void) | null = null;
+    let setValue: (v: number) => void = () => {};
 
     function* Comp() {
       const [v, sv] = yield* $state(init);
@@ -33,14 +33,14 @@ describe("$state", () => {
     expect(capturedValue).toBe(42);
 
     // Re-render should not call the initializer again
-    setValue!(99);
+    setValue(99);
     expect(init).toHaveBeenCalledTimes(1);
     expect(capturedValue).toBe(99);
   });
 
   it("accepts a functional updater that receives the previous state", () => {
     const values: number[] = [];
-    let setValue: ((v: number | ((prev: number) => number)) => void) | null = null;
+    let setValue: (v: number | ((prev: number) => number)) => void = () => {};
 
     function* Comp() {
       const [v, sv] = yield* $state(0);
@@ -52,10 +52,10 @@ describe("$state", () => {
     render(createElement(Comp as never, {}), container);
     expect(values).toEqual([0]);
 
-    setValue!((prev) => prev + 5);
+    setValue((prev) => prev + 5);
     expect(values).toEqual([0, 5]);
 
-    setValue!((prev) => prev * 2);
+    setValue((prev) => prev * 2);
     expect(values).toEqual([0, 5, 10]);
   });
 });

--- a/src/hooks/$render.ts
+++ b/src/hooks/$render.ts
@@ -170,7 +170,7 @@ export function _processRender(descriptor: { [key: string]: unknown }, ctx: Hook
       status: "waiting",
       deps,
       value: undefined,
-      resumeCallback: null!,
+      resumeCallback: null as unknown as (value: unknown) => void,
     };
     hookStates[hookIndex] = newSlot;
     newSlot.resumeCallback = (value: unknown): void => {

--- a/src/render/dispatch.ts
+++ b/src/render/dispatch.ts
@@ -27,6 +27,7 @@ import type { RenderContext } from "./types";
  * @param domEvent    - The lowercase DOM event name (e.g. `"click"`).
  * @param rctx        - The render context for this root.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: capture+bubble dispatch with propagation checks
 export function dispatchDelegatedEvent(
   nativeEvent: Event,
   rootElement: Element,
@@ -60,7 +61,7 @@ export function dispatchDelegatedEvent(
   try {
     // 4. Capture phase (root → target): walk path from outermost to innermost.
     for (let i = path.length - 1; i >= 0; i--) {
-      const el = path[i]!;
+      const el = path[i] as Element;
       const entry = getHandlers(el, domEvent);
       if (entry?.capture) {
         syntheticEvent._setCurrentTarget(el);
@@ -77,7 +78,7 @@ export function dispatchDelegatedEvent(
     // 5. Bubble phase (target → root): walk path from innermost to outermost.
     if (!syntheticEvent._isPropagationStopped()) {
       for (let i = 0; i < path.length; i++) {
-        const el = path[i]!;
+        const el = path[i] as Element;
         const entry = getHandlers(el, domEvent);
         if (entry?.bubble) {
           syntheticEvent._setCurrentTarget(el);

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -66,6 +66,7 @@ import type { GenInstance, HookState, RenderContext, Slot } from "./types";
  * @returns The real DOM node. For generator components and Providers, returns
  *   a `DocumentFragment` containing the output nodes + endMarker.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: VNode type dispatch with many branches
 export function buildNode(child: Child): Node {
   if (child == null || typeof child === "boolean") {
     return document.createTextNode("");
@@ -296,6 +297,7 @@ export function mountGeneratorComponent(
    * @param mounted - `false` on initial mount, `true` on rerenders. Controls
    *   whether nodes are stored for fragment assembly or reconciled in place.
    */
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: generator lifecycle with retry, defer, and reconciliation
   function executeRerender(initiallyMounted: boolean): Promise<void> {
     let mounted = initiallyMounted;
     // eslint-disable-next-line no-constant-condition

--- a/src/render/patch-queue.ts
+++ b/src/render/patch-queue.ts
@@ -39,7 +39,7 @@ export function commitPatch(): void {
   if (ctx.ops === null) return;
   const ops = ctx.ops;
   ctx.ops = null;
-  for (let i = 0; i < ops.length; i++) ops[i]!();
+  for (let i = 0; i < ops.length; i++) ops[i]?.();
 }
 
 /** Returns `true` while a patch is being collected. */

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -46,7 +46,7 @@ function _registerEvent(
     addNonDelegatedListener(el, domEvent, handler);
   } else {
     registerHandler(el, domEvent, handler, isCapture);
-    _requireActiveCtx().delegationRoot!.ensureListening(domEvent);
+    _requireActiveCtx().delegationRoot?.ensureListening(domEvent);
   }
 }
 
@@ -95,6 +95,7 @@ function _unregisterEvent(el: HTMLElement, propKey: string): void {
  * @param el    - The freshly-created DOM element.
  * @param props - The VNode's props object.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: prop type dispatch with many branches
 export function applyProps(el: HTMLElement, props: Record<string, unknown>): void {
   for (const [key, value] of Object.entries(props)) {
     if (key.startsWith("$")) continue;
@@ -166,6 +167,7 @@ export function applyProps(el: HTMLElement, props: Record<string, unknown>): voi
  * @param prevProps - The props from the previous render (stored in `Slot.props`).
  * @param nextProps - The props from the new VNode.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: prop type dispatch with many branches
 export function updateProps(
   el: HTMLElement,
   prevProps: Record<string, unknown>,

--- a/src/render/reconciler.ts
+++ b/src/render/reconciler.ts
@@ -174,6 +174,7 @@ function collectSlotDOMNodes(slot: Slot): Node[] {
  * 4. Unmount any unused previous slots.
  * 5. Reorder DOM nodes so they appear in the new child order.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: keyed reconciliation with reuse/reorder/remove phases
 function* reconcileKeyedSlotsGen(
   parent: HTMLElement | Node,
   prevSlots: Slot[],
@@ -185,7 +186,7 @@ function* reconcileKeyedSlotsGen(
   const prevKeyMap = new Map<string | number, number>();
   const nonKeyedPrevIndices: number[] = [];
   for (let i = 0; i < prevSlots.length; i++) {
-    const key = prevSlots[i]!.props["$key"] as string | undefined;
+    const key = prevSlots[i]?.props["$key"] as string | undefined;
     if (key !== undefined) {
       prevKeyMap.set(key, i);
     } else {
@@ -199,14 +200,15 @@ function* reconcileKeyedSlotsGen(
   let nonKeyedCursor = 0;
 
   for (let i = 0; i < flatNext.length; i++) {
-    const nextChild = flatNext[i]!;
+    const nextChild = flatNext[i] as Child;
     const nextKey = getChildKey(nextChild);
 
     let matchedPrevSlot: Slot | null = null;
 
     if (nextKey !== undefined && prevKeyMap.has(nextKey)) {
       // Keyed match
-      const prevIndex = prevKeyMap.get(nextKey)!;
+      // SAFETY: guarded by prevKeyMap.has(nextKey) above
+      const prevIndex = prevKeyMap.get(nextKey) as number;
       if (!usedPrevIndices.has(prevIndex)) {
         matchedPrevSlot = prevSlots[prevIndex] ?? null;
         usedPrevIndices.add(prevIndex);
@@ -214,7 +216,7 @@ function* reconcileKeyedSlotsGen(
     } else if (nextKey === undefined) {
       // Non-keyed: match positionally against non-keyed prev slots
       while (nonKeyedCursor < nonKeyedPrevIndices.length) {
-        const prevIndex = nonKeyedPrevIndices[nonKeyedCursor++]!;
+        const prevIndex = nonKeyedPrevIndices[nonKeyedCursor++] as number;
         if (!usedPrevIndices.has(prevIndex)) {
           matchedPrevSlot = prevSlots[prevIndex] ?? null;
           usedPrevIndices.add(prevIndex);
@@ -245,8 +247,9 @@ function* reconcileKeyedSlotsGen(
   // Unmount unused prev slots
   for (let i = 0; i < prevSlots.length; i++) {
     if (!usedPrevIndices.has(i)) {
-      unmountSlot(prevSlots[i]!);
-      removeSlotNodes(parent, prevSlots[i]!);
+      // SAFETY: i is bounded by prevSlots.length
+      unmountSlot(prevSlots[i] as Slot);
+      removeSlotNodes(parent, prevSlots[i] as Slot);
     }
   }
 
@@ -257,7 +260,7 @@ function* reconcileKeyedSlotsGen(
     if (freshNode) {
       domInsertBefore(parent, freshNode, anchor);
     } else {
-      for (const n of collectSlotDOMNodes(nextSlots[i]!)) {
+      for (const n of collectSlotDOMNodes(nextSlots[i] as Slot)) {
         domInsertBefore(parent, n, anchor);
       }
     }
@@ -275,6 +278,7 @@ function* reconcileKeyedSlotsGen(
  * In sync mode, the scheduler (or `runToCompletion`) drains the generator
  * immediately — identical to the non-generator behavior.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: positional diffing with keyed fallback
 export function* reconcileSlotsGen(
   parent: HTMLElement | Node,
   prevSlots: Slot[],
@@ -325,7 +329,8 @@ export function* reconcileSlotsGen(
 
   // Remove any extra old DOM nodes (the new list is shorter).
   for (let i = flatNext.length; i < prevSlots.length; i++) {
-    const old = prevSlots[i]!;
+    // SAFETY: i is bounded by prevSlots.length
+    const old = prevSlots[i] as Slot;
     unmountSlot(old);
     removeSlotNodes(parent, old);
   }
@@ -409,6 +414,7 @@ export function reconcileSlots(
  *     freshly-mounted generator components / Providers).
  *   - `replaced` — true if the DOM node changed and needs to be swapped in by the caller.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: VNode type dispatch with many match/replace branches
 function* reconcileOneGen(
   prevSlot: Slot | null,
   nextChild: Child,
@@ -532,6 +538,7 @@ function* reconcileOneGen(
  * Handles same-type updates (props diff, context propagation, live-only skip),
  * Provider in-place reconciliation, generator rerenders, and fresh mounts.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: component reconciliation with provider/generator/plain paths
 function* reconcileFunctionComponent(
   prevSlot: Slot | null,
   vnode: VNode,

--- a/src/render/scheduler.ts
+++ b/src/render/scheduler.ts
@@ -183,10 +183,12 @@ function _runLoop(rctx: RenderContext): void {
       beginPatch();
     }
 
-    const set = rctx.pendingUpdates.get(priority)!;
+    // SAFETY: priority came from _getLowestPriority or activePriority — entry always exists
+    const set = rctx.pendingUpdates.get(priority) as Set<GenInstance>;
 
     while (set.size > 0) {
-      const instance = set.values().next().value!;
+      // SAFETY: set.size > 0 guarantees .next().value is defined
+      const instance = set.values().next().value as GenInstance;
       set.delete(instance);
 
       instance._executeRerender();
@@ -227,11 +229,13 @@ function _handlePreemption(rctx: RenderContext, currentPriority: number): void {
     const savedOps = savePatchOps();
 
     // Process the higher-priority level fully.
-    const set = rctx.pendingUpdates.get(hp)!;
+    // SAFETY: hp came from _getHigherPriorityThan which checks set.size > 0
+    const set = rctx.pendingUpdates.get(hp) as Set<GenInstance>;
     beginPatch();
 
     while (set.size > 0) {
-      const inst = set.values().next().value!;
+      // SAFETY: set.size > 0 guarantees .next().value is defined
+      const inst = set.values().next().value as GenInstance;
       set.delete(inst);
       inst._executeRerender();
 

--- a/src/render/state.ts
+++ b/src/render/state.ts
@@ -53,7 +53,10 @@ export function _getActiveCtx(): RenderContext | null {
  * @internal
  */
 export function _requireActiveCtx(): RenderContext {
-  return _activeCtx!;
+  if (!_activeCtx) {
+    throw new Error("No active render context — _requireActiveCtx called outside a render pass");
+  }
+  return _activeCtx;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes all ~497 Biome lint warnings and updates the `lint` script to use `--error-on-warnings`, so future warnings fail CI instead of passing silently.

## Changes

- **`package.json`**: Updated `lint` script to `biome check --error-on-warnings .`
- **Source files** (`src/render/state.ts`, `dispatch.ts`, `scheduler.ts`, `reconciler.ts`, `props.ts`, `mount.ts`, `patch-queue.ts`, `src/hooks/$render.ts`):
  - Replaced `!` non-null assertions with runtime guards, `as` type casts, or explicit null checks
  - Added `biome-ignore lint/complexity/noExcessiveCognitiveComplexity` suppressions on 9 inherently complex functions (dispatch, reconciler, prop application)
- **Test files** (17 files):
  - Replaced `setter?.(args)` pattern (which caused TS2349 due to closure narrowing) with no-op initialization (`= () => {}`) and direct calls
  - Replaced nullable object patterns (`| null = null`) with typed defaults where null check wasn't meaningful
  - Converted `querySelector()!` to `as HTMLElement` casts
- **`examples/src/main.tsx`**: Fixed `querySelector` non-null assertion
- **`playwright-tests/visual.test.ts`**: Fixed `querySelector` non-null assertions

## Verification

- `npm run lint` (with `--error-on-warnings`) — 0 warnings
- `npm run build` — passes
- `npm test` — 19 suites, 216 tests pass
- `npm run test:visual` — 57 tests pass

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)