### PR TITLE
docs: rewrite README for end-user focus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ If any step fails, fix and re-run the full sequence.
 
 - **Target branch:** `dev`
 - **Commit format:** [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `chore:`)
-- **Issue linking:** Every PR must link to a GitHub issue. Include `Closes #<number>` or `Fixes #<number>` in the PR body.
+- **Issue linking:** Every PR must link to a GitHub issue. Include `Closes #<number>` or `Fixes #<number>` in the PR body. If no issue exists for the work being done, create one first. A CI check enforces this — PRs without an issue reference will fail.
 
 ## Project structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to Y'ract
+
+## Development setup
+
+```bash
+git clone https://github.com/jEnbuska/yract.git
+cd yract
+npm ci
+npm ci --prefix examples
+```
+
+## Commands
+
+| Command | Description |
+| :--- | :--- |
+| `npm run build` | Compile TypeScript to `dist/` |
+| `npm run typecheck` | Type-check including test files (no emit) |
+| `npm run typecheck:examples` | Type-check example components |
+| `npm test` | Run Vitest unit tests (jsdom) |
+| `npm run test:visual` | Run Playwright visual tests |
+| `npm run knip` | Detect dead code and unused exports |
+| `npm run lint` | Check lint and formatting (Biome) |
+| `npm run lint:fix` | Auto-fix lint and formatting issues |
+| `npm run format` | Auto-fix formatting only |
+| `npm test -- <path>` | Run a specific test file |
+
+## Before opening a PR
+
+Run the full check sequence:
+
+```bash
+npm run knip          # dead code check
+npm run lint:fix      # lint and format
+npm run build         # type check and build
+npm run typecheck:examples  # type check examples
+npm test              # unit tests
+npm run test:visual   # visual tests
+```
+
+If any step fails, fix and re-run the full sequence.
+
+## Pull request guidelines
+
+- **Target branch:** `dev`
+- **Commit format:** [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `chore:`)
+- **Issue linking:** Every PR must link to a GitHub issue. Include `Closes #<number>` or `Fixes #<number>` in the PR body.
+
+## Project structure
+
+| Path | Description |
+| :--- | :--- |
+| `src/jsx.ts` | VNode types, `createElement`, `createPortal` |
+| `src/jsx-types.ts` | HTML/SVG attribute type definitions |
+| `src/jsx-runtime.ts` | Automatic JSX transform (`jsx`, `jsxs`, `jsxDEV`) |
+| `src/events.ts` | `SyntheticEvent` type and proxy-based event wrapper |
+| `src/context.ts` | `createContext`, `useContext`, context map helpers |
+| `src/index.ts` | Public API re-exports |
+| `src/render/` | Renderer: mount, reconciler, scheduler, patches, delegation |
+| `src/hooks/` | Hook implementations (`useState`, `useEffect`, etc.) |
+| `examples/` | Demo app with tabbed component examples |
+| `docs/` | API reference and design documentation |
+
+## JSX configuration
+
+The library build uses the classic `react` transform (`jsxFactory: "createElement"`). Consumers (including `examples/`) use `react-jsx` with `jsxImportSource: "yract"`.
+
+### Local / monorepo usage
+
+If running yract directly from source and your editor shows "Cannot find module 'yract'", add path mappings to your `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "yract": ["../src/index.ts"],
+      "yract/jsx-runtime": ["../src/jsx-runtime.ts"],
+      "yract/jsx-dev-runtime": ["../src/jsx-runtime.ts"]
+    }
+  }
+}
+```
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -4,78 +4,9 @@
 
 # Y'ract
 
-> JSX UI library focused on ease of use and easy to understanding the internals of the library itself
+> A minimal JSX UI library powered by JavaScript generator functions
 
-**yract** is a tiny, transparent JSX UI library that uses plain JavaScript
-[generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*)
-as components. Each `yield` statement produces the JSX for the current render.
-State lives in ordinary local variables — no magic, no hidden framework machinery.
-
----
-
-## How it works (in ~100 lines)
-
-The whole library consists of three small modules:
-
-| File                                       | What it does                                                  |
-| ------------------------------------------ | ------------------------------------------------------------- |
-| [`src/jsx.ts`](src/jsx.ts)                 | Defines the `VNode` type and the `createElement` JSX factory  |
-| [`src/render.ts`](src/render.ts)           | Turns VNodes into real DOM nodes; mounts components          |
-| [`src/jsx-runtime.ts`](src/jsx-runtime.ts) | Automatic JSX transform support (`jsxImportSource`)           |
-
-### Components
-
-```tsx
-import { createElement, render } from 'yract';
-
-// A generator function IS a component.
-// `rerender` – passed as the second argument – repaints the component
-// by advancing the generator to its next `yield`.
-function* Counter(_props: {}, rerender: () => void) {
-  let count = 0;
-  while (true) {
-    yield (
-      <button
-        onClick={() => {
-          count++;
-          rerender();
-        }}
-      >
-        Clicked {count} times
-      </button>
-    );
-  }
-}
-
-render(<Counter />, document.getElementById('root')!);
-```
-
-### Lifecycle in plain English
-
-1. `render(<Counter />, container)` creates a generator instance and calls
-   `gen.next()` to get the **initial JSX**.
-2. The resulting DOM node is placed inside a `<span style="display:contents">`
-   host element (transparent to layout) and added to the container.
-3. When `rerender()` is called (e.g. from an `onClick` handler), the library
-   calls `gen.next()` again. The generator resumes, updates its local
-   variables, and `yield`s new JSX.
-4. The host element is cleared and repopulated with the new DOM nodes.
-5. When the generator returns (`done: true`) it stops rerendering.
-
-### Fragments
-
-```tsx
-import { createElement, Fragment, render } from 'yract';
-
-function* List() {
-  yield (
-    <>
-      <li>One</li>
-      <li>Two</li>
-    </>
-  );
-}
-```
+**yract** uses plain JavaScript [generator functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) as components. Hooks are called with `yield*`, JSX is produced by `return`, and state lives in local variables managed by the framework. No magic, no hidden machinery.
 
 ---
 
@@ -85,9 +16,23 @@ function* List() {
 npm install yract
 ```
 
-## TypeScript / JSX setup
+### JSX setup
 
-Add to your `tsconfig.json`:
+Add to your `tsconfig.json` (recommended):
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "yract"
+  }
+}
+```
+
+No manual imports needed — the automatic JSX transform handles everything. Full `JSX.IntrinsicElements` type checking for all HTML/SVG tags is included out of the box.
+
+<details>
+<summary>Classic JSX transform (alternative)</summary>
 
 ```json
 {
@@ -99,55 +44,170 @@ Add to your `tsconfig.json`:
 }
 ```
 
-…and import at the top of every JSX file:
+With the classic transform, import at the top of every JSX file:
 
 ```ts
 import { createElement, Fragment } from 'yract';
 ```
 
-Or use the automatic JSX transform:
+</details>
 
-```json
-{
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "jsxImportSource": "yract"
+---
+
+## Quick start
+
+```tsx
+import { createRoot, useState } from 'yract';
+
+function* Counter() {
+  const [count, setCount] = yield* useState(0);
+  return (
+    <button onClick={() => setCount((c) => c + 1)}>
+      Clicked {count} times
+    </button>
+  );
+}
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<Counter />);
+```
+
+Components are generator functions. The body re-runs from the top on every render, but hook state persists across runs — there are no stale-closure problems.
+
+---
+
+## Features
+
+### Hooks
+
+All hooks are generators called with `yield*`.
+
+```tsx
+function* Timer() {
+  const [tick, setTick] = yield* useState(0);
+
+  yield* useEffect((signal) => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <p>Seconds: {tick}</p>;
+}
+```
+
+Available hooks: `useState`, `useEffect`, `useRef`, `useId`, `useMemo`, `useResolve`, `useResolveRaw`, `useRender`, `useResume`, `useUIPatch`, `usePatchContext`.
+
+### Context
+
+Pass data through the tree without prop-drilling.
+
+```tsx
+import { createContext, useContext } from 'yract';
+
+const ThemeCtx = createContext<'light' | 'dark'>('light');
+
+function* ThemedButton() {
+  const theme = yield* useContext(ThemeCtx);
+  return <button className={theme}>Click</button>;
+}
+
+function* App() {
+  return (
+    <ThemeCtx.Provider value="dark">
+      <ThemedButton />
+    </ThemeCtx.Provider>
+  );
+}
+```
+
+`useContext` supports optional selectors to skip rerenders when only unrelated fields change.
+
+### Async data
+
+`useResolve` pauses rendering while a promise is pending and shows a loading placeholder:
+
+```tsx
+function* UserProfile({ userId }: { userId: number }) {
+  const user = yield* useResolve(
+    {
+      fn: (signal) => fetch(`/api/users/${userId}`, { signal }).then((r) => r.json()),
+      loading: <p>Loading...</p>,
+      error: <p>Failed to load</p>,
+    },
+    [userId],
+  );
+  return <div>{user.name}</div>;
+}
+```
+
+The `fn` callback receives an `AbortSignal` that is automatically aborted when deps change or the component unmounts.
+
+### Conditional rendering
+
+`$shown` mounts/unmounts any element or component without shifting sibling positions:
+
+```tsx
+function* App() {
+  const [open, setOpen] = yield* useState(false);
+  return (
+    <>
+      <button onClick={() => setOpen((v) => !v)}>Toggle</button>
+      <Modal $shown={open} />
+    </>
+  );
+}
+```
+
+### Portals
+
+Render children into a DOM node outside the render root:
+
+```tsx
+import { createPortal } from 'yract';
+
+function* App() {
+  return (
+    <div>
+      <h1>App</h1>
+      {createPortal(<Modal />, document.getElementById('modal-root')!)}
+    </div>
+  );
+}
+```
+
+Context and events flow through the component tree, not the DOM tree.
+
+### UI patches (transitions)
+
+Freeze DOM updates during async work, then apply all changes at once:
+
+```tsx
+import { startUIPatch, commitUIPatch } from 'yract';
+
+async function navigate(next: string) {
+  startUIPatch();
+  try {
+    const data = await fetchPageData(next);
+    setPageData(data);
+  } finally {
+    commitUIPatch(); // all changes applied atomically
   }
 }
 ```
 
-Either configuration provides full JSX type checking out of the box —
-including `JSX.IntrinsicElements` support for all HTML / SVG tags.
-No additional `/// <reference>` directives or manual type imports are needed.
-
-> **Local / monorepo usage (pre-publish)**
->
-> If you are running yract directly from source (e.g. inside the
-> `examples/` folder of this repo) and your editor shows
-> _"Cannot find module 'yract'"_, add the following to your
-> project's `tsconfig.json` so the TypeScript language server resolves
-> the package from source:
->
-> ```json
-> {
->   "compilerOptions": {
->     "baseUrl": ".",
->     "paths": {
->       "yract": ["../src/index.ts"],
->       "yract/jsx-runtime": ["../src/jsx-runtime.ts"],
->       "yract/jsx-dev-runtime": ["../src/jsx-runtime.ts"]
->     }
->   }
-> }
-> ```
+Use `$patch="live"` on subtrees that should keep updating during a patch (e.g. clocks, animations). Use `useUIPatch` for component-scoped patches. Use `$deferred` to mark lower-priority subtrees for the cooperative scheduler.
 
 ---
 
-## Running the tests
+## API reference
 
-```bash
-npm test
-```
+See the full [API documentation](docs/api.md) for detailed signatures, examples, and design decisions.
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, commands, and workflow.
 
 ---
 


### PR DESCRIPTION
## Summary

Rewrites the README to focus on end users of the library. The old README was outdated (showed the pre-hooks `rerender` callback pattern, referenced a stale 3-file architecture) and mixed contributor-facing content with user documentation. Contributor content is moved to a new CONTRIBUTING.md.

## Changes

- **README.md**: Rewritten with current `yield*` hooks + `return` JSX component model, installation/setup first, quick start example, feature highlights (hooks, context, async data, `$shown`, portals, UI patches), and links to full API docs
- **CONTRIBUTING.md**: New file with development setup, commands, PR guidelines, project structure, and local/monorepo JSX configuration tips (all moved from README)
- Removed outdated content: old `rerender` callback examples, stale 3-file architecture table, incorrect lifecycle description, "Running the tests" section

## Closes #120

## Verification

All checks passed: knip, lint, build, typecheck:examples, unit tests (232), visual tests (330).

## CLAUDE.md Update

No update needed — no workflow, scripts, or project structure changes.