### PR TITLE
refactor: introduce DependencyList type alias for hook deps

### DIFF
--- a/src/hooks/$effect.ts
+++ b/src/hooks/$effect.ts
@@ -1,4 +1,4 @@
-import { $EFFECT, depsChanged, type HookContext } from "./symbols";
+import { $EFFECT, type DependencyList, depsChanged, type HookContext } from "./symbols";
 
 /**
  * Side-effect hook for generator components.
@@ -31,7 +31,7 @@ import { $EFFECT, depsChanged, type HookContext } from "./symbols";
  */
 export function* $effect(
   fn: (signal: AbortSignal) => (() => void) | undefined,
-  deps: unknown[],
+  deps: DependencyList,
 ): Generator<unknown, void, unknown> {
   yield { type: $EFFECT, fn, deps };
 }
@@ -40,7 +40,7 @@ export function* $effect(
 export function _processEffect(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, cleanupFns, pendingEffects } = ctx;
   const fn = descriptor["fn"] as (signal: AbortSignal) => (() => void) | undefined;
-  const deps = descriptor["deps"] as unknown[];
+  const deps = descriptor["deps"] as DependencyList;
   const existing = hookStates[hookIndex];
 
   if (existing === undefined || existing.kind !== "effect" || depsChanged(existing.deps, deps)) {

--- a/src/hooks/$memo.ts
+++ b/src/hooks/$memo.ts
@@ -1,4 +1,4 @@
-import { $MEMO, depsChanged, type HookContext } from "./symbols";
+import { $MEMO, type DependencyList, depsChanged, type HookContext } from "./symbols";
 
 /**
  * Memoized value hook for generator components.
@@ -25,7 +25,7 @@ export function $memo<T, Deps extends [unknown, ...unknown[]]>(
 ): Generator<unknown, T, unknown>;
 export function* $memo<T>(
   fn: (...args: unknown[]) => T,
-  deps: unknown[],
+  deps: DependencyList,
 ): Generator<unknown, T, unknown> {
   const value = yield { type: $MEMO, fn, deps };
   return value as T;
@@ -35,7 +35,7 @@ export function* $memo<T>(
 export function _processMemo(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates } = ctx;
   const fn = descriptor["fn"] as (...args: unknown[]) => unknown;
-  const deps = descriptor["deps"] as unknown[];
+  const deps = descriptor["deps"] as DependencyList;
   const existing = hookStates[hookIndex];
   if (existing === undefined || existing.kind !== "memo" || depsChanged(existing.deps, deps)) {
     const newState = { kind: "memo" as const, value: fn(...deps), deps };

--- a/src/hooks/$render.ts
+++ b/src/hooks/$render.ts
@@ -1,6 +1,6 @@
 import { $context, createContext } from "../context";
 import { type Child, createElement } from "../jsx";
-import { $RENDER, depsChanged, type HookContext } from "./symbols";
+import { $RENDER, type DependencyList, depsChanged, type HookContext } from "./symbols";
 
 /**
  * Inline render factory passed to `$render` (Variant 2).
@@ -19,7 +19,7 @@ export type UseRenderFn<T> = (props: { resume: (value: T) => void }) => Child;
 export type UseRenderState<T> = {
   kind: "render";
   status: "waiting" | "resolved";
-  deps: unknown[];
+  deps: DependencyList;
   value: T | undefined;
   /** Stable callback reference – created once per deps change and reused. */
   resumeCallback: (value: T) => void;
@@ -86,10 +86,13 @@ const _resumeCtx = createContext<((value: unknown) => void) | null>(null);
  * Must be called with `yield*` inside a generator component.
  */
 export function $render<T>(child: Child): Generator<unknown, T, unknown>;
-export function $render<T>(fn: UseRenderFn<T>, deps: unknown[]): Generator<unknown, T, unknown>;
+export function $render<T>(
+  fn: UseRenderFn<T>,
+  deps: DependencyList,
+): Generator<unknown, T, unknown>;
 export function* $render<T>(
   fnOrChild: Child | UseRenderFn<T>,
-  deps?: unknown[],
+  deps?: DependencyList,
 ): Generator<unknown, T, unknown> {
   // Request a persistent slot + stable resumeCallback from the renderer.
   const effectiveDeps = deps ?? [];
@@ -160,7 +163,7 @@ export function* $resume<T>(): Generator<unknown, (value: T) => void, unknown> {
 /** @internal */
 export function _processRender(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, resume } = ctx;
-  const deps = descriptor["deps"] as unknown[];
+  const deps = descriptor["deps"] as DependencyList;
   const existing = hookStates[hookIndex];
   let slot: UseRenderState<unknown>;
 

--- a/src/hooks/$resolve.ts
+++ b/src/hooks/$resolve.ts
@@ -1,5 +1,11 @@
 import type { AnyComponentFn, Child } from "../jsx";
-import { $RESOLVE, $RESOLVE_RAW, depsChanged, type HookContext } from "./symbols";
+import {
+  $RESOLVE,
+  $RESOLVE_RAW,
+  type DependencyList,
+  depsChanged,
+  type HookContext,
+} from "./symbols";
 
 /**
  * A value that can be rendered: a VNode-like child, a component function,
@@ -91,7 +97,7 @@ export function* $resolveRaw<T, E = unknown>(
  */
 export function* $resolve<T>(
   options: UseResolveOptions<T>,
-  deps: unknown[],
+  deps: DependencyList,
 ): Generator<unknown, T, unknown> {
   // $RESOLVE handles both memoization and AbortController lifecycle.
   // The renderer creates a new AbortController on first call or when deps change,
@@ -160,7 +166,7 @@ export function _processResolveRaw(
 export function _processResolve(descriptor: { [key: string]: unknown }, ctx: HookContext): unknown {
   const { hookIndex, hookStates, cleanupFns } = ctx;
   const fn = descriptor["fn"] as (signal: AbortSignal) => Promise<unknown>;
-  const deps = descriptor["deps"] as unknown[];
+  const deps = descriptor["deps"] as DependencyList;
   const existing = hookStates[hookIndex];
 
   if (existing === undefined || existing.kind !== "resolve" || depsChanged(existing.deps, deps)) {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -43,6 +43,7 @@ export {
   $RESOLVE_RAW,
   $STATE,
   $UI_PATCH,
+  type DependencyList,
   depsChanged,
   type HookContext,
 } from "./symbols";

--- a/src/hooks/symbols.ts
+++ b/src/hooks/symbols.ts
@@ -39,8 +39,16 @@ export const $RENDER = Symbol("$render");
 /** @internal */
 export const $UI_PATCH = Symbol("$uiPatch");
 
+/**
+ * Hook dependency list type, aligned with React 19's `DependencyList`.
+ *
+ * A read-only array of values compared via shallow `Object.is` by the
+ * renderer. Hooks re-run only when at least one element changes.
+ */
+export type DependencyList = readonly unknown[];
+
 /** Returns true when the dependency arrays differ (shallow Object.is comparison). */
-export function depsChanged(prev: unknown[] | undefined, next: unknown[]): boolean {
+export function depsChanged(prev: DependencyList | undefined, next: DependencyList): boolean {
   if (prev === undefined) return true;
   if (prev.length !== next.length) return true;
   for (let i = 0; i < prev.length; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export type { Context } from "./context";
 export { $context, createContext } from "./context";
 export type { SEvent, SyntheticEvent } from "./events";
 export type {
+  DependencyList,
   RefObject,
   Renderable,
   ResolveRawResult,

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -1,5 +1,6 @@
 import type { Context, UseContextState } from "../context";
 import type { UseRenderState } from "../hooks/$render";
+import type { DependencyList } from "../hooks/symbols";
 import type { Child, GeneratorComponentFn, VNode } from "../jsx";
 import type { DelegationRoot } from "./delegation";
 
@@ -79,13 +80,13 @@ export interface IdHookState {
 export interface MemoHookState {
   kind: "memo";
   value: unknown;
-  deps: unknown[];
+  deps: DependencyList;
 }
 
 /** Persistent state for a `$effect` hook. */
 export interface EffectHookState {
   kind: "effect";
-  deps: unknown[];
+  deps: DependencyList;
   cleanup: (() => void) | undefined;
   controller: AbortController;
 }
@@ -99,7 +100,7 @@ export type ResolveRawHookState =
 /** Persistent state for a `$resolve` hook. */
 export interface ResolveHookState {
   kind: "resolve";
-  deps: unknown[];
+  deps: DependencyList;
   promise: Promise<unknown>;
   controller: AbortController;
 }


### PR DESCRIPTION
## Summary

Adds a `DependencyList = readonly unknown[]` type alias aligned with React 19's `DependencyList` convention, replacing inline `unknown[]` across all hook signatures and state interfaces.

## Changes

- **`src/hooks/symbols.ts`**: Added `DependencyList` type alias and updated `depsChanged` to use it
- **`src/hooks/$effect.ts`**, **`$memo.ts`**, **`$resolve.ts`**, **`$render.ts`**: Updated deps parameters and internal casts to use `DependencyList`
- **`src/render/types.ts`**: Updated `MemoHookState`, `EffectHookState`, `ResolveHookState` deps fields
- **`src/hooks/index.ts`**, **`src/index.ts`**: Exported `DependencyList` from the public API

Note: `$memo`'s typed overload (`Deps extends [unknown, ...unknown[]]`) is unchanged — only the implementation signature and state type use `DependencyList`.

## Verification

- `npm run lint` — passes (0 warnings)
- `npm run build` — passes
- `npm test` — 19 suites, 216 tests pass
- `npm run test:visual` — 57 tests pass

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)