### PR TITLE
chore: replace `as` type casts with `satisfies` where possible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ function* Counter(_props: object) {
 - **NPM Script Policy:** Never use `npx`. Always use the existing `npm run` scripts to ensure version consistency.
 - **Linting:** Biome (`biome.json`) handles linting and formatting. Prettier was removed.
 - **TypeScript:** Strictly typed; `any` is forbidden. `noUncheckedIndexedAccess` and `noPropertyAccessFromIndexSignature` are enabled.
+- **Prefer `satisfies` over `as`:** Strongly avoid `as` type assertions. Use `satisfies` to validate that a value conforms to a type without silencing the type checker. Only use `as` where genuine type narrowing is required (e.g., DOM element downcasts, narrowing `T | undefined` to `T`, casting `unknown` from external APIs, generator yield values). Never use `as` when `satisfies` would work.
 - **Special Props:** Always support the `$shown={boolean}` prop.
 - **Dependencies:** Zero-dependency goal.
 - **JSX Config:** The library build uses the classic `react` transform (`jsxFactory: "createElement"`). Consumers (including `examples/`) use `react-jsx` with `jsxImportSource: "yract"`, backed by `src/jsx-runtime.ts`.

--- a/examples/src/components/Navigation.tsx
+++ b/examples/src/components/Navigation.tsx
@@ -16,7 +16,7 @@ export function* Navigation({
       data-testid={`${scope}-nav`}
       style={{ display: "flex", gap: "0.5rem", marginBottom: "1rem" }}
     >
-      {(["home", "about", "contact"] as Page[]).map((p) => (
+      {(["home", "about", "contact"] satisfies Page[]).map((p) => (
         <button
           key={p}
           data-testid={`${scope}-nav-${p}`}

--- a/examples/src/components/TransformConsumer.tsx
+++ b/examples/src/components/TransformConsumer.tsx
@@ -8,7 +8,7 @@ export function* TransformConsumer() {
 
   const upperName = yield* useContext(
     AppCtx,
-    (c) => [c.user.name] as [string],
+    (c) => [c.user.name] satisfies [string],
     (name) => name.toUpperCase(),
   );
 

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -30,7 +30,7 @@ export function jsx(
   if (Array.isArray(children)) {
     return createElement(type, rest, ...children);
   }
-  return createElement(type, rest, children as Child);
+  return createElement(type, rest, children);
 }
 
 /** Used by the JSX transform for multi-child expressions (static children). */

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -164,7 +164,7 @@ export const Portal: unique symbol = Symbol("Portal");
  */
 export function createPortal(children: Child | Child[], container: Element, key?: string): VNode {
   const childArray = Array.isArray(children) ? children : [children];
-  const props: InternalProps = { $portalContainer: container } as InternalProps;
+  const props: InternalProps = { $portalContainer: container } satisfies InternalProps;
   if (key != null) props.key = String(key);
   return { type: Portal, props, children: childArray };
 }
@@ -214,8 +214,8 @@ export function createElement(
 ): VNode {
   return {
     type,
-    props: (props ?? {}) as InternalProps,
-    children: children.flat() as Child[],
+    props: (props ?? {}) satisfies InternalProps,
+    children: children.flat() satisfies Child[],
   };
 }
 

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -132,7 +132,7 @@ export function flattenChildren(children: Child[]): Child[] {
 export function mergedProps(vnode: VNode): InternalProps {
   return (
     vnode.children.length > 0 ? { ...vnode.props, children: vnode.children } : vnode.props
-  ) as InternalProps;
+  ) satisfies InternalProps;
 }
 
 /**
@@ -182,7 +182,7 @@ export function isShown(props: SpecialProps): boolean {
 export function stripFrameworkDirectives(props: InternalProps): InternalProps {
   if (!("$deferred" in props) && !("$deps" in props)) return props;
   const { $deferred: _d, $deps: _p, ...rest } = props;
-  return rest as InternalProps;
+  return rest satisfies InternalProps;
 }
 
 /**
@@ -197,5 +197,5 @@ export function stripFrameworkDirectives(props: InternalProps): InternalProps {
 export function stripDeferred(props: InternalProps): InternalProps {
   if (!("$deferred" in props)) return props;
   const { $deferred: _, ...rest } = props;
-  return rest as InternalProps;
+  return rest satisfies InternalProps;
 }


### PR DESCRIPTION
## Summary

Replaces `as` type assertions with `satisfies` wherever possible, and adds a CLAUDE.md coding standard to prefer `satisfies` over `as` going forward.

## Changes

- **`src/render/helpers.ts`** — `mergedProps`, `stripFrameworkDirectives`, `stripDeferred`: replaced `as InternalProps` with `satisfies InternalProps`
- **`src/jsx.ts`** — `createPortal` and `createElement`: replaced `as InternalProps` and `as Child[]` with `satisfies`
- **`src/jsx-runtime.ts`** — removed unnecessary `as Child` cast (TypeScript narrows correctly after `Array.isArray` and `=== undefined` checks)
- **`examples/src/components/Navigation.tsx`** — replaced `as Page[]` with `satisfies Page[]`
- **`examples/src/components/TransformConsumer.tsx`** — replaced `as [string]` with `satisfies [string]`
- **`CLAUDE.md`** — added "Prefer `satisfies` over `as`" coding standard

Note: ~70+ remaining `as` casts were investigated and must stay — they perform genuine type narrowing (DOM downcasts, `T | undefined` → `T`, `unknown` casting, generator yield values) that `satisfies` cannot handle.

Closes #140

## Verification

All checks passed: `knip`, `lint:fix`, `build`, `typecheck:examples`, `test` (246/246), `test:visual` (402/402).

## CLAUDE.md Update

Yes — added "Prefer `satisfies` over `as`" to Coding Standards & Rules.