### PR TITLE
fix: allow multiple sequential useRender calls in the same component

### DIFF
--- a/examples/src/components/ConfirmDialog.tsx
+++ b/examples/src/components/ConfirmDialog.tsx
@@ -140,6 +140,165 @@ function* Variant2() {
 }
 
 // ---------------------------------------------------------------------------
+// Variant 3 – wizard: multiple sequential useRender calls (useResume)
+// ---------------------------------------------------------------------------
+
+function* NameStep() {
+  const resume = yield* useResume<string>();
+  const [name, setName] = yield* useState("");
+  return (
+    <div data-testid="v3-step-name" style={{ display: "flex", gap: "0.5rem" }}>
+      <input
+        data-testid="v3-name-input"
+        value={name}
+        onInput={(e) => setName((e.target as HTMLInputElement).value)}
+        placeholder="Enter your name"
+        style={{ padding: "0.4rem" }}
+      />
+      <button
+        data-testid="v3-name-next"
+        onClick={() => resume(name)}
+        style={{
+          padding: "0.4rem 1rem",
+          background: "#0070f3",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
+        }}
+      >
+        Next
+      </button>
+    </div>
+  );
+}
+
+function* ColorStep() {
+  const resume = yield* useResume<string>();
+  return (
+    <div data-testid="v3-step-color" style={{ display: "flex", gap: "0.5rem" }}>
+      {["Red", "Green", "Blue"].map((color) => (
+        <button
+          key={color}
+          data-testid={`v3-color-${color.toLowerCase()}`}
+          onClick={() => resume(color)}
+          style={{
+            padding: "0.4rem 1rem",
+            border: "1px solid #ccc",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          {color}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function* Variant3() {
+  const result = yield* useRef<{ name: string; color: string } | null>(null);
+  const [, rerender] = yield* useState(0);
+
+  while (result.current === null) {
+    const name = yield* useRender<string>(<NameStep />);
+    const color = yield* useRender<string>(<ColorStep />);
+    result.current = { name, color };
+  }
+
+  return (
+    <p data-testid="v3-result">
+      Wizard result: <strong data-testid="v3-answer">{result.current.name}</strong> chose{" "}
+      <strong data-testid="v3-color">{result.current.color}</strong>{" "}
+      <button
+        data-testid="v3-reset"
+        onClick={() => {
+          result.current = null;
+          rerender((n) => n + 1);
+        }}
+        style={{ marginLeft: "0.5rem", cursor: "pointer" }}
+      >
+        Reset
+      </button>
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Variant 4 – wizard: multiple sequential useRender calls (inline)
+// ---------------------------------------------------------------------------
+
+function* Variant4() {
+  const result = yield* useRef<{ a: number; b: number } | null>(null);
+  const [, rerender] = yield* useState(0);
+
+  while (result.current === null) {
+    const a = yield* useRender<number>(
+      ({ resume }) => (
+        <div data-testid="v4-step-a" style={{ display: "flex", gap: "0.5rem" }}>
+          {[1, 2, 3].map((n) => (
+            <button
+              key={String(n)}
+              data-testid={`v4-a-${n}`}
+              onClick={() => resume(n)}
+              style={{
+                padding: "0.4rem 1rem",
+                border: "1px solid #ccc",
+                borderRadius: "4px",
+                cursor: "pointer",
+              }}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      ),
+      [],
+    );
+    const b = yield* useRender<number>(
+      ({ resume }) => (
+        <div data-testid="v4-step-b" style={{ display: "flex", gap: "0.5rem" }}>
+          {[10, 20, 30].map((n) => (
+            <button
+              key={String(n)}
+              data-testid={`v4-b-${n}`}
+              onClick={() => resume(n)}
+              style={{
+                padding: "0.4rem 1rem",
+                border: "1px solid #ccc",
+                borderRadius: "4px",
+                cursor: "pointer",
+              }}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      ),
+      [],
+    );
+    result.current = { a, b };
+  }
+
+  return (
+    <p data-testid="v4-result">
+      Result: <strong data-testid="v4-answer">{result.current.a + result.current.b}</strong> (
+      {result.current.a} + {result.current.b}){" "}
+      <button
+        data-testid="v4-reset"
+        onClick={() => {
+          result.current = null;
+          rerender((n) => n + 1);
+        }}
+        style={{ marginLeft: "0.5rem", cursor: "pointer" }}
+      >
+        Reset
+      </button>
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Top-level export
 // ---------------------------------------------------------------------------
 
@@ -159,6 +318,12 @@ export function* ConfirmDialog() {
 
       <h3>Variant 2 – inline render function</h3>
       <Variant2 />
+
+      <h3>Variant 3 – wizard (multiple useRender with useResume)</h3>
+      <Variant3 />
+
+      <h3>Variant 4 – wizard (multiple useRender inline)</h3>
+      <Variant4 />
     </div>
   );
 }

--- a/examples/src/components/ConfirmDialog.tsx
+++ b/examples/src/components/ConfirmDialog.tsx
@@ -299,6 +299,78 @@ function* Variant4() {
 }
 
 // ---------------------------------------------------------------------------
+// Variant 5 – parent state reflected in useRender dialog
+// ---------------------------------------------------------------------------
+
+function* QuantityDialog({
+  quantity,
+  setQuantity,
+}: {
+  quantity: number;
+  setQuantity: (fn: (prev: number) => number) => void;
+}) {
+  const resume = yield* useResume<number>();
+  return (
+    <div data-testid="v5-dialog" style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+      <button
+        data-testid="v5-decrement"
+        onClick={() => setQuantity((n) => Math.max(0, n - 1))}
+        style={{
+          padding: "0.4rem 0.8rem",
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+          cursor: "pointer",
+        }}
+      >
+        −
+      </button>
+      <span data-testid="v5-quantity" style={{ minWidth: "2rem", textAlign: "center" }}>
+        {quantity}
+      </span>
+      <button
+        data-testid="v5-increment"
+        onClick={() => setQuantity((n) => n + 1)}
+        style={{
+          padding: "0.4rem 0.8rem",
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+          cursor: "pointer",
+        }}
+      >
+        +
+      </button>
+      <button
+        data-testid="v5-confirm"
+        onClick={() => resume(quantity)}
+        style={{
+          padding: "0.4rem 1rem",
+          marginLeft: "0.5rem",
+          background: "#0070f3",
+          color: "#fff",
+          border: "none",
+          borderRadius: "4px",
+          cursor: "pointer",
+        }}
+      >
+        Confirm
+      </button>
+    </div>
+  );
+}
+
+function* Variant5() {
+  const [quantity, setQuantity] = yield* useState(1);
+  const confirmed = yield* useRender<number>(
+    <QuantityDialog quantity={quantity} setQuantity={setQuantity} />,
+  );
+  return (
+    <p data-testid="v5-result">
+      Confirmed quantity: <strong data-testid="v5-answer">{confirmed}</strong>
+    </p>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Top-level export
 // ---------------------------------------------------------------------------
 
@@ -324,6 +396,9 @@ export function* ConfirmDialog() {
 
       <h3>Variant 4 – wizard (multiple useRender inline)</h3>
       <Variant4 />
+
+      <h3>Variant 5 – parent state reflected in dialog</h3>
+      <Variant5 />
     </div>
   );
 }

--- a/examples/tests/confirm-dialog.spec.ts
+++ b/examples/tests/confirm-dialog.spec.ts
@@ -144,4 +144,40 @@ test.describe("useRender / ConfirmDialog example", () => {
     await expect(page.getByTestId("v4-step-a")).toBeVisible();
     await expect(page.getByTestId("v4-result")).not.toBeAttached();
   });
+
+  // ── Variant 5: parent state reflected in useRender dialog ──
+
+  test("variant 5: dialog shows initial quantity", async ({ page }) => {
+    await expect(page.getByTestId("v5-dialog")).toBeVisible();
+    await expect(page.getByTestId("v5-quantity")).toHaveText("1");
+    await expect(page.getByTestId("v5-result")).not.toBeAttached();
+  });
+
+  test("variant 5: incrementing updates quantity in dialog", async ({ page }) => {
+    await page.getByTestId("v5-increment").click();
+    await expect(page.getByTestId("v5-quantity")).toHaveText("2");
+
+    await page.getByTestId("v5-increment").click();
+    await expect(page.getByTestId("v5-quantity")).toHaveText("3");
+  });
+
+  test("variant 5: decrementing updates quantity in dialog", async ({ page }) => {
+    await page.getByTestId("v5-increment").click();
+    await page.getByTestId("v5-increment").click();
+    await expect(page.getByTestId("v5-quantity")).toHaveText("3");
+
+    await page.getByTestId("v5-decrement").click();
+    await expect(page.getByTestId("v5-quantity")).toHaveText("2");
+  });
+
+  test("variant 5: confirming shows the current quantity", async ({ page }) => {
+    await page.getByTestId("v5-increment").click();
+    await page.getByTestId("v5-increment").click();
+    await page.getByTestId("v5-increment").click();
+    await expect(page.getByTestId("v5-quantity")).toHaveText("4");
+
+    await page.getByTestId("v5-confirm").click();
+    await expect(page.getByTestId("v5-dialog")).not.toBeAttached();
+    await expect(page.getByTestId("v5-answer")).toHaveText("4");
+  });
 });

--- a/examples/tests/confirm-dialog.spec.ts
+++ b/examples/tests/confirm-dialog.spec.ts
@@ -75,4 +75,73 @@ test.describe("useRender / ConfirmDialog example", () => {
     await expect(page.getByTestId("v2-result")).not.toBeAttached();
     await page.screenshot({ path: "test-results/confirm-v2-reset.png" });
   });
+
+  // ── Variant 3: wizard with multiple useRender (useResume) ──
+
+  test("variant 3: starts on name step", async ({ page }) => {
+    await expect(page.getByTestId("v3-step-name")).toBeVisible();
+    await expect(page.getByTestId("v3-step-color")).not.toBeAttached();
+    await expect(page.getByTestId("v3-result")).not.toBeAttached();
+  });
+
+  test("variant 3: completing name step advances to color step", async ({ page }) => {
+    await page.getByTestId("v3-name-input").fill("Alice");
+    await page.getByTestId("v3-name-next").click();
+
+    await expect(page.getByTestId("v3-step-name")).not.toBeAttached();
+    await expect(page.getByTestId("v3-step-color")).toBeVisible();
+  });
+
+  test("variant 3: completing both steps shows result", async ({ page }) => {
+    await page.getByTestId("v3-name-input").fill("Bob");
+    await page.getByTestId("v3-name-next").click();
+    await page.getByTestId("v3-color-green").click();
+
+    await expect(page.getByTestId("v3-step-color")).not.toBeAttached();
+    await expect(page.getByTestId("v3-answer")).toHaveText("Bob");
+    await expect(page.getByTestId("v3-color")).toHaveText("Green");
+  });
+
+  test("variant 3: reset returns to name step", async ({ page }) => {
+    await page.getByTestId("v3-name-input").fill("Eve");
+    await page.getByTestId("v3-name-next").click();
+    await page.getByTestId("v3-color-red").click();
+    await expect(page.getByTestId("v3-answer")).toHaveText("Eve");
+
+    await page.getByTestId("v3-reset").click();
+    await expect(page.getByTestId("v3-step-name")).toBeVisible();
+    await expect(page.getByTestId("v3-result")).not.toBeAttached();
+  });
+
+  // ── Variant 4: wizard with multiple useRender (inline) ──
+
+  test("variant 4: starts on step A", async ({ page }) => {
+    await expect(page.getByTestId("v4-step-a")).toBeVisible();
+    await expect(page.getByTestId("v4-step-b")).not.toBeAttached();
+    await expect(page.getByTestId("v4-result")).not.toBeAttached();
+  });
+
+  test("variant 4: selecting A advances to step B", async ({ page }) => {
+    await page.getByTestId("v4-a-2").click();
+
+    await expect(page.getByTestId("v4-step-a")).not.toBeAttached();
+    await expect(page.getByTestId("v4-step-b")).toBeVisible();
+  });
+
+  test("variant 4: completing both steps shows sum", async ({ page }) => {
+    await page.getByTestId("v4-a-3").click();
+    await page.getByTestId("v4-b-20").click();
+
+    await expect(page.getByTestId("v4-answer")).toHaveText("23");
+  });
+
+  test("variant 4: reset returns to step A", async ({ page }) => {
+    await page.getByTestId("v4-a-1").click();
+    await page.getByTestId("v4-b-10").click();
+    await expect(page.getByTestId("v4-answer")).toHaveText("11");
+
+    await page.getByTestId("v4-reset").click();
+    await expect(page.getByTestId("v4-step-a")).toBeVisible();
+    await expect(page.getByTestId("v4-result")).not.toBeAttached();
+  });
 });

--- a/src/__tests__/use-render.test.ts
+++ b/src/__tests__/use-render.test.ts
@@ -198,6 +198,136 @@ describe("useRender (Variant 1 – JSX child with useResume)", () => {
   });
 });
 
+describe("useRender – multiple sequential calls", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("two sequential useRender calls (inline variant)", () => {
+    let resumeFirst: (v: string) => void = () => {};
+    let resumeSecond: (v: number) => void = () => {};
+
+    function* Wizard() {
+      const name = yield* useRender<string>(({ resume }) => {
+        resumeFirst = resume;
+        return createElement("span", null, "step-1");
+      }, []);
+      const age = yield* useRender<number>(({ resume }) => {
+        resumeSecond = resume;
+        return createElement("span", null, "step-2");
+      }, []);
+      return createElement("p", null, `${name}:${age}`);
+    }
+
+    render(createElement(Wizard as never, {}), container);
+    expect(container.querySelector("span")?.textContent).toBe("step-1");
+
+    resumeFirst("Alice");
+    expect(container.querySelector("span")?.textContent).toBe("step-2");
+
+    resumeSecond(30);
+    expect(container.querySelector("p")?.textContent).toBe("Alice:30");
+  });
+
+  it("two sequential useRender calls (JSX child variant)", () => {
+    let resumeFirst: (v: string) => void = () => {};
+    let resumeSecond: (v: string) => void = () => {};
+
+    function* StepOne() {
+      const resume = yield* useResume<string>();
+      resumeFirst = resume;
+      return createElement("span", null, "step-1");
+    }
+
+    function* StepTwo() {
+      const resume = yield* useResume<string>();
+      resumeSecond = resume;
+      return createElement("span", null, "step-2");
+    }
+
+    function* Wizard() {
+      const a = yield* useRender<string>(createElement(StepOne as never, {}));
+      const b = yield* useRender<string>(createElement(StepTwo as never, {}));
+      return createElement("p", null, `${a}+${b}`);
+    }
+
+    render(createElement(Wizard as never, {}), container);
+    expect(container.querySelector("span")?.textContent).toBe("step-1");
+
+    resumeFirst("X");
+    expect(container.querySelector("span")?.textContent).toBe("step-2");
+
+    resumeSecond("Y");
+    expect(container.querySelector("p")?.textContent).toBe("X+Y");
+  });
+
+  it("three sequential useRender calls", () => {
+    const resumes: Array<(v: number) => void> = [];
+
+    function* Multi() {
+      const a = yield* useRender<number>(({ resume }) => {
+        resumes[0] = resume;
+        return createElement("span", null, "s1");
+      }, []);
+      const b = yield* useRender<number>(({ resume }) => {
+        resumes[1] = resume;
+        return createElement("span", null, "s2");
+      }, []);
+      const c = yield* useRender<number>(({ resume }) => {
+        resumes[2] = resume;
+        return createElement("span", null, "s3");
+      }, []);
+      return createElement("p", null, `${a}+${b}+${c}`);
+    }
+
+    render(createElement(Multi as never, {}), container);
+    expect(container.querySelector("span")?.textContent).toBe("s1");
+
+    resumes[0]?.(1);
+    expect(container.querySelector("span")?.textContent).toBe("s2");
+
+    resumes[1]?.(2);
+    expect(container.querySelector("span")?.textContent).toBe("s3");
+
+    resumes[2]?.(3);
+    expect(container.querySelector("p")?.textContent).toBe("1+2+3");
+  });
+
+  it("useRender after useState works correctly", () => {
+    let resumeFirst: (v: string) => void = () => {};
+    let resumeSecond: (v: string) => void = () => {};
+
+    function* Comp() {
+      const [count] = yield* useState(0);
+      const a = yield* useRender<string>(({ resume }) => {
+        resumeFirst = resume;
+        return createElement("span", null, `waiting-1:${count}`);
+      }, []);
+      const b = yield* useRender<string>(({ resume }) => {
+        resumeSecond = resume;
+        return createElement("span", null, `waiting-2:${count}`);
+      }, []);
+      return createElement("p", null, `${a}-${b}-${count}`);
+    }
+
+    render(createElement(Comp as never, {}), container);
+    expect(container.querySelector("span")?.textContent).toBe("waiting-1:0");
+
+    resumeFirst("A");
+    expect(container.querySelector("span")?.textContent).toBe("waiting-2:0");
+
+    resumeSecond("B");
+    expect(container.querySelector("p")?.textContent).toBe("A-B-0");
+  });
+});
+
 describe("useResume", () => {
   let container: HTMLElement;
 

--- a/src/render/hooks-runtime.ts
+++ b/src/render/hooks-runtime.ts
@@ -403,6 +403,10 @@ export function runHooks(
     result = gen.next(value);
   }
 
+  // Track where the generator paused so `resume` can continue from
+  // the correct hook index when the generator advances past a useRender.
+  instance.resumeHookIndex = hookIndex;
+
   // Validate hook count on generator completion.
   if (result.done) {
     if (instance.finalHookCount !== undefined && hookIndex !== instance.finalHookCount) {
@@ -422,6 +426,71 @@ export function runHooks(
     vnode: (result.value as Child) ?? null,
     gen: result.done ? undefined : gen,
     cancelled: false,
+  };
+}
+
+/**
+ * Continue a paused generator, processing any hook descriptors it yields.
+ *
+ * When `useRender`'s `resumeCallback` resolves and calls `gen.next()`, the
+ * generator may advance past the resolved `useRender` into another hook
+ * (`useRender`, `useState`, etc.). This function handles that by looping
+ * over yielded descriptors — the same way `runHooks` does — until the
+ * generator yields a non-descriptor (VNode) or returns.
+ *
+ * @param instance - The component instance whose generator to continue.
+ * @param rerender - Function to trigger a rerender.
+ * @param resume   - Function to resume a paused generator (for nested `useRender`).
+ * @returns An object with:
+ *   - `vnode`: the yielded/returned VNode (Child).
+ *   - `done`: true if the generator returned (no more yields).
+ */
+export function resumeGenerator(
+  instance: ComponentInstance,
+  rerender: () => Promise<void>,
+  resume: () => void,
+): { vnode: Child; done: boolean } {
+  const gen = instance.gen;
+  if (!gen) return { vnode: null, done: true };
+
+  let hookIndex = instance.resumeHookIndex;
+  let result = gen.next();
+
+  while (!result.done && isHookDescriptor(result.value)) {
+    const descriptor = result.value as HookDescriptor;
+    const value = processOneDescriptor(
+      descriptor,
+      hookIndex++,
+      instance.hookStates,
+      instance.cleanupFns,
+      instance.pendingEffects,
+      rerender,
+      resume,
+      instance,
+    );
+    result = gen.next(value);
+  }
+
+  instance.resumeHookIndex = hookIndex;
+
+  if (result.done) {
+    instance.gen = undefined;
+    if (instance.finalHookCount !== undefined && hookIndex !== instance.finalHookCount) {
+      const componentName = instance.component.name || "Anonymous";
+      throw new Error(
+        `Hook count mismatch in "${componentName}": ` +
+          `previous render completed with ${instance.finalHookCount} hooks, ` +
+          `but this render completed with ${hookIndex}. ` +
+          `Hooks must be called in the same order and quantity on every render. ` +
+          `Do not call hooks inside conditions, loops, or after early returns.`,
+      );
+    }
+    instance.finalHookCount = hookIndex;
+  }
+
+  return {
+    vnode: (result.value as Child) ?? null,
+    done: result.done === true,
   };
 }
 

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -36,7 +36,7 @@ import {
   mergedProps,
   stripFrameworkDirectives,
 } from "./helpers";
-import { flushEffects, runHooks } from "./hooks-runtime";
+import { flushEffects, resumeGenerator, runHooks } from "./hooks-runtime";
 import { isPatchActive } from "./patch-queue";
 import { applyProps } from "./props";
 import { reconcileSlots } from "./reconciler";
@@ -263,11 +263,7 @@ export function mountComponent(
 
     let vnode: Child;
     try {
-      const { value, done } = instance.gen.next();
-      if (done) {
-        instance.gen = undefined;
-      }
-      vnode = (value as Child) ?? null;
+      ({ vnode } = resumeGenerator(instance, rerender, resume));
     } finally {
       _setCtxMap(prevCtx);
     }
@@ -454,6 +450,7 @@ export function mountComponent(
     pendingRerender: false,
     renderResolvers: [],
     priority,
+    resumeHookIndex: 0,
     _executeRerender: () => executeRerender(true),
     rerender,
     consumedContexts: new Set(),

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -486,6 +486,16 @@ export interface ComponentInstance {
   priority: number;
 
   /**
+   * Hook index at which the generator last paused (yielded a non-descriptor,
+   * e.g. inside `useRender`). Used by `resume()` to continue processing
+   * hook descriptors from the correct index when the generator advances
+   * past a `useRender` to the next hook.
+   *
+   * Reset to 0 by `runHooks` at the start of each full render cycle.
+   */
+  resumeHookIndex: number;
+
+  /**
    * Total hook count from the first completed (done=true) generator run.
    *
    * `undefined` until the generator has fully returned at least once


### PR DESCRIPTION
## Summary

The `resume()` function in `mount.ts` called `gen.next()` directly without processing hook descriptors, so when a resolved `useRender` advanced the generator into a second `useRender` (or any other hook), the descriptor was treated as a VNode, causing incorrect behavior.

## Changes

- **`src/render/types.ts`** — Added `resumeHookIndex` to `ComponentInstance` to track where the generator paused
- **`src/render/hooks-runtime.ts`** — Added `resumeGenerator()` which loops over hook descriptors the same way `runHooks` does; `runHooks` now sets `instance.resumeHookIndex` when the generator pauses
- **`src/render/mount.ts`** — `resume()` now uses `resumeGenerator()` instead of raw `gen.next()`
- **`src/__tests__/use-render.test.ts`** — 4 new tests: two sequential calls (inline + JSX variant), three sequential calls, and useRender after useState

## Closes #133

## Verification

All `npm` checks passed: knip, lint, build, typecheck:examples, test (246 passed), test:visual (366 passed).

## CLAUDE.md Update

No changes needed — no new public API or workflow changes.