### PR TITLE
fix: prevent zombie rerender crash on useResolve unmount

### DIFF
--- a/playwright-tests/data-fetcher.test.ts
+++ b/playwright-tests/data-fetcher.test.ts
@@ -278,6 +278,73 @@ test("useResolveRaw: deps change during pending", async ({ page, setupPage }) =>
   await expect(page.locator("#data")).toHaveText("Item 2", { timeout: 3000 });
 });
 
+test("switching tabs while useResolve is loading does not freeze", async ({ page, setupPage }) => {
+  await setupPage();
+
+  await page.evaluate(() => {
+    const { createElement, render, useState, useResolve } = (
+      window as unknown as { Yielderact: typeof import("../src/index") }
+    ).Yielderact;
+
+    const win = window as unknown as Record<string, unknown>;
+
+    function* Inner() {
+      const data = yield* useResolve(
+        {
+          fn: (_signal) =>
+            new Promise<string>((resolve) => {
+              setTimeout(() => resolve("Fetched OK"), 200);
+            }),
+          loading: createElement("span", { id: "loading" }, "Loading..."),
+          error: createElement("span", { id: "error" }, "Error"),
+        },
+        [],
+      );
+      return createElement("span", { id: "data" }, data);
+    }
+
+    function* App() {
+      const [tab, setTab] = yield* useState<"data" | "other">("data");
+      win.setTab = setTab;
+      if (tab === "data") {
+        return createElement(
+          "div",
+          {},
+          createElement("span", { id: "tab-label" }, "Data Tab"),
+          createElement(Inner as never, {}),
+        );
+      }
+      return createElement("span", { id: "other-tab" }, "Other Tab");
+    }
+
+    render(createElement(App as never, {}), document.getElementById("root") as HTMLElement);
+  });
+
+  // Verify Inner is mounted and loading
+  await expect(page.locator("#loading")).toHaveText("Loading...");
+
+  // Switch away from the data tab WHILE the fetch is pending
+  await page.evaluate(() => {
+    (window as unknown as Record<string, (v: string) => void>).setTab("other");
+  });
+
+  // Other tab should render — this proves the UI is not frozen
+  await expect(page.locator("#other-tab")).toHaveText("Other Tab", { timeout: 3000 });
+
+  // Wait a bit for the promise to resolve in the background
+  await page.waitForTimeout(500);
+
+  // UI should still be responsive
+  await expect(page.locator("#other-tab")).toHaveText("Other Tab");
+
+  // Switch back — should show fresh data (new mount)
+  await page.evaluate(() => {
+    (window as unknown as Record<string, (v: string) => void>).setTab("data");
+  });
+
+  await expect(page.locator("#data")).toHaveText("Fetched OK", { timeout: 3000 });
+});
+
 test("useResolveRaw: rapid deps changes — only latest resolves", async ({ page, setupPage }) => {
   await setupPage();
 

--- a/src/__tests__/use-resolve.test.ts
+++ b/src/__tests__/use-resolve.test.ts
@@ -1,4 +1,5 @@
 import { useMemo, useResolve, useResolveRaw, useState } from "../hooks";
+import type { Child } from "../jsx";
 import { createElement } from "../jsx";
 import { render } from "../render";
 
@@ -428,5 +429,140 @@ describe("render – generator components with useResolveRaw", () => {
     await firstPromise;
     // Stale result must not overwrite the current render
     expect(container.querySelector("#result")?.textContent).toBe("2:user2");
+  });
+});
+
+describe("useResolve / useResolveRaw – unmount during pending (zombie rerender)", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("does not crash when component with useResolve is unmounted while loading", async () => {
+    let resolvePromise!: (data: string) => void;
+    const promise = new Promise<string>((res) => {
+      resolvePromise = res;
+    });
+    let setShow: (v: boolean) => void = () => {};
+
+    function* Inner() {
+      const data = yield* useResolve(
+        {
+          fn: (_signal) => promise,
+          // Use <div> for loading — different tag from the resolved <span>,
+          // so the zombie rerender forces a type-mismatch replace path that
+          // crashes when endMarker.parentNode is null.
+          loading: createElement("div", { id: "loading" }, "Loading…"),
+          error: createElement("div", { id: "error" }, "Error"),
+        },
+        [],
+      );
+      return createElement("span", { id: "data" }, data);
+    }
+
+    function* Outer() {
+      const [show, ss] = yield* useState(true);
+      setShow = ss;
+      return show
+        ? (createElement(Inner as never, {}) as Child)
+        : createElement("span", { id: "empty" }, "gone");
+    }
+
+    render(createElement(Outer as never, {}), container);
+    expect(container.querySelector("#loading")).not.toBeNull();
+
+    // Unmount Inner while the promise is still pending
+    setShow(false);
+    expect(container.querySelector("#empty")).not.toBeNull();
+
+    // Resolve the promise AFTER unmount — must not crash
+    resolvePromise("Hello");
+    await promise;
+
+    // UI should still show "gone", not crash or freeze
+    expect(container.querySelector("#empty")?.textContent).toBe("gone");
+  });
+
+  it("does not crash when useResolveRaw promise rejects after unmount", async () => {
+    let rejectPromise!: (reason: unknown) => void;
+    const promise = new Promise<string>((_res, rej) => {
+      rejectPromise = rej;
+    });
+    let setShow: (v: boolean) => void = () => {};
+
+    function* Inner() {
+      const p = yield* useMemo(() => promise, []);
+      const { data, loading, error } = yield* useResolveRaw<string, Error>(p);
+      // Use <div> for loading/error, <span> for data — different tags
+      // trigger the type-mismatch replace path in the zombie rerender.
+      if (loading) return createElement("div", { id: "loading" }, "Loading…");
+      if (error) return createElement("div", { id: "error" }, error.message);
+      return createElement("span", { id: "data" }, data);
+    }
+
+    function* Outer() {
+      const [show, ss] = yield* useState(true);
+      setShow = ss;
+      return show
+        ? (createElement(Inner as never, {}) as Child)
+        : createElement("span", { id: "empty" }, "gone");
+    }
+
+    render(createElement(Outer as never, {}), container);
+    expect(container.querySelector("#loading")).not.toBeNull();
+
+    // Unmount Inner
+    setShow(false);
+    expect(container.querySelector("#empty")).not.toBeNull();
+
+    // Reject the promise AFTER unmount — must not crash
+    rejectPromise(new Error("network error"));
+    await promise.catch(() => {});
+
+    expect(container.querySelector("#empty")?.textContent).toBe("gone");
+  });
+
+  it("does not crash when component with useResolveRaw is unmounted while loading", async () => {
+    let resolvePromise!: (data: string) => void;
+    const promise = new Promise<string>((res) => {
+      resolvePromise = res;
+    });
+    let setShow: (v: boolean) => void = () => {};
+
+    function* Inner() {
+      const p = yield* useMemo(() => promise, []);
+      const { data, loading } = yield* useResolveRaw<string>(p);
+      // Use <div> for loading, <span> for data — different tags
+      // trigger the type-mismatch replace path in the zombie rerender.
+      if (loading) return createElement("div", { id: "loading" }, "Loading…");
+      return createElement("span", { id: "data" }, data);
+    }
+
+    function* Outer() {
+      const [show, ss] = yield* useState(true);
+      setShow = ss;
+      return show
+        ? (createElement(Inner as never, {}) as Child)
+        : createElement("span", { id: "empty" }, "gone");
+    }
+
+    render(createElement(Outer as never, {}), container);
+    expect(container.querySelector("#loading")).not.toBeNull();
+
+    // Unmount Inner
+    setShow(false);
+    expect(container.querySelector("#empty")).not.toBeNull();
+
+    // Resolve the promise AFTER unmount — must not crash
+    resolvePromise("Hello");
+    await promise;
+
+    expect(container.querySelector("#empty")?.textContent).toBe("gone");
   });
 });

--- a/src/render/hooks-runtime.ts
+++ b/src/render/hooks-runtime.ts
@@ -161,6 +161,11 @@ export function unmountSlot(slot: Slot): void {
     // localPatchRefCount is intentionally left as-is; the local patch commit()
     // checks pendingVNode === undefined and skips accordingly.
     slot.componentInstance.renderCtx.dirtyInstances.delete(slot.componentInstance);
+    // Remove from scheduler queue so pending async callbacks (useResolveRaw
+    // promise handlers) don't trigger a zombie rerender.
+    for (const [, set] of slot.componentInstance.renderCtx.pendingUpdates) {
+      set.delete(slot.componentInstance);
+    }
   }
   // Portal cleanup: release the ref-counted delegation root.
   if (slot.portalContainer) {

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -243,6 +243,7 @@ export function mountComponent(
    */
   function resume(): void {
     if (!instance.gen) return;
+    if (!instance.endMarker.parentNode) return;
     _setActiveCtx(rctx);
 
     // Restore context: inherited context + own $patch applied for children.
@@ -374,6 +375,11 @@ export function mountComponent(
 
       // A follow-up rerender may have been requested (e.g. from an effect or
       // an async callback that fired synchronously after resolve()).
+      // Guard against zombie rerenders: if the component was unmounted during
+      // this render cycle (e.g. by an effect), bail out.
+      if (mounted && !instance.endMarker.parentNode) {
+        return Promise.resolve();
+      }
       if (instance.pendingRerender) {
         instance.pendingRerender = false;
         continue;
@@ -412,6 +418,7 @@ export function mountComponent(
         instance.renderResolvers.push(resolve);
       });
     }
+    if (!instance.endMarker.parentNode) return Promise.resolve();
     _setActiveCtx(rctx);
     if (isPatchActive()) {
       // During an active patch (another component is rendering or a

--- a/src/render/patch.ts
+++ b/src/render/patch.ts
@@ -30,6 +30,7 @@ import type { ComponentInstance } from "./types";
 export function _flushPendingVNodes(instances: ComponentInstance[]): void {
   for (const inst of instances) {
     if (inst.pendingVNode === undefined) continue;
+    if (!inst.endMarker.parentNode) continue;
     const vnode = inst.pendingVNode;
     inst.pendingVNode = undefined;
     inst.renderCtx.dirtyInstances.delete(inst);


### PR DESCRIPTION
## Summary

- When a component using `useResolve`/`useResolveRaw` is unmounted while a promise is pending, the promise handler calls `rerender()` on the dead instance. This causes `reconcileSlots` to operate on a null parent (`endMarker.parentNode`), crashing with `TypeError: Cannot read properties of null` or corrupting state and freezing the UI.
- Added `endMarker.parentNode` zombie guards to `rerender()`, `resume()`, `executeRerender()`, and `_flushPendingVNodes()`. Also removes unmounted instances from the scheduler's `pendingUpdates` queue in `unmountSlot()`.

## Changes

- **`src/render/mount.ts`**: Added zombie guards to `rerender()` (line 421), `resume()` (line 246), and `executeRerender()` (line 378) — all bail out early when `endMarker.parentNode` is null.
- **`src/render/patch.ts`**: Added zombie guard in `_flushPendingVNodes()` loop to skip instances with null parent.
- **`src/render/hooks-runtime.ts`**: `unmountSlot()` now removes the instance from `renderCtx.pendingUpdates` to prevent queued async callbacks from triggering zombie rerenders.
- **`src/__tests__/use-resolve.test.ts`**: Added 3 unit tests reproducing the crash (unmount during useResolve loading, useResolveRaw reject after unmount, useResolveRaw resolve after unmount). Tests use different element types for loading vs resolved state to trigger the type-mismatch replace path that accesses the null parent.
- **`playwright-tests/data-fetcher.test.ts`**: Added visual test for switching tabs while useResolve is loading.

Closes #97

## Verification

- `npm run knip` ✅
- `npm run lint:fix` ✅
- `npm run build` ✅
- `npm run typecheck:examples` ✅
- `npm test` — 232/232 ✅
- `npm run test:visual` — 372/372 ✅

## CLAUDE.md Update

No changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)