### PR TITLE
chore: update repository URLs after GitHub rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yract
+# Y'ract
 
 > JSX UI library focused on ease of use and easy to understanding the internals of the library itself
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="assets/wordmark.svg" alt="Y'ract" height="80" />
+</p>
+
 # Y'ract
 
 > JSX UI library focused on ease of use and easy to understanding the internals of the library itself

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <!-- yract square icon: ?* on purple rounded square -->
+  <rect width="256" height="256" rx="56" fill="#534AB7"/>
+  <text x="80" y="178" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="152" font-weight="600" fill="#EEEDFE">?</text>
+  <text x="170" y="140" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="72" font-weight="600" fill="#EF9F27">*</text>
+</svg>

--- a/assets/wordmark.svg
+++ b/assets/wordmark.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 520 160">
+  <!-- yract wordmark: ?r*act — adaptive light/dark -->
+  <style>
+    .q { fill: #534AB7 }
+    .t { fill: #1a1a1a }
+    .s { fill: #EF9F27 }
+    @media (prefers-color-scheme: dark) {
+      .q { fill: #AFA9EC }
+      .t { fill: #f0f0f0 }
+    }
+  </style>
+  <text x="60" y="105" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="96" font-weight="600" class="q">?</text>
+  <text x="118" y="105" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="96" font-weight="600" class="t">r</text>
+  <text x="176" y="105" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="96" font-weight="600" class="s">*</text>
+  <text x="234" y="105" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="96" font-weight="600" class="t">act</text>
+</svg>

--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>yract examples</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Y'ract examples</title>
     <style>
       *,
       *::before,

--- a/examples/public/favicon.svg
+++ b/examples/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <!-- yract square icon: ?* on purple rounded square -->
+  <rect width="256" height="256" rx="56" fill="#534AB7"/>
+  <text x="80" y="178" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="152" font-weight="600" fill="#EEEDFE">?</text>
+  <text x="170" y="140" font-family="ui-monospace, 'Cascadia Code', 'Fira Code', 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace" font-size="72" font-weight="600" fill="#EF9F27">*</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jEnbuska/yielderact.git"
+    "url": "git+https://github.com/jEnbuska/yract.git"
   },
   "keywords": [
     "jsx",
@@ -51,9 +51,9 @@
   "author": "jEnbuska",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jEnbuska/yielderact/issues"
+    "url": "https://github.com/jEnbuska/yract/issues"
   },
-  "homepage": "https://github.com/jEnbuska/yielderact#readme",
+  "homepage": "https://github.com/jEnbuska/yract#readme",
   "devDependencies": {
     "@biomejs/biome": "^2.4.6",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Summary

Completes the repository rename from `yielderact` to `yract`. Updates all repository URLs in `package.json`, adds branding assets (wordmark + favicon SVGs), and wires the favicon into the examples app.

## Changes

- Updated `repository.url`, `bugs.url`, and `homepage` in `package.json` to point to `github.com/jEnbuska/yract`
- Fixed README title to `Y'ract`
- Added `assets/` directory with adaptive light/dark wordmark SVG and favicon SVG
- Added wordmark image to README (above title)
- Wired favicon into `examples/index.html` via `examples/public/favicon.svg`
- Updated examples page title to `Y'ract examples`

Closes #118

## Verification

All checks passed: knip, lint, build, typecheck:examples, unit tests (232), visual tests (330).

## CLAUDE.md Update

No update needed — CLAUDE.md already references `yract`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)