### PR TITLE
ci: upgrade GitHub Actions from v4 to v5 for Node.js 24 support

### DIFF
--- a/.github/workflows/auto-resolve-conflicts.yml
+++ b/.github/workflows/auto-resolve-conflicts.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.find-conflicts.outputs.conflicted != ''
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -47,10 +47,10 @@ jobs:
         browser: [chromium, firefox, webkit]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -74,7 +74,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report-${{ matrix.browser }}
           path: examples/playwright-report/


### PR DESCRIPTION
## Summary

Upgrades `actions/checkout`, `actions/setup-node`, and `actions/upload-artifact` from v4 to v5 across all CI workflow files. This eliminates the Node.js 20 deprecation warning and prepares for the June 2nd, 2026 deadline when Node.js 24 becomes the default runner.

## Changes

- Bumped `actions/checkout` v4 → v5 in `ci.yml` and `auto-resolve-conflicts.yml`
- Bumped `actions/setup-node` v4 → v5 in `ci.yml` and `auto-resolve-conflicts.yml`
- Bumped `actions/upload-artifact` v4 → v5 in `ci.yml`

Closes #115

## Verification

All `npm` checks passed (knip, lint, build, typecheck:examples, unit tests, 330 visual tests).

## CLAUDE.md Update

No update needed — no workflow, script, or project structure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)