### PR TITLE
feat: add $deps framework prop for dependency-based rerender control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ function* Counter(_props: object) {
 
 Example components live in `examples/src/components/`. The app entry point is `examples/src/main.tsx`, which renders a tabbed view of all demos.
 
-**Top-level demos** (each a tab in main.tsx): `Counter`, `TodoList`, `ThemeDemo`, `DataFetcher`/`ResolveRawDemo`, `HooksShowcase`, `ShownDemo`, `ConfirmDialog`, `EffectDemo`, `TransitionDemo`, `ContextDemo`, `LazyContextDemo`, `AbortSignalEffectDemo`, `KeyShuffleDemo`, `PortalDemo`.
+**Top-level demos** (each a tab in main.tsx): `Counter`, `TodoList`, `ThemeDemo`, `DataFetcher`/`ResolveRawDemo`, `HooksShowcase`, `ShownDemo`, `ConfirmDialog`, `EffectDemo`, `TransitionDemo`, `ContextDemo`, `LazyContextDemo`, `AbortSignalEffectDemo`, `KeyShuffleDemo`, `DepsDemo`, `PortalDemo`.
 
 **Multi-file demos** split one-component-per-file:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -779,6 +779,43 @@ function* App() {
 
 > Unlike a conditional `{open && <Modal />}`, `$shown` keeps the JSX position stable in the tree, which avoids reconciler position-shift issues.
 
+### `$deps`
+
+```tsx
+<Component $deps={[relevantValue]} otherProp={data} />
+<div $deps={[relevantValue]} className={cls} />
+```
+
+Replaces the default shallow-equal props check with a dependency-array comparison — the same `depsChanged()` mechanism used by hooks. The component or element only rerenders/updates when the deps change.
+
+Useful when a parent passes new object references on every render but the component only cares about a subset of values.
+
+| Parameter | Type         | Description                                     |
+| --------- | ------------ | ----------------------------------------------- |
+| `$deps`   | `unknown[]`  | Dependency array compared via shallow `Object.is` |
+
+```tsx
+function* Parent() {
+  const [relevant, setRelevant] = yield* useState(0);
+  const [irrelevant, setIrrelevant] = yield* useState(0);
+
+  // ExpensiveChild only rerenders when `relevant` changes,
+  // even though `data` is a new object reference every render.
+  return (
+    <ExpensiveChild
+      data={{ relevant, irrelevant }}
+      $deps={[relevant]}
+    />
+  );
+}
+```
+
+**For components:** when `$deps` is present and unchanged, the component's generator body is not re-executed. Context changes still trigger a rerender regardless of `$deps`.
+
+**For HTML elements:** when `$deps` is present and unchanged, prop diffing (`updateProps`) is skipped. Children are still reconciled normally.
+
+`$deps` is never set as a DOM attribute and is not visible in the component's props object.
+
 ### `$patch`
 
 ```tsx

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -345,4 +345,4 @@ regardless of active patches.
 | `src/render/mount.ts`       | `commitOrDefer`, `executeRerender`, `rerender` closures    |
 | `src/render/state.ts`       | Shared mutable state (`patchDepth`, `liveOnlyMode`, etc.)  |
 | `src/context.ts`            | `_priorityCtx`, `_withPriority`, `_getCurrentPriority`     |
-| `src/render/helpers.ts`     | `stripDeferred` — removes `$deferred` from component props |
+| `src/render/helpers.ts`     | `stripFrameworkDirectives` — removes `$deferred` / `$deps` from component props |

--- a/examples/src/components/DepsDemo.tsx
+++ b/examples/src/components/DepsDemo.tsx
@@ -1,0 +1,96 @@
+/**
+ * DepsDemo – demonstrates the `$deps` prop, which replaces the default
+ * shallow-equal props check with a dependency-array comparison.
+ *
+ * The parent passes new object references on every render, but the child
+ * component only rerenders when its `$deps` change. A render counter
+ * makes the skip behaviour visible.
+ */
+import { useRef, useState } from "yract";
+
+// ---------------------------------------------------------------------------
+// Child: tracks how many times it actually renders
+// ---------------------------------------------------------------------------
+
+function* RenderCounter({
+  label,
+  value,
+}: {
+  label: string;
+  value: number;
+  data?: Record<string, number>;
+}) {
+  const countRef = yield* useRef(0);
+  countRef.current++;
+
+  return (
+    <div
+      data-testid={`deps-${label}`}
+      style={{
+        display: "flex",
+        gap: "0.5rem",
+        alignItems: "center",
+        padding: "0.5rem 0.75rem",
+        background: "#f8f9fa",
+        border: "1px solid #dee2e6",
+        borderRadius: "6px",
+        marginBottom: "0.5rem",
+      }}
+    >
+      <strong>{label}:</strong>
+      <span>
+        value=<span data-testid={`deps-${label}-value`}>{value}</span>
+      </span>
+      <span style={{ color: "#666" }}>
+        (renders: <span data-testid={`deps-${label}-renders`}>{countRef.current}</span>)
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main demo
+// ---------------------------------------------------------------------------
+
+export function* DepsDemo() {
+  const [relevant, setRelevant] = yield* useState(0);
+  const [irrelevant, setIrrelevant] = yield* useState(0);
+
+  return (
+    <section aria-label="deps prop demo">
+      <h2>
+        <code>$deps</code> Prop
+      </h2>
+      <p>
+        The <code>$deps</code> prop replaces the default shallow-equal props check with a
+        dependency-array comparison. The component below only rerenders when <code>$deps</code>{" "}
+        changes — even though new object references are passed on every parent render.
+      </p>
+
+      <div style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}>
+        <button data-testid="deps-inc-relevant" onClick={() => setRelevant((v) => v + 1)}>
+          Increment relevant ({relevant})
+        </button>
+        <button data-testid="deps-inc-irrelevant" onClick={() => setIrrelevant((v) => v + 1)}>
+          Increment irrelevant ({irrelevant})
+        </button>
+      </div>
+
+      <h3>With $deps (only rerenders when relevant changes)</h3>
+      <RenderCounter
+        label="with-deps"
+        value={relevant}
+        data={{ relevant, irrelevant }}
+        $deps={[relevant]}
+      />
+
+      <h3>Without $deps (rerenders on every parent render)</h3>
+      <RenderCounter label="without-deps" value={relevant} data={{ relevant, irrelevant }} />
+
+      <p style={{ color: "#666", fontSize: "0.9rem" }}>
+        Click "Increment irrelevant" — the component <strong>with</strong> <code>$deps</code> stays
+        at the same render count, while the one <strong>without</strong> rerenders every time.
+      </p>
+    </section>
+  );
+}

--- a/examples/src/main.tsx
+++ b/examples/src/main.tsx
@@ -9,6 +9,7 @@ import { ConfirmDialog } from "./components/ConfirmDialog";
 import { ContextDemo } from "./components/ContextDemo";
 import { Counter } from "./components/Counter";
 import { DataFetcher, ResolveRawDemo } from "./components/DataFetcher";
+import { DepsDemo } from "./components/DepsDemo";
 import { EffectDemo } from "./components/EffectDemo";
 import { HooksShowcase } from "./components/HooksShowcase";
 import { KeyShuffleDemo } from "./components/KeyShuffleDemo";
@@ -34,6 +35,7 @@ type Tab =
   | "lazy-ctx"
   | "abort-signal"
   | "key-shuffle"
+  | "deps"
   | "portal";
 
 const tabs: { id: Tab; label: string }[] = [
@@ -51,6 +53,7 @@ const tabs: { id: Tab; label: string }[] = [
   { id: "lazy-ctx", label: "Lazy Context" },
   { id: "abort-signal", label: "AbortSignal Effect" },
   { id: "key-shuffle", label: "Key Shuffle" },
+  { id: "deps", label: "$deps prop" },
   { id: "portal", label: "createPortal" },
 ];
 
@@ -73,7 +76,7 @@ function* App() {
       >
         {tabs.map((tab) => (
           <button
-            $key={tab.id}
+            key={tab.id}
             role="tab"
             data-testid={`tab-${tab.id}`}
             id={`tab-${tab.id}`}
@@ -109,6 +112,7 @@ function* App() {
         <LazyContextDemo $shown={activeTab === "lazy-ctx"} />
         <AbortSignalEffectDemo $shown={activeTab === "abort-signal"} />
         <KeyShuffleDemo $shown={activeTab === "key-shuffle"} />
+        <DepsDemo $shown={activeTab === "deps"} />
         <PortalDemo $shown={activeTab === "portal"} />
       </div>
     </div>

--- a/examples/tests/deps.spec.ts
+++ b/examples/tests/deps.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
+
+test.describe("$deps prop example", () => {
+  test.beforeEach(async ({ page }) => {
+    await goToApp(page);
+    await clickTab(page, "$deps prop");
+    await page.waitForSelector('[data-testid="deps-with-deps"]');
+  });
+
+  test("both counters start at 1 render", async ({ page }) => {
+    await expect(page.getByTestId("deps-with-deps-renders")).toHaveText("1");
+    await expect(page.getByTestId("deps-without-deps-renders")).toHaveText("1");
+    await page.screenshot({ path: "test-results/deps-initial.png" });
+  });
+
+  test("incrementing relevant rerenders both counters", async ({ page }) => {
+    await page.getByTestId("deps-inc-relevant").click();
+    await expect(page.getByTestId("deps-with-deps-renders")).toHaveText("2");
+    await expect(page.getByTestId("deps-without-deps-renders")).toHaveText("2");
+    await expect(page.getByTestId("deps-with-deps-value")).toHaveText("1");
+    await page.screenshot({ path: "test-results/deps-relevant-click.png" });
+  });
+
+  test("incrementing irrelevant only rerenders the counter without $deps", async ({ page }) => {
+    await page.getByTestId("deps-inc-irrelevant").click();
+    // With $deps: render count stays at 1 — deps didn't change
+    await expect(page.getByTestId("deps-with-deps-renders")).toHaveText("1");
+    // Without $deps: render count goes to 2 — props reference changed
+    await expect(page.getByTestId("deps-without-deps-renders")).toHaveText("2");
+    await page.screenshot({ path: "test-results/deps-irrelevant-click.png" });
+  });
+
+  test("multiple irrelevant clicks keep with-deps render count at 1", async ({ page }) => {
+    await page.getByTestId("deps-inc-irrelevant").click();
+    await page.getByTestId("deps-inc-irrelevant").click();
+    await page.getByTestId("deps-inc-irrelevant").click();
+    await expect(page.getByTestId("deps-with-deps-renders")).toHaveText("1");
+    await expect(page.getByTestId("deps-without-deps-renders")).toHaveText("4");
+    await page.screenshot({ path: "test-results/deps-multiple-irrelevant.png" });
+  });
+});

--- a/examples/tests/helpers.ts
+++ b/examples/tests/helpers.ts
@@ -22,6 +22,7 @@ const tabIds: Record<string, string> = {
   "Lazy Context": "tab-lazy-ctx",
   "AbortSignal Effect": "tab-abort-signal",
   "Key Shuffle": "tab-key-shuffle",
+  "$deps prop": "tab-deps",
   createPortal: "tab-portal",
 };
 

--- a/src/__tests__/deps-prop.test.ts
+++ b/src/__tests__/deps-prop.test.ts
@@ -1,0 +1,238 @@
+import { createContext, useContext } from "../context";
+import { useState } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
+
+describe("$deps prop", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("skips component rerender when $deps are unchanged", () => {
+    let renderCount = 0;
+    let setParentState: (v: number) => void = () => {};
+
+    function* Child(_props: { data: Record<string, unknown> }) {
+      renderCount++;
+      return createElement("p", null, `renders: ${renderCount}`);
+    }
+
+    function* Parent() {
+      const [count, setCount] = yield* useState(0);
+      setParentState = setCount;
+      const data = { value: count };
+      // $deps only depends on count — if count stays the same,
+      // child should not rerender even though data is a new object.
+      return createElement("div", null, createElement(Child as never, { data, $deps: [count] }));
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(renderCount).toBe(1);
+
+    // Trigger parent rerender with same count → child should be skipped
+    setParentState(0);
+    expect(renderCount).toBe(1);
+
+    // Trigger parent rerender with different count → child should rerender
+    setParentState(1);
+    expect(renderCount).toBe(2);
+  });
+
+  it("rerenders component when $deps change", () => {
+    let renderCount = 0;
+    let setA: (v: number) => void = () => {};
+
+    function* Child(_props: { a: number; b: number }) {
+      renderCount++;
+      return createElement("span", null, `a=${_props.a}`);
+    }
+
+    function* Parent() {
+      const [a, setAFn] = yield* useState(1);
+      setA = setAFn;
+      return createElement(Child as never, { a, b: 99, $deps: [a] });
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(renderCount).toBe(1);
+
+    setA(2);
+    expect(renderCount).toBe(2);
+    expect(container.textContent).toContain("a=2");
+  });
+
+  it("skips HTML element updateProps when $deps are unchanged", () => {
+    let setParentState: (v: string) => void = () => {};
+
+    function* Parent() {
+      const [cls, setCls] = yield* useState("cls-a");
+      setParentState = setCls;
+      return createElement("div", {
+        className: cls,
+        "data-extra": Math.random().toString(),
+        $deps: [cls],
+      });
+    }
+
+    render(createElement(Parent as never, {}), container);
+    const el = container.querySelector("div") as HTMLElement;
+    expect(el.className).toBe("cls-a");
+    const extraBefore = el.getAttribute("data-extra");
+
+    // Same cls → $deps unchanged → updateProps skipped → data-extra unchanged
+    setParentState("cls-a");
+    expect(el.getAttribute("data-extra")).toBe(extraBefore);
+
+    // Different cls → $deps changed → updateProps runs
+    setParentState("cls-b");
+    expect(el.className).toBe("cls-b");
+    expect(el.getAttribute("data-extra")).not.toBe(extraBefore);
+  });
+
+  it("updates HTML element when $deps change", () => {
+    let setVal: (v: string) => void = () => {};
+
+    function* Parent() {
+      const [val, setValFn] = yield* useState("hello");
+      setVal = setValFn;
+      return createElement("div", { "data-val": val, $deps: [val] });
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect((container.querySelector("div") as HTMLElement).getAttribute("data-val")).toBe("hello");
+
+    setVal("world");
+    expect((container.querySelector("div") as HTMLElement).getAttribute("data-val")).toBe("world");
+  });
+
+  it("does not set $deps as a DOM attribute", () => {
+    render(createElement("div", { $deps: [1, 2, 3] }), container);
+    const el = container.querySelector("div") as HTMLElement;
+    expect(el.hasAttribute("$deps")).toBe(false);
+  });
+
+  it("does not pass $deps to component props", () => {
+    let receivedProps: Record<string, unknown> = {};
+
+    function* Child(props: { name: string }) {
+      receivedProps = props;
+      return createElement("p", null, props.name);
+    }
+
+    render(createElement(Child as never, { name: "test", $deps: [1] }), container);
+    expect(receivedProps["name"]).toBe("test");
+    expect("$deps" in receivedProps).toBe(false);
+  });
+
+  it("falls back to shallowEqual when $deps is removed", () => {
+    let renderCount = 0;
+    let setUseDeps: (v: boolean) => void = () => {};
+    let setVal: (v: number) => void = () => {};
+
+    function* Child(_props: { val: number }) {
+      renderCount++;
+      return createElement("p", null, `${renderCount}`);
+    }
+
+    function* Parent() {
+      const [useDeps, setUseDepsF] = yield* useState(true);
+      const [val, setValF] = yield* useState(0);
+      setUseDeps = setUseDepsF;
+      setVal = setValF;
+      const props: Record<string, unknown> = { val };
+      if (useDeps) props.$deps = [val];
+      return createElement(Child as never, props);
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(renderCount).toBe(1);
+
+    // Remove $deps → props differ (prevSlot had $deps, new doesn't) → rerenders
+    setUseDeps(false);
+    expect(renderCount).toBe(2);
+
+    // Now using shallowEqual: same val → skip
+    setVal(0);
+    expect(renderCount).toBe(2);
+
+    // Change val → shallowEqual detects difference → rerender
+    setVal(1);
+    expect(renderCount).toBe(3);
+  });
+
+  it("still unmounts when $shown becomes false with $deps", () => {
+    let setShown: (v: boolean) => void = () => {};
+
+    function* Child() {
+      return createElement("p", null, "child");
+    }
+
+    function* Parent() {
+      const [shown, setS] = yield* useState(true);
+      setShown = setS;
+      return createElement(Child as never, { $shown: shown, $deps: [] });
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(container.querySelector("p")).not.toBeNull();
+
+    setShown(false);
+    expect(container.querySelector("p")).toBeNull();
+  });
+
+  it("context changes still trigger rerender even when $deps unchanged", () => {
+    let renderCount = 0;
+    let setTheme: (v: string) => void = () => {};
+
+    const ThemeCtx = createContext("light");
+
+    function* Consumer(_props: { extra: number }) {
+      const theme = yield* useContext(ThemeCtx);
+      renderCount++;
+      return createElement("span", null, theme);
+    }
+
+    function* Provider() {
+      const [theme, setT] = yield* useState("light");
+      setTheme = setT;
+      return createElement(
+        ThemeCtx.Provider as never,
+        { value: theme },
+        // $deps is stable (empty) but context should still trigger rerender
+        createElement(Consumer as never, { extra: 42, $deps: [] }),
+      );
+    }
+
+    render(createElement(Provider as never, {}), container);
+    expect(renderCount).toBe(1);
+    expect(container.textContent).toContain("light");
+
+    setTheme("dark");
+    expect(renderCount).toBe(2);
+    expect(container.textContent).toContain("dark");
+  });
+
+  it("still reconciles children of HTML element when $deps skips props", () => {
+    let setChild: (v: string) => void = () => {};
+
+    function* Parent() {
+      const [child, setC] = yield* useState("hello");
+      setChild = setC;
+      return createElement("div", { className: "wrapper", $deps: ["stable"] }, child);
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(container.textContent).toContain("hello");
+
+    setChild("world");
+    // Children should still reconcile even though $deps didn't change
+    expect(container.textContent).toContain("world");
+  });
+});

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,4 +1,4 @@
-import type { ComponentGenerator } from "./hooks/types";
+import type { ComponentGenerator, DependencyList } from "./hooks/types";
 import type { IntrinsicElements as IntrinsicElementsDef } from "./jsx-types";
 
 export type VNodeType = string | symbol | Component;
@@ -25,7 +25,7 @@ export type Child = VNode | string | number | boolean | null | undefined;
  */
 export interface FrameworkProps {
   /** Reconciliation key — not rendered to the DOM. Must be a string. */
-  $key?: string;
+  key?: string;
   /** When false, the element/component is removed from the DOM. */
   $shown?: boolean;
   /**
@@ -47,6 +47,17 @@ export interface FrameworkProps {
    * see `$deferred` in their props object.
    */
   $deferred?: boolean;
+  /**
+   * Dependency array for reconciliation memoization.
+   *
+   * When present, replaces the default `shallowEqual` props check with a
+   * `depsChanged()` comparison — the same mechanism used by hooks. The
+   * component or element only rerenders/updates when the deps change.
+   *
+   * Useful when a parent passes new object references but the component
+   * only cares about a subset of values.
+   */
+  $deps?: DependencyList;
 }
 
 /**
@@ -154,7 +165,7 @@ export const Portal: unique symbol = Symbol("Portal");
 export function createPortal(children: Child | Child[], container: Element, key?: string): VNode {
   const childArray = Array.isArray(children) ? children : [children];
   const props: InternalProps = { $portalContainer: container } as InternalProps;
-  if (key != null) props.$key = String(key);
+  if (key != null) props.key = String(key);
   return { type: Portal, props, children: childArray };
 }
 
@@ -232,9 +243,9 @@ declare global {
      * elements and custom components — without needing to be
      * declared in the component's own props type.
      *
-     * Only framework-level props (`$key`, `$shown`, `$patch`, `$deferred`)
-     * are universally available. `children` and `$ref` must be explicitly
-     * declared in a component's props type to be accepted.
+     * Only framework-level props (`key`, `$shown`, `$patch`, `$deferred`,
+     * `$deps`) are universally available. `children` and `$ref` must be
+     * explicitly declared in a component's props type to be accepted.
      */
     interface IntrinsicAttributes extends FrameworkProps {}
   }

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -163,20 +163,36 @@ export function isShown(props: SpecialProps): boolean {
 }
 
 /**
- * Strip `$deferred` from a props object, returning props without it.
+ * Strip framework-level directives (`$deferred`, `$deps`) from a props
+ * object, returning props without them.
  *
- * `$deferred` is a framework-level directive that controls priority
- * scheduling. It is **not** passed to the component — the component
- * should never see it in its props.
+ * These directives are consumed by the reconciler/scheduler and are
+ * **not** passed to the component — the component should never see them
+ * in its props.
  *
- * If `$deferred` is not present, returns the original object (no allocation).
+ * If neither directive is present, returns the original object (no allocation).
  *
  * **Called by:**
- * - `reconcileOneGen` in `reconciler.ts` — before passing props to components.
+ * - `reconcileComponent` in `reconciler.ts` — before passing props to components.
  * - `buildNode` / `buildVNodeList` in `mount.ts` — same.
  *
- * @param props - The (merged) props that may contain `$deferred`.
- * @returns Props without `$deferred`.
+ * @param props - The (merged) props that may contain `$deferred` / `$deps`.
+ * @returns Props without `$deferred` or `$deps`.
+ */
+export function stripFrameworkDirectives(props: InternalProps): InternalProps {
+  if (!("$deferred" in props) && !("$deps" in props)) return props;
+  const { $deferred: _d, $deps: _p, ...rest } = props;
+  return rest as InternalProps;
+}
+
+/**
+ * Strip `$deferred` from a props object, keeping `$deps` intact.
+ *
+ * Used to produce the "slot props" stored in `Slot.props` — `$deps`
+ * is retained so the reconciler can compare it on the next update,
+ * while `$deferred` is propagated via context and not needed on the slot.
+ *
+ * If `$deferred` is not present, returns the original object (no allocation).
  */
 export function stripDeferred(props: InternalProps): InternalProps {
   if (!("$deferred" in props)) return props;

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -29,7 +29,13 @@ import {
 } from "../context";
 import { $USE_EFFECT } from "../hooks/descriptors";
 import { type Child, type Component, Fragment, type InternalProps, Portal } from "../jsx";
-import { getPatchMode, isComponentNode, isShown, mergedProps, stripDeferred } from "./helpers";
+import {
+  getPatchMode,
+  isComponentNode,
+  isShown,
+  mergedProps,
+  stripFrameworkDirectives,
+} from "./helpers";
 import { flushEffects, runHooks } from "./hooks-runtime";
 import { isPatchActive } from "./patch-queue";
 import { applyProps } from "./props";
@@ -92,8 +98,8 @@ export function buildNode(child: Child): Node {
     if (!isShown(allPropsRaw)) {
       return document.createTextNode("");
     }
-    // Strip $deferred from component props; propagate via context.
-    const allProps = stripDeferred(allPropsRaw);
+    // Strip $deferred and $deps from component props; propagate $deferred via context.
+    const allProps = stripFrameworkDirectives(allPropsRaw);
     const compDeferred = allPropsRaw.$deferred;
     const prevCtx = _getCtxMap();
     if (compDeferred) _setCtxMap(_withPriority(prevCtx, _getCurrentPriority() + 1));

--- a/src/render/reconciler.ts
+++ b/src/render/reconciler.ts
@@ -58,6 +58,7 @@ import {
   onlyPatchChanged,
   shallowEqual,
   stripDeferred,
+  stripFrameworkDirectives,
 } from "./helpers";
 import { propagateContextUpdate, unmountSlot } from "./hooks-runtime";
 import { buildNode, mountComponent, mountContextProvider } from "./mount";
@@ -137,7 +138,7 @@ function removeSlotNodes(parent: Node, slot: Slot): void {
  */
 function getChildKey(child: Child): string | undefined {
   if (!isVNode(child)) return undefined;
-  return child.props.$key;
+  return child.props.key;
 }
 
 /**
@@ -205,7 +206,7 @@ function* reconcileKeyedSlotsGen(
   const prevKeyMap = new Map<string | number, number>();
   const nonKeyedPrevIndices: number[] = [];
   for (let i = 0; i < prevSlots.length; i++) {
-    const key = prevSlots[i]?.props.$key;
+    const key = prevSlots[i]?.props.key;
     if (key !== undefined) {
       prevKeyMap.set(key, i);
     } else {
@@ -570,9 +571,13 @@ function* reconcileComponent(
   allPropsForShown: InternalProps,
 ): Generator<void, { slot: Slot; node: Node; replaced: boolean }, void> {
   const allPropsRaw = allPropsForShown;
-  const allProps = stripDeferred(allPropsRaw);
+  // allProps: what the component sees (no $deferred, no $deps)
+  const allProps = stripFrameworkDirectives(allPropsRaw);
+  // slotProps: what Slot.props stores (keeps $deps for next comparison, strips $deferred)
+  const slotProps = stripDeferred(allPropsRaw);
   const component = vnode.type;
   const providerCtx = _getProviderCtx(component);
+  const newDeps = allPropsRaw.$deps;
 
   // Propagate $deferred to the subtree via context.
   // Save and restore the context map so siblings are unaffected.
@@ -582,23 +587,28 @@ function* reconcileComponent(
   try {
     // ── Same component type at same position ──
     if (prevSlot?.type === vnode.type) {
-      // Props unchanged / only $patch changed → skip rerender
-      const propsUnchanged = shallowEqual(prevSlot.props, allProps);
-      const patchOnly = !propsUnchanged && onlyPatchChanged(prevSlot.props, allProps);
+      // $deps replaces the shallowEqual check when present on the new VNode.
+      const propsUnchanged = newDeps
+        ? !depsChanged(prevSlot.props.$deps, newDeps)
+        : shallowEqual(prevSlot.props, allProps);
+      const patchOnly = !propsUnchanged && !newDeps && onlyPatchChanged(prevSlot.props, allProps);
       if (propsUnchanged || patchOnly) {
         const inst = prevSlot.componentInstance;
+        // When $deps says "unchanged", still update prevSlot.props so next
+        // comparison uses the fresh deps array reference.
+        if (newDeps) prevSlot.props = slotProps;
         if (patchOnly && inst) {
           // Forward the new $patch value so shouldDefer reads it correctly.
           inst.props["$patch"] = allProps["$patch"];
           if (inst.consumedContexts.has(_batchCtx as Context<unknown>)) {
-            prevSlot.props = allProps;
+            prevSlot.props = slotProps;
             inst.capturedCtx = _withBatch(inst.capturedCtx, _getCurrentBatch());
             inst.rerender();
             return { slot: prevSlot, node: prevSlot.node, replaced: false };
           }
         }
         if (patchOnly) {
-          prevSlot.props = allProps;
+          prevSlot.props = slotProps;
         }
         if (inst) {
           // Check if any consumed context value differs from capturedCtx.
@@ -639,7 +649,7 @@ function* reconcileComponent(
             const hasContentChange = Object.keys({ ...prevSlot.props, ...allProps }).some(
               (k) => k !== "$patch" && k !== "$shown" && !Object.is(prevSlot.props[k], allProps[k]),
             );
-            if (!hasContentChange) prevSlot.props = allProps;
+            if (!hasContentChange) prevSlot.props = slotProps;
           }
           return { slot: prevSlot, node: prevSlot.node, replaced: false };
         }
@@ -667,7 +677,7 @@ function* reconcileComponent(
         } finally {
           _setCtxMap(prevCtxMap);
         }
-        prevSlot.props = allProps;
+        prevSlot.props = slotProps;
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
       }
 
@@ -679,7 +689,7 @@ function* reconcileComponent(
           _getCurrentBatch(),
         );
         prevSlot.componentInstance.rerender();
-        prevSlot.props = allProps;
+        prevSlot.props = slotProps;
         return { slot: prevSlot, node: prevSlot.node, replaced: false };
       }
     }
@@ -709,7 +719,7 @@ function* reconcileComponent(
         slot: {
           type: vnode.type,
           node: endMarker,
-          props: allProps,
+          props: slotProps,
           childSlots,
         },
         node: fragment,
@@ -721,7 +731,7 @@ function* reconcileComponent(
       slot: {
         type: vnode.type,
         node: componentInstance.endMarker,
-        props: allProps,
+        props: slotProps,
         childSlots: [],
         componentInstance,
       },
@@ -752,15 +762,18 @@ function* reconcileHTMLElement(
   if (elDeferred) _setCtxMap(_withPriority(_getCtxMap(), _getCurrentPriority() + 1));
   try {
     if (prevSlot?.type === vnode.type && prevSlot.node instanceof HTMLElement) {
-      // Same tag → update props in place and reconcile children
-      if (!isLiveOnlyDefault()) {
+      // Same tag → update props in place and reconcile children.
+      // When $deps is present, skip updateProps when deps are unchanged.
+      const elDeps = vnode.props.$deps;
+      const skipProps = elDeps && !depsChanged(prevSlot.props.$deps, elDeps);
+      if (!isLiveOnlyDefault() && !skipProps) {
         const prevProps = prevSlot.props;
         domEnqueue(
           () => updateProps(prevSlot.node as HTMLElement, prevProps, vnode.props),
           prevSlot.node,
         );
-        prevSlot.props = vnode.props;
       }
+      prevSlot.props = vnode.props;
       prevSlot.childSlots = yield* reconcileSlotsGen(
         prevSlot.node,
         prevSlot.childSlots,


### PR DESCRIPTION
## Summary

- Adds `$deps` framework prop that replaces `shallowEqual` with `depsChanged()` for reconciliation memoization
- Components skip rerender when deps are unchanged; HTML elements skip `updateProps` while still reconciling children
- Context changes still trigger rerenders regardless of `$deps`

## Changes

- **`src/jsx.ts`** — Added `$deps?: DependencyList` to `FrameworkProps`
- **`src/render/helpers.ts`** — Added `stripFrameworkDirectives` (strips `$deferred` + `$deps`) alongside `stripDeferred` (keeps `$deps` for slot comparison)
- **`src/render/reconciler.ts`** — Component path uses `depsChanged()` when `$deps` present; HTML element path skips `updateProps` when deps unchanged
- **`src/render/mount.ts`** — Updated import and comment
- **`src/__tests__/deps-prop.test.ts`** — 10 unit tests (skip, rerender, HTML elements, DOM attribute, props stripping, shallowEqual fallback, `$shown` interaction, context changes, child reconciliation)
- **`examples/src/components/DepsDemo.tsx`** — Demo with render counters showing skip behaviour
- **`examples/tests/deps.spec.ts`** — 4 Playwright visual tests (12 across 3 browsers)
- **`docs/api.md`** — `$deps` section under Special props
- **`CLAUDE.md`** — Added `DepsDemo` to top-level demos list

## Closes #94

## Verification

All checks pass: `knip`, `lint`, `build`, `typecheck:examples`, `npm test` (242 tests), `test:visual` (342 tests).

> **Note:** This branch will need a rebase after the `$key` → `key` rename PR merges.

## CLAUDE.md Update

Added `DepsDemo` to the top-level demos list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)