### PR TITLE
perf: skip component generator when only children change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ function* Counter(_props: object) {
 
 Example components live in `examples/src/components/`. The app entry point is `examples/src/main.tsx`, which renders a tabbed view of all demos.
 
-**Top-level demos** (each a tab in main.tsx): `Counter`, `TodoList`, `ThemeDemo`, `DataFetcher`/`ResolveRawDemo`, `HooksShowcase`, `ShownDemo`, `ConfirmDialog`, `EffectDemo`, `TransitionDemo`, `ContextDemo`, `LazyContextDemo`, `AbortSignalEffectDemo`, `KeyShuffleDemo`, `DepsDemo`, `PortalDemo`.
+**Top-level demos** (each a tab in main.tsx): `Counter`, `TodoList`, `ThemeDemo`, `DataFetcher`/`ResolveRawDemo`, `HooksShowcase`, `ShownDemo`, `ConfirmDialog`, `EffectDemo`, `TransitionDemo`, `ContextDemo`, `LazyContextDemo`, `AbortSignalEffectDemo`, `KeyShuffleDemo`, `DepsDemo`, `ChildrenOptDemo`, `PortalDemo`.
 
 **Multi-file demos** split one-component-per-file:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -874,6 +874,40 @@ function* App() {
 
 ---
 
+### Children reconciliation optimization
+
+When a parent rerenders and a child component receives new `children` via JSX but its own props are unchanged, the renderer **skips the component's generator** and reconciles only the children within its stored output VNode tree.
+
+This avoids unnecessary generator re-execution for "wrapper" or "layout" components whose job is simply to render their children inside some markup.
+
+```tsx
+function* Card({ title, children }: { title: string; children?: Child | Child[] }) {
+  return (
+    <div class="card">
+      <h2>{title}</h2>
+      <div class="body">{children}</div>
+    </div>
+  );
+}
+
+function* App() {
+  const [count, setCount] = yield* useState(0);
+  return (
+    <Card title="Counter">
+      {/* Card's generator won't re-run — only children are reconciled */}
+      <span>{count}</span>
+      <button onClick={() => setCount(c => c + 1)}>+</button>
+    </Card>
+  );
+}
+```
+
+**Fallback conditions** — the optimization falls back to a full rerender when:
+- The component transforms or filters children (no contiguous reference match)
+- The component ignores children entirely
+- All passed children are primitives (no VNode references to track)
+- `$deps` is set (takes full control of the skip decision)
+
 ### `key`
 
 ```tsx

--- a/examples/src/components/ChildrenOptDemo.tsx
+++ b/examples/src/components/ChildrenOptDemo.tsx
@@ -1,0 +1,78 @@
+/**
+ * ChildrenOptDemo — demonstrates the children-only reconciliation optimization.
+ *
+ * When a parent rerenders but a child wrapper's own props haven't changed,
+ * the wrapper's generator is skipped and only the passed children are
+ * reconciled. Render counters show the optimization in action.
+ */
+import type { Child } from "yract";
+import { useRef, useState } from "yract";
+
+/** A wrapper that passes children through. Tracks its own render count via ref. */
+function* Wrapper({ label, children }: { label: string; children?: Child | Child[] }) {
+  const countRef = yield* useRef(0);
+  countRef.current++;
+
+  return (
+    <div
+      data-testid={`wrapper-${label}`}
+      style={{
+        border: "1px solid #ccc",
+        borderRadius: "6px",
+        padding: "0.75rem",
+        marginBottom: "0.75rem",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "0.5rem" }}>
+        <strong>{label}</strong>
+        <span data-testid={`render-count-${label}`} style={{ color: "#888", fontSize: "0.85rem" }}>
+          renders: {countRef.current}
+        </span>
+      </div>
+      <div data-testid={`content-${label}`}>{children}</div>
+    </div>
+  );
+}
+
+/** A child component that also tracks renders via ref. */
+function* RenderChild({ value }: { value: number }) {
+  const countRef = yield* useRef(0);
+  countRef.current++;
+
+  return (
+    <span data-testid="child-value">
+      value={value} (child renders: <span data-testid="child-render-count">{countRef.current}</span>
+      )
+    </span>
+  );
+}
+
+export function* ChildrenOptDemo() {
+  const [count, setCount] = yield* useState(0);
+
+  return (
+    <div data-testid="children-opt-demo">
+      <h2>Children Optimization</h2>
+      <p style={{ color: "#555", marginBottom: "1rem" }}>
+        Click the button to increment the counter. The &ldquo;Optimized&rdquo; wrapper&apos;s render
+        count stays at 1 because only its children change &mdash; the generator is skipped.
+      </p>
+
+      <button
+        data-testid="increment-btn"
+        onClick={() => setCount((c: number) => c + 1)}
+        style={{ padding: "0.4rem 0.9rem", marginBottom: "1rem" }}
+      >
+        Count: {count}
+      </button>
+
+      <Wrapper label="optimized">
+        <RenderChild value={count} />
+      </Wrapper>
+
+      <Wrapper label="with-prop" $shown={count >= 0}>
+        <span data-testid="static-child">This wrapper always has the same children</span>
+      </Wrapper>
+    </div>
+  );
+}

--- a/examples/src/main.tsx
+++ b/examples/src/main.tsx
@@ -5,6 +5,7 @@
  */
 import { createRoot, useState } from "yract";
 import { AbortSignalEffectDemo } from "./components/AbortSignalEffectDemo";
+import { ChildrenOptDemo } from "./components/ChildrenOptDemo";
 import { ConfirmDialog } from "./components/ConfirmDialog";
 import { ContextDemo } from "./components/ContextDemo";
 import { Counter } from "./components/Counter";
@@ -36,6 +37,7 @@ type Tab =
   | "abort-signal"
   | "key-shuffle"
   | "deps"
+  | "children-opt"
   | "portal";
 
 const tabs: { id: Tab; label: string }[] = [
@@ -54,6 +56,7 @@ const tabs: { id: Tab; label: string }[] = [
   { id: "abort-signal", label: "AbortSignal Effect" },
   { id: "key-shuffle", label: "Key Shuffle" },
   { id: "deps", label: "$deps prop" },
+  { id: "children-opt", label: "Children Opt" },
   { id: "portal", label: "createPortal" },
 ];
 
@@ -113,6 +116,7 @@ function* App() {
         <AbortSignalEffectDemo $shown={activeTab === "abort-signal"} />
         <KeyShuffleDemo $shown={activeTab === "key-shuffle"} />
         <DepsDemo $shown={activeTab === "deps"} />
+        <ChildrenOptDemo $shown={activeTab === "children-opt"} />
         <PortalDemo $shown={activeTab === "portal"} />
       </div>
     </div>

--- a/examples/tests/children-opt.spec.ts
+++ b/examples/tests/children-opt.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import { clickTab, goToApp } from "./helpers";
+
+test.describe("Children Optimization demo", () => {
+  test.beforeEach(async ({ page }) => {
+    await goToApp(page);
+    await clickTab(page, "Children Opt");
+  });
+
+  test("renders the demo with initial state", async ({ page }) => {
+    await expect(page.getByTestId("children-opt-demo")).toBeVisible();
+    await expect(page.getByTestId("increment-btn")).toHaveText("Count: 0");
+    await expect(page.getByTestId("child-value")).toContainText("value=0");
+    await page.screenshot({ path: "test-results/children-opt-initial.png" });
+  });
+
+  test("wrapper render count stays at 1 after incrementing", async ({ page }) => {
+    // Initial render count should be 1
+    await expect(page.getByTestId("render-count-optimized")).toHaveText("renders: 1");
+
+    // Click increment several times
+    await page.getByTestId("increment-btn").click();
+    await page.getByTestId("increment-btn").click();
+    await page.getByTestId("increment-btn").click();
+
+    // Child value updated
+    await expect(page.getByTestId("child-value")).toContainText("value=3");
+
+    // Wrapper render count should still be 1 — optimization skipped it
+    await expect(page.getByTestId("render-count-optimized")).toHaveText("renders: 1");
+    await page.screenshot({ path: "test-results/children-opt-skipped.png" });
+  });
+
+  test("child component re-executes when its props change", async ({ page }) => {
+    await expect(page.getByTestId("child-render-count")).toHaveText("1");
+
+    await page.getByTestId("increment-btn").click();
+    // Child's own render count increases because its props changed
+    await expect(page.getByTestId("child-render-count")).toHaveText("2");
+
+    await page.getByTestId("increment-btn").click();
+    await expect(page.getByTestId("child-render-count")).toHaveText("3");
+  });
+});

--- a/examples/tests/helpers.ts
+++ b/examples/tests/helpers.ts
@@ -23,6 +23,7 @@ const tabIds: Record<string, string> = {
   "AbortSignal Effect": "tab-abort-signal",
   "Key Shuffle": "tab-key-shuffle",
   "$deps prop": "tab-deps",
+  "Children Opt": "tab-children-opt",
   createPortal: "tab-portal",
 };
 

--- a/src/__tests__/children-optimization.test.ts
+++ b/src/__tests__/children-optimization.test.ts
@@ -1,0 +1,499 @@
+import { createContext, useContext } from "../context";
+import { useResolve, useState } from "../hooks";
+import { createElement } from "../jsx";
+import { render } from "../render";
+
+// jsdom is provided by vitest (see vitest.config.ts)
+
+describe("children-only reconciliation optimization", () => {
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("skips generator re-execution when only children change", () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(Wrapper as never, {}, createElement("span", null, `phase-${phase}`));
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("phase-0");
+
+    // Parent rerenders → Wrapper gets new children VNode, but same own props
+    setPhase(1);
+    // Wrapper generator should NOT re-execute
+    expect(wrapperRuns).toBe(1);
+    // But children should update in the DOM
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("phase-1");
+  });
+
+  it("rerenders when non-children props change", () => {
+    let wrapperRuns = 0;
+    let setLabel: (v: string) => void = () => {};
+
+    function* Wrapper({ label, children }: { label: string; children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, label, ": ", children);
+    }
+
+    function* Parent() {
+      const [label, sl] = yield* useState("hello");
+      setLabel = sl;
+      return createElement(Wrapper as never, { label }, createElement("span", null, "child"));
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+
+    setLabel("world");
+    // Non-children prop changed → full rerender
+    expect(wrapperRuns).toBe(2);
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("world: child");
+  });
+
+  it("handles children added (empty → non-empty)", () => {
+    let wrapperRuns = 0;
+    let setShowChild: (v: boolean) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, children);
+    }
+
+    function* Parent() {
+      const [showChild, ss] = yield* useState(false);
+      setShowChild = ss;
+      if (!showChild) {
+        return createElement(Wrapper as never, {});
+      }
+      return createElement(Wrapper as never, {}, createElement("span", null, "hello"));
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector("span")).toBeNull();
+
+    setShowChild(true);
+    // Children changed from none to some — optimization handles this
+    // (falls back to rerender since childrenPosition was undefined → null transition)
+    expect(container.querySelector("span")?.textContent).toBe("hello");
+  });
+
+  it("handles children removed (non-empty → empty)", () => {
+    let wrapperRuns = 0;
+    let setShowChild: (v: boolean) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, children);
+    }
+
+    function* Parent() {
+      const [showChild, ss] = yield* useState(true);
+      setShowChild = ss;
+      if (showChild) {
+        return createElement(Wrapper as never, {}, createElement("span", null, "hello"));
+      }
+      return createElement(Wrapper as never, {});
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector("span")?.textContent).toBe("hello");
+
+    setShowChild(false);
+    // Children removed — the optimization reconciles the output
+    expect(container.querySelector("span")).toBeNull();
+  });
+
+  it("updates child component props through the optimization", () => {
+    let childRuns = 0;
+    let setCount: (v: number) => void = () => {};
+
+    function* Child({ value }: { value: number }) {
+      childRuns++;
+      return createElement("span", { "data-testid": "child" }, `val-${value}`);
+    }
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      return createElement("div", null, children);
+    }
+
+    function* Parent() {
+      const [count, sc] = yield* useState(0);
+      setCount = sc;
+      return createElement(Wrapper as never, {}, createElement(Child as never, { value: count }));
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(childRuns).toBe(1);
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe("val-0");
+
+    setCount(5);
+    // Child should rerender with new props through the optimization
+    expect(childRuns).toBe(2);
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe("val-5");
+  });
+
+  it("falls back to full rerender when component filters children", () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+
+    function* FilterWrapper({ children }: { children?: unknown[] }) {
+      wrapperRuns++;
+      // Filter: only keep first child (breaks contiguous match when count > 1)
+      const filtered = (children ?? []).slice(0, 1);
+      return createElement("div", { "data-testid": "wrapper" }, ...filtered);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(
+        FilterWrapper as never,
+        {},
+        createElement("span", null, `kept-${phase}`),
+        createElement("b", null, `dropped-${phase}`),
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector("b")).toBeNull();
+
+    setPhase(1);
+    // FilterWrapper drops second child → no full contiguous match → full rerender
+    expect(wrapperRuns).toBe(2);
+    expect(container.querySelector("span")?.textContent).toBe("kept-1");
+  });
+
+  it("falls back when component ignores children", () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+
+    function* IgnoresChildren(_props: { children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, "static");
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(
+        IgnoresChildren as never,
+        {},
+        createElement("span", null, `phase-${phase}`),
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("static");
+
+    setPhase(1);
+    // Children not used → no contiguous match → full rerender
+    expect(wrapperRuns).toBe(2);
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("static");
+  });
+
+  it("$deps takes full control — children optimization skipped", () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      // $deps freezes the component — no rerender regardless of children
+      return createElement(
+        Wrapper as never,
+        { $deps: [] },
+        createElement("span", null, `phase-${phase}`),
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+
+    setPhase(1);
+    // $deps=[] → frozen, no rerender, children not reconciled
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector("span")?.textContent).toBe("phase-0");
+  });
+
+  it("context change still triggers rerender", () => {
+    const Ctx = createContext("default");
+    let wrapperRuns = 0;
+    let setCtxVal: (v: string) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      const ctx = yield* useContext(Ctx);
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, ctx, " ", children);
+    }
+
+    function* Parent() {
+      const [val, sv] = yield* useState("v1");
+      setCtxVal = sv;
+      return createElement(
+        Ctx.Provider as never,
+        { value: val },
+        createElement(Wrapper as never, {}, createElement("span", null, "child")),
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("v1 child");
+
+    setCtxVal("v2");
+    // Context changed → Wrapper must rerender
+    expect(wrapperRuns).toBe(2);
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("v2 child");
+  });
+
+  it("preserves component state across children-only updates", () => {
+    let setPhase: (v: number) => void = () => {};
+    let setInner: (v: number) => void = () => {};
+
+    function* Stateful() {
+      const [inner, si] = yield* useState(0);
+      setInner = si;
+      return createElement("span", { "data-testid": "stateful" }, `inner-${inner}`);
+    }
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      return createElement("div", null, children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(
+        Wrapper as never,
+        {},
+        createElement("p", null, `phase-${phase}`),
+        createElement(Stateful as never, {}),
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(container.querySelector('[data-testid="stateful"]')?.textContent).toBe("inner-0");
+
+    // Build up state in the nested stateful component
+    setInner(42);
+    expect(container.querySelector('[data-testid="stateful"]')?.textContent).toBe("inner-42");
+
+    // Trigger parent rerender with children-only change
+    setPhase(1);
+    // State should be preserved
+    expect(container.querySelector('[data-testid="stateful"]')?.textContent).toBe("inner-42");
+    expect(container.querySelector("p")?.textContent).toBe("phase-1");
+  });
+
+  it("works with multiple children", () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(
+        Wrapper as never,
+        {},
+        createElement("span", null, `a-${phase}`),
+        createElement("span", null, `b-${phase}`),
+        createElement("span", null, `c-${phase}`),
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    const spans = container.querySelectorAll("span");
+    expect(spans).toHaveLength(3);
+
+    setPhase(1);
+    expect(wrapperRuns).toBe(1);
+    const updatedSpans = container.querySelectorAll("span");
+    expect(updatedSpans[0]?.textContent).toBe("a-1");
+    expect(updatedSpans[1]?.textContent).toBe("b-1");
+    expect(updatedSpans[2]?.textContent).toBe("c-1");
+  });
+
+  it("works with nested wrapper components (recursive optimization)", () => {
+    let outerRuns = 0;
+    let innerRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+
+    function* Inner({ children }: { children?: unknown }) {
+      innerRuns++;
+      return createElement("div", { "data-testid": "inner" }, children);
+    }
+
+    function* Outer({ children }: { children?: unknown }) {
+      outerRuns++;
+      return createElement(Inner as never, {}, children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(Outer as never, {}, createElement("span", null, `phase-${phase}`));
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(outerRuns).toBe(1);
+    expect(innerRuns).toBe(1);
+
+    setPhase(1);
+    // Outer skipped via children optimization; Inner also skipped since
+    // Outer's output passes children through without transformation
+    expect(outerRuns).toBe(1);
+    expect(innerRuns).toBe(1);
+    expect(container.querySelector("span")?.textContent).toBe("phase-1");
+  });
+
+  it("handles children with mixed VNodes and primitives", () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      wrapperRuns++;
+      return createElement("div", { "data-testid": "wrapper" }, children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(
+        Wrapper as never,
+        {},
+        "prefix: ",
+        createElement("span", null, `phase-${phase}`),
+        " suffix",
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+
+    setPhase(1);
+    // Mixed children with VNodes and primitives — VNode is tracked
+    expect(wrapperRuns).toBe(1);
+    expect(container.querySelector("span")?.textContent).toBe("phase-1");
+  });
+
+  it("does not disrupt paused generator (useResolve pending) when children change", async () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+    let resolvePromise: (v: string) => void = () => {};
+
+    function* Wrapper({ children }: { children?: unknown }) {
+      wrapperRuns++;
+      const data = yield* useResolve(
+        {
+          fn: () =>
+            new Promise<string>((resolve) => {
+              resolvePromise = resolve;
+            }),
+          loading: createElement("span", { "data-testid": "loading" }, "Loading..."),
+        },
+        [],
+      );
+      return createElement("div", { "data-testid": "wrapper" }, data, " ", children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      return createElement(Wrapper as never, {}, createElement("span", null, `phase-${phase}`));
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    // Should show loading spinner (generator is paused)
+    expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe("Loading...");
+
+    // Parent rerenders with new children while generator is paused
+    setPhase(1);
+    // Generator must NOT be restarted — run count stays at 1
+    expect(wrapperRuns).toBe(1);
+    // Loading spinner should still be visible
+    expect(container.querySelector('[data-testid="loading"]')?.textContent).toBe("Loading...");
+
+    // Resolve the promise — generator rerenders from the top with resolved data
+    resolvePromise("fetched");
+    await new Promise((r) => setTimeout(r, 0));
+    // Generator rerenders (2nd run) with the resolved data
+    expect(wrapperRuns).toBe(2);
+    // New children should appear (props were updated during pause)
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("fetched phase-1");
+  });
+
+  it("does not rerender when component returns null and children change", () => {
+    let wrapperRuns = 0;
+    let setPhase: (v: number) => void = () => {};
+    let setVisible: (v: boolean) => void = () => {};
+
+    function* ConditionalWrapper({ visible, children }: { visible: boolean; children?: unknown }) {
+      wrapperRuns++;
+      if (!visible) return null;
+      return createElement("div", { "data-testid": "wrapper" }, children);
+    }
+
+    function* Parent() {
+      const [phase, sp] = yield* useState(0);
+      setPhase = sp;
+      const [visible, sv] = yield* useState(false);
+      setVisible = sv;
+      return createElement(
+        ConditionalWrapper as never,
+        { visible },
+        createElement("span", null, `phase-${phase}`),
+      );
+    }
+
+    render(createElement(Parent as never, {}), container);
+    expect(wrapperRuns).toBe(1);
+    // Component returned null — nothing visible
+    expect(container.querySelector('[data-testid="wrapper"]')).toBeNull();
+
+    // Change children while component renders null
+    setPhase(1);
+    // Should NOT rerender — would just return null again (wasted work)
+    expect(wrapperRuns).toBe(1);
+
+    // Now make it visible with a non-children prop change
+    setVisible(true);
+    // Full rerender since non-children prop changed
+    expect(wrapperRuns).toBe(2);
+    // Should render with the latest children
+    expect(container.querySelector('[data-testid="wrapper"]')?.textContent).toBe("phase-1");
+  });
+});

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -89,6 +89,176 @@ export function onlyPatchChanged(a: InternalProps, b: InternalProps): boolean {
 }
 
 /**
+ * Shallow equality check excluding the `children` key.
+ *
+ * Used as the primary memoization gate in the children-only reconciliation
+ * optimization. When all non-children props are unchanged, the component
+ * generator can be skipped and only the children subtree is reconciled.
+ *
+ * @param a - Previous props (from `Slot.props`).
+ * @param b - Next props (from the new VNode).
+ */
+export function shallowEqualExcludingChildren(a: InternalProps, b: InternalProps): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  let aCount = 0;
+  let bCount = 0;
+  for (const k of aKeys) if (k !== "children") aCount++;
+  for (const k of bKeys) if (k !== "children") bCount++;
+  if (aCount !== bCount) return false;
+  for (const k of aKeys) {
+    if (k === "children") continue;
+    if (!Object.is(a[k], b[k])) return false;
+  }
+  return true;
+}
+
+/**
+ * Returns true when `a` and `b` differ **only** in the `$patch` prop
+ * (and possibly `children`) and all other content props are identical.
+ *
+ * Like `onlyPatchChanged` but also skips the `children` key.
+ *
+ * @param a - Previous props.
+ * @param b - Next props.
+ */
+export function onlyPatchChangedExcludingChildren(a: InternalProps, b: InternalProps): boolean {
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  let aCount = 0;
+  let bCount = 0;
+  for (const k of aKeys) if (k !== "children") aCount++;
+  for (const k of bKeys) if (k !== "children") bCount++;
+  if (aCount !== bCount) return false;
+  let patchDiffers = false;
+  for (const k of aKeys) {
+    if (k === "children") continue;
+    if (Object.is(a[k], b[k])) continue;
+    if (k === "$patch") {
+      patchDiffers = true;
+      continue;
+    }
+    return false;
+  }
+  return patchDiffers;
+}
+
+/**
+ * Compare two `children` arrays element-wise via `Object.is`.
+ *
+ * Returns `true` when the arrays have the same length and every element
+ * is identical. `undefined` is treated as an empty array.
+ */
+export function childrenShallowEqual(a: Child[] | undefined, b: Child[] | undefined): boolean {
+  const aLen = a?.length ?? 0;
+  const bLen = b?.length ?? 0;
+  if (aLen !== bLen) return false;
+  if (aLen === 0) return true;
+  for (let i = 0; i < aLen; i++) {
+    if (!Object.is((a as Child[])[i], (b as Child[])[i])) return false;
+  }
+  return true;
+}
+
+/**
+ * Walk an output VNode tree to find where `passedChildren` appear as a
+ * contiguous run of children (matched by reference, VNode objects only).
+ *
+ * Returns `{ path, startIdx, count }` or `null` if no contiguous match
+ * is found. Only VNode objects are matched by reference — primitives are
+ * skipped to avoid ambiguity.
+ *
+ * @param vnode - The output VNode tree to search.
+ * @param passedChildren - The children array from props.
+ * @param path - Current path (array of child indices) for recursion.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: VNode tree walk with contiguous reference matching
+export function findChildrenPosition(
+  vnode: VNode,
+  passedChildren: Child[],
+  path: number[],
+): { path: number[]; startIdx: number; count: number } | null {
+  // Filter to only VNode references for matching (skip primitives)
+  const vnodeRefs = passedChildren.filter(isVNode);
+  if (vnodeRefs.length === 0) return null;
+
+  const children = vnode.children;
+  // Try to find a contiguous run of vnodeRefs in this node's children
+  const firstRef = vnodeRefs[0] as VNode;
+  for (let startIdx = 0; startIdx < children.length; startIdx++) {
+    if (children[startIdx] === firstRef) {
+      // Check if all vnodeRefs appear contiguously starting here
+      let matched = true;
+      let childIdx = startIdx;
+      let refIdx = 0;
+      while (refIdx < vnodeRefs.length && childIdx < children.length) {
+        const child = children[childIdx];
+        if (isVNode(child)) {
+          if (child !== vnodeRefs[refIdx]) {
+            matched = false;
+            break;
+          }
+          refIdx++;
+        }
+        childIdx++;
+      }
+      if (matched && refIdx === vnodeRefs.length) {
+        return { path, startIdx, count: childIdx - startIdx };
+      }
+    }
+  }
+
+  // Recurse into VNode children
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    if (isVNode(child) && child.children.length > 0) {
+      const result = findChildrenPosition(child, passedChildren, [...path, i]);
+      if (result) return result;
+    }
+  }
+  return null;
+}
+
+/**
+ * Navigate the stored VNode tree via `path`, shallow-clone nodes on the
+ * path, and splice `newChildren` at the tracked position.
+ *
+ * Only O(path.length) clones are made — the rest of the tree is shared.
+ *
+ * @param vnode - The stored output VNode.
+ * @param position - The tracked children position.
+ * @param newChildren - The new children to splice in.
+ */
+export function patchOutputVNode(
+  vnode: VNode,
+  position: { path: number[]; startIdx: number; count: number },
+  newChildren: Child[],
+): VNode {
+  if (position.path.length === 0) {
+    // Replace at this level
+    const newChildArray = [...vnode.children];
+    newChildArray.splice(position.startIdx, position.count, ...newChildren);
+    return { type: vnode.type, props: vnode.props, children: newChildArray };
+  }
+
+  // Navigate deeper: clone this node and the child at path[0]
+  const idx = position.path[0] as number;
+  const newChildArray = [...vnode.children];
+  const childAtIdx = newChildArray[idx];
+  if (!isVNode(childAtIdx)) return vnode; // safety
+  newChildArray[idx] = patchOutputVNode(
+    childAtIdx,
+    {
+      path: position.path.slice(1),
+      startIdx: position.startIdx,
+      count: position.count,
+    },
+    newChildren,
+  );
+  return { type: vnode.type, props: vnode.props, children: newChildArray };
+}
+
+/**
  * Recursively flatten Fragment VNodes into a flat list of non-Fragment children.
  *
  * Fragments (`<>…</>`) are virtual grouping nodes that produce no DOM element.

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -30,9 +30,11 @@ import {
 import { $USE_EFFECT } from "../hooks/descriptors";
 import { type Child, type Component, Fragment, type InternalProps, Portal } from "../jsx";
 import {
+  findChildrenPosition,
   getPatchMode,
   isComponentNode,
   isShown,
+  isVNode,
   mergedProps,
   stripFrameworkDirectives,
 } from "./helpers";
@@ -268,6 +270,9 @@ export function mountComponent(
       _setCtxMap(prevCtx);
     }
 
+    // Track output VNode and children position for children-only optimization.
+    _trackChildrenPosition(instance, vnode);
+
     commitOrDefer(instance, vnode);
   }
 
@@ -350,6 +355,9 @@ export function mountComponent(
         instance.pendingRerender = false;
         continue;
       }
+
+      // Track output VNode and children position for children-only optimization.
+      _trackChildrenPosition(instance, vnode);
 
       // ── Commit ──
       if (!mounted) {
@@ -513,4 +521,20 @@ export function mountContextProvider(
     _setCtxMap(prevCtxMap);
   }
   return { fragment, endMarker, childSlots };
+}
+
+/**
+ * Store the output VNode and compute the children position on a component
+ * instance for the children-only reconciliation optimization.
+ *
+ * @internal
+ */
+function _trackChildrenPosition(instance: ComponentInstance, vnode: Child): void {
+  instance.lastOutputVNode = vnode;
+  const passedChildren = (instance.props as { children?: Child[] }).children;
+  if (passedChildren && passedChildren.length > 0 && vnode != null && isVNode(vnode)) {
+    instance.childrenPosition = findChildrenPosition(vnode, passedChildren, []);
+  } else {
+    instance.childrenPosition = passedChildren?.length ? null : undefined;
+  }
 }

--- a/src/render/reconciler.ts
+++ b/src/render/reconciler.ts
@@ -48,6 +48,8 @@ import type { Child, Component, InternalProps, VNode } from "../jsx";
 import { Portal } from "../jsx";
 import { acquirePortalDelegation } from "./delegation";
 import {
+  childrenShallowEqual,
+  findChildrenPosition,
   flattenChildren,
   getPatchMode,
   isComponentNode,
@@ -56,7 +58,10 @@ import {
   isVNode,
   mergedProps,
   onlyPatchChanged,
+  onlyPatchChangedExcludingChildren,
+  patchOutputVNode,
   shallowEqual,
+  shallowEqualExcludingChildren,
   stripDeferred,
   stripFrameworkDirectives,
 } from "./helpers";
@@ -588,10 +593,20 @@ function* reconcileComponent(
     // ── Same component type at same position ──
     if (prevSlot?.type === vnode.type) {
       // $deps replaces the shallowEqual check when present on the new VNode.
+      // For regular components, exclude children from the comparison — they
+      // are reconciled separately below. Providers don't have a generator to
+      // skip, so use the standard shallowEqual that includes children.
       const propsUnchanged = newDeps
         ? !depsChanged(prevSlot.props.$deps, newDeps)
-        : shallowEqual(prevSlot.props, allProps);
-      const patchOnly = !propsUnchanged && !newDeps && onlyPatchChanged(prevSlot.props, allProps);
+        : providerCtx
+          ? shallowEqual(prevSlot.props, allProps)
+          : shallowEqualExcludingChildren(prevSlot.props, allProps);
+      const patchOnly =
+        !propsUnchanged &&
+        !newDeps &&
+        (providerCtx
+          ? onlyPatchChanged(prevSlot.props, allProps)
+          : onlyPatchChangedExcludingChildren(prevSlot.props, allProps));
       if (propsUnchanged || patchOnly) {
         const inst = prevSlot.componentInstance;
         // When $deps says "unchanged", still update prevSlot.props so next
@@ -610,6 +625,52 @@ function* reconcileComponent(
         if (patchOnly) {
           prevSlot.props = slotProps;
         }
+
+        // Children-only reconciliation: when non-children props are stable
+        // but children differ, skip the generator and reconcile only the
+        // children within the stored output VNode. Guarded by !newDeps —
+        // $deps takes full control when present.
+        if (!newDeps && inst) {
+          const prevChildren = (prevSlot.props as { children?: Child[] }).children;
+          const newChildren = (allProps as { children?: Child[] }).children;
+          if (!childrenShallowEqual(prevChildren, newChildren)) {
+            if (inst.childrenPosition != null && inst.lastOutputVNode != null) {
+              // Patch stored VNode with new children, reconcile output
+              const patchedVNode = patchOutputVNode(
+                inst.lastOutputVNode as VNode,
+                inst.childrenPosition,
+                newChildren ?? [],
+              );
+              inst.lastOutputVNode = patchedVNode;
+              inst.childrenPosition = findChildrenPosition(patchedVNode, newChildren ?? [], []);
+              inst.props = allProps;
+              prevSlot.props = slotProps;
+              const parent = inst.endMarker.parentNode as HTMLElement;
+              inst.slots = yield* reconcileSlotsGen(
+                parent,
+                inst.slots,
+                [patchedVNode],
+                inst.endMarker,
+              );
+              // No flushEffects — generator didn't run, no new effects queued
+            } else if (inst.lastOutputVNode == null || inst.gen) {
+              // Component returned null (children aren't visible) or generator
+              // is paused (useResolve/useRender). Don't rerender — just update
+              // props so the next render/resume sees the new children.
+              inst.props = allProps;
+              prevSlot.props = slotProps;
+            } else {
+              // Children position truly untrackable and generator is idle →
+              // fall back to full rerender
+              inst.props = allProps;
+              inst.capturedCtx = _withBatch(inst.capturedCtx, _getCurrentBatch());
+              inst.rerender();
+              prevSlot.props = slotProps;
+              return { slot: prevSlot, node: prevSlot.node, replaced: false };
+            }
+          }
+        }
+
         if (inst) {
           // Check if any consumed context value differs from capturedCtx.
           const currentCtxMap = _getCtxMap();

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -496,6 +496,31 @@ export interface ComponentInstance {
   resumeHookIndex: number;
 
   /**
+   * The VNode returned by the generator on the last completed render.
+   *
+   * Used by the children-only reconciliation optimization: when a parent
+   * rerenders but only `children` changed, the stored output VNode is
+   * patched with the new children and reconciled without re-executing the
+   * generator.
+   *
+   * **Written by:** `executeRerender` and `resume` in `mount.ts`.
+   * **Read by:** `reconcileComponent` in `reconciler.ts`.
+   */
+  lastOutputVNode?: Child;
+
+  /**
+   * Where `props.children` elements appear in the output VNode tree.
+   *
+   * - `undefined` — not yet computed (initial state).
+   * - `null` — children are not trackable (transformed, all primitives, etc.).
+   * - `{ path, startIdx, count }` — contiguous position of children elements.
+   *
+   * **Written by:** `executeRerender` and `resume` in `mount.ts`.
+   * **Read by:** `reconcileComponent` in `reconciler.ts`.
+   */
+  childrenPosition?: { path: number[]; startIdx: number; count: number } | null;
+
+  /**
    * Total hook count from the first completed (done=true) generator run.
    *
    * `undefined` until the generator has fully returned at least once


### PR DESCRIPTION
## Summary

When a parent rerenders and a child component's own props are unchanged but its `children` differ, the renderer now skips the component's generator and reconciles only the children within the stored output VNode tree. This avoids unnecessary generator re-execution for wrapper/layout components.

## Changes

- **`src/render/helpers.ts`** — Add `shallowEqualExcludingChildren`, `onlyPatchChangedExcludingChildren`, `childrenShallowEqual`, `findChildrenPosition`, and `patchOutputVNode` utilities.
- **`src/render/mount.ts`** — Track output VNode and children position on component instances after each render via `_trackChildrenPosition`.
- **`src/render/reconciler.ts`** — Children-only reconciliation path: when non-children props are stable but children differ, patch the stored output VNode and reconcile without re-executing the generator. Falls back to full rerender when children position is untrackable.
- **`src/render/types.ts`** — Add `lastOutputVNode` and `childrenPosition` fields to `ComponentInstance`.
- **`examples/src/components/ChildrenOptDemo.tsx`** — Demo component with render counters showing the optimization in action.
- **`examples/tests/children-opt.spec.ts`** — Playwright visual tests for the demo.
- **`src/__tests__/children-optimization.test.ts`** — Unit tests for the optimization.
- **`docs/api.md`** — Document the optimization with code examples and fallback conditions.
- **`CLAUDE.md`** — Add `ChildrenOptDemo` to the demo list.

Closes #130

## Verification

All checks passed:
- `npm run knip` — no dead code
- `npm run lint:fix` — clean
- `npm run build` — compiles
- `npm run typecheck:examples` — passes
- `npm test` — 255/255 tests pass
- `npm run test:visual` — 375/375 tests pass

## CLAUDE.md Update

Updated to add `ChildrenOptDemo` to the top-level demos list.