### PR TITLE
Add CI automation workflows

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Resolve conflicts
         if: steps.find-conflicts.outputs.conflicted != ''
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -12,6 +12,7 @@ jobs:
   resolve-conflicts:
     name: Resolve PR conflicts
     runs-on: ubuntu-latest
+    if: github.event.sender.login == 'jEnbuska'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -1,0 +1,126 @@
+name: Auto-resolve merge conflicts
+
+on:
+  push:
+    branches: [dev]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  resolve-conflicts:
+    name: Resolve PR conflicts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find conflicted PRs
+        id: find-conflicts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get all open PRs targeting dev
+          prs=$(gh pr list --base dev --state open --json number,headRefName --jq '.[] | "\(.number) \(.headRefName)"')
+
+          if [ -z "$prs" ]; then
+            echo "No open PRs targeting dev"
+            echo "conflicted=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch origin dev
+
+          conflicted=""
+          while IFS=' ' read -r pr_number branch; do
+            git fetch origin "$branch"
+            # Test merge without committing
+            if ! git merge-tree --write-tree origin/dev "origin/$branch" > /dev/null 2>&1; then
+              conflicted="$conflicted $pr_number:$branch"
+            fi
+          done <<< "$prs"
+
+          echo "conflicted=$conflicted" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        if: steps.find-conflicts.outputs.conflicted != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Claude Code CLI
+        if: steps.find-conflicts.outputs.conflicted != ''
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Resolve conflicts
+        if: steps.find-conflicts.outputs.conflicted != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          for entry in ${{ steps.find-conflicts.outputs.conflicted }}; do
+            pr_number="${entry%%:*}"
+            branch="${entry#*:}"
+
+            echo "=== Resolving conflicts for PR #$pr_number ($branch) ==="
+
+            # Start from a clean state
+            git checkout "origin/$branch"
+            git checkout -B "$branch"
+
+            # Attempt merge — will fail with conflicts
+            if git merge origin/dev --no-edit 2>/dev/null; then
+              echo "PR #$pr_number: merged cleanly (race condition — conflict already resolved)"
+              git push origin "$branch"
+              continue
+            fi
+
+            # Get list of conflicted files for the prompt
+            conflicted_files=$(git diff --name-only --diff-filter=U)
+            echo "Conflicted files: $conflicted_files"
+
+            # Use Claude to resolve conflicts
+            claude -p \
+              "There are git merge conflicts after merging dev into branch '$branch'. The conflicted files are: $conflicted_files. For each conflicted file: 1) Read the file to see the conflict markers. 2) Understand the intent of both sides (ours = the PR branch, theirs = dev). 3) Resolve the conflicts by keeping both changes where possible. 4) Write the resolved file. 5) Run 'git add <file>' on each resolved file. Do NOT run 'git commit'. Only resolve and stage." \
+              --dangerously-skip-permissions \
+              --allowedTools "Bash(git diff*)" "Bash(git add*)" "Bash(git status*)" "Read" "Edit" "Write" "Glob" "Grep" \
+              --max-turns 30 \
+              --model sonnet \
+              --output-format text \
+              2>&1 || true
+
+            # Check if all conflicts are resolved
+            remaining=$(git diff --name-only --diff-filter=U)
+            if [ -n "$remaining" ]; then
+              echo "PR #$pr_number: could not resolve all conflicts"
+              body=$(printf '%s\n\n%s\n\n```\n%s\n```\n\n%s' \
+                '## Auto-merge conflict resolution failed' \
+                'After merging `dev` into this branch, some conflicts could not be resolved automatically:' \
+                "$remaining" \
+                'Please resolve these conflicts manually.')
+              gh pr comment "$pr_number" --body "$body"
+              git merge --abort
+              continue
+            fi
+
+            # Commit and push
+            git commit --no-edit
+            git push origin "$branch"
+
+            body=$(printf '%s\n\n%s\n\n%s\n\n```\n%s\n```\n\n%s' \
+              '## Merge conflicts auto-resolved' \
+              'Merged `dev` into this branch and resolved conflicts automatically.' \
+              '**Resolved files:**' \
+              "$conflicted_files" \
+              'Please review the merge commit to verify the resolution is correct.')
+            gh pr comment "$pr_number" --body "$body"
+
+            echo "PR #$pr_number: conflicts resolved and pushed"
+          done

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -1,0 +1,35 @@
+name: Close linked issues on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [dev, main]
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    name: Close linked issues
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Close referenced issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Extract issue numbers from Closes #N, Fixes #N, Resolves #N (case-insensitive)
+          issues=$(echo "$PR_BODY" | grep -ioP '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\K\d+' | sort -u)
+
+          if [ -z "$issues" ]; then
+            echo "No linked issues found in PR #$PR_NUMBER body"
+            exit 0
+          fi
+
+          for issue in $issues; do
+            echo "Closing issue #$issue (linked from PR #$PR_NUMBER)"
+            gh issue close "$issue" --repo "$GITHUB_REPOSITORY" --comment "Closed by PR #$PR_NUMBER" || echo "Warning: could not close issue #$issue"
+          done

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -1,0 +1,24 @@
+name: Require issue link
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+    branches: [dev, main]
+
+jobs:
+  check-issue-link:
+    name: PR links an issue
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check PR body for issue reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if echo "$PR_BODY" | grep -iqP '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+'; then
+            echo "PR #$PR_NUMBER links to an issue"
+          else
+            echo "::error::PR #$PR_NUMBER does not contain a 'Closes #N', 'Fixes #N', or 'Resolves #N' reference. Every PR must link to a GitHub issue."
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ yielderact is a minimal JSX UI library using JavaScript generator functions.
 - **`ci.yml`** — Runs on push to `dev`/`main` and all PRs. Steps: dead code check (`knip`), lint, test, build, then visual tests (Playwright).
 - **`auto-resolve-conflicts.yml`** — Runs on push to `dev`. Finds open PRs targeting `dev` with merge conflicts and uses Claude Code CLI to resolve them automatically. Comments on the PR with the result. Requires `CLAUDE_CODE_OAUTH_TOKEN` secret.
 - **`close-issues.yml`** — Runs when a PR is merged to `dev` or `main`. Parses the PR body for `Closes #N` / `Fixes #N` / `Resolves #N` and closes the linked issues.
+- **`require-issue-link.yml`** — Runs on PR open/edit/sync targeting `dev` or `main`. Fails if the PR body does not contain a `Closes #N` / `Fixes #N` / `Resolves #N` reference.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ yielderact is a minimal JSX UI library using JavaScript generator functions.
 ### 4. CI Workflows
 
 - **`ci.yml`** — Runs on push to `dev`/`main` and all PRs. Steps: dead code check (`knip`), lint, test, build, then visual tests (Playwright).
-- **`auto-resolve-conflicts.yml`** — Runs on push to `dev`. Finds open PRs targeting `dev` with merge conflicts and uses Claude Code CLI to resolve them automatically. Comments on the PR with the result. Requires `ANTHROPIC_API_KEY` secret.
+- **`auto-resolve-conflicts.yml`** — Runs on push to `dev`. Finds open PRs targeting `dev` with merge conflicts and uses Claude Code CLI to resolve them automatically. Comments on the PR with the result. Requires `CLAUDE_CODE_OAUTH_TOKEN` secret.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ yielderact is a minimal JSX UI library using JavaScript generator functions.
 
 - **`ci.yml`** — Runs on push to `dev`/`main` and all PRs. Steps: dead code check (`knip`), lint, test, build, then visual tests (Playwright).
 - **`auto-resolve-conflicts.yml`** — Runs on push to `dev`. Finds open PRs targeting `dev` with merge conflicts and uses Claude Code CLI to resolve them automatically. Comments on the PR with the result. Requires `CLAUDE_CODE_OAUTH_TOKEN` secret.
+- **`close-issues.yml`** — Runs when a PR is merged to `dev` or `main`. Parses the PR body for `Closes #N` / `Fixes #N` / `Resolves #N` and closes the linked issues.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,11 @@ yielderact is a minimal JSX UI library using JavaScript generator functions.
   - **Verification:** Confirm all `npm` checks passed.
   - **CLAUDE.md Update:** State if this file was updated to reflect new changes.
 
+### 4. CI Workflows
+
+- **`ci.yml`** — Runs on push to `dev`/`main` and all PRs. Steps: dead code check (`knip`), lint, test, build, then visual tests (Playwright).
+- **`auto-resolve-conflicts.yml`** — Runs on push to `dev`. Finds open PRs targeting `dev` with merge conflicts and uses Claude Code CLI to resolve them automatically. Comments on the PR with the result. Requires `ANTHROPIC_API_KEY` secret.
+
 ---
 
 ## Technical Architecture


### PR DESCRIPTION
## Summary

Adds three GitHub Actions workflows for CI automation: auto-resolve merge conflicts on open PRs when dev is updated, auto-close linked issues on PR merge, and a required check ensuring every PR references an issue.

## Changes

- **`auto-resolve-conflicts.yml`**: On push to `dev` by jEnbuska, finds open PRs with merge conflicts and resolves them using Claude Code CLI. Comments on the PR with the result.
- **`close-issues.yml`**: On PR merge to `dev`/`main`, parses the PR body for `Closes #N` / `Fixes #N` / `Resolves #N` and closes linked issues.
- **`require-issue-link.yml`**: Blocks PRs targeting `dev`/`main` that don't reference an issue with a closing keyword.
- **CLAUDE.md**: Documented all new workflows in the CI Workflows section.

Closes #98

## Verification

- `npm run knip` — clean
- `npm run lint:fix` — clean
- `npm run build` — pass
- CLAUDE.md updated ✓