### PR TITLE
refactor: replace Context.Provider with $context prop

### DIFF
--- a/examples/src/components/ContextDemo.tsx
+++ b/examples/src/components/ContextDemo.tsx
@@ -44,22 +44,19 @@ export function* ContextDemo() {
       <p style={{ fontSize: "0.9rem", color: "#555", marginBottom: "0.5rem" }}>
         Theme and Locale are separate contexts. Toggling one must not affect the other.
       </p>
-      <ThemeCtx.Provider value={theme}>
-        <LocaleCtx.Provider value={locale}>
-          <div
-            data-testid="independent-panel"
-            style={{
-              padding: "0.75rem",
-              borderRadius: "6px",
-              ...themeStyles[theme],
-              marginBottom: "1rem",
-            }}
-          >
-            Theme: <ThemeBadge data-testid="theme-badge" /> &nbsp; Locale: <LocaleBadge /> &nbsp;
-            Both: <BothBadge />
-          </div>
-        </LocaleCtx.Provider>
-      </ThemeCtx.Provider>
+      <div
+        $context={[ThemeCtx(theme), LocaleCtx(locale)]}
+        data-testid="independent-panel"
+        style={{
+          padding: "0.75rem",
+          borderRadius: "6px",
+          ...themeStyles[theme],
+          marginBottom: "1rem",
+        }}
+      >
+        Theme: <ThemeBadge data-testid="theme-badge" /> &nbsp; Locale: <LocaleBadge /> &nbsp; Both:{" "}
+        <BothBadge />
+      </div>
 
       {/* Part 2: inner Provider shadows outer */}
       <h3>2 - Nested Provider override</h3>
@@ -67,30 +64,29 @@ export function* ContextDemo() {
         The outer theme is <em>{theme}</em>. An inner Provider hard-codes the theme to <em>dark</em>
         . The inner card must always display <em>dark</em>.
       </p>
-      <ThemeCtx.Provider value={theme}>
-        <div data-testid="outer-card" style={{ padding: "0.5rem", ...themeStyles[theme] }}>
-          <span>Outer card -- theme: </span>
-          <ThemeBadge data-testid="outer-theme-badge" />
-          <ThemeCtx.Provider value="dark">
-            <div
-              data-testid="inner-card"
-              style={{ marginTop: "0.5rem", padding: "0.5rem", ...themeStyles["dark"] }}
-            >
-              <span>Inner card (always dark) -- theme: </span>
-              <ThemeBadge data-testid="inner-theme-badge" />
-            </div>
-          </ThemeCtx.Provider>
+      <div
+        $context={ThemeCtx(theme)}
+        data-testid="outer-card"
+        style={{ padding: "0.5rem", ...themeStyles[theme] }}
+      >
+        <span>Outer card -- theme: </span>
+        <ThemeBadge data-testid="outer-theme-badge" />
+        <div
+          $context={ThemeCtx("dark")}
+          data-testid="inner-card"
+          style={{ marginTop: "0.5rem", padding: "0.5rem", ...themeStyles["dark"] }}
+        >
+          <span>Inner card (always dark) -- theme: </span>
+          <ThemeBadge data-testid="inner-theme-badge" />
         </div>
-      </ThemeCtx.Provider>
+      </div>
 
       {/* Part 3: state preserved across context updates */}
       <h3>3 - State preserved across context updates</h3>
       <p style={{ fontSize: "0.9rem", color: "#555", marginBottom: "0.5rem" }}>
         Increment the counter, then toggle the outer theme. The counter must keep its value.
       </p>
-      <ThemeCtx.Provider value={theme}>
-        <StatefulConsumer />
-      </ThemeCtx.Provider>
+      <StatefulConsumer $context={ThemeCtx(theme)} />
 
       {/* Part 4: sibling providers are isolated */}
       <SiblingProvidersDemo />

--- a/examples/src/components/LazyContextDemo.tsx
+++ b/examples/src/components/LazyContextDemo.tsx
@@ -78,13 +78,14 @@ export function* LazyContextDemo() {
         <strong>{state.user.role}</strong> | count: <strong>{state.count}</strong>
       </p>
 
-      <AppCtx.Provider value={state}>
-        <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-          <NoSelectorConsumer />
-          <SelectorConsumer />
-          <TransformConsumer />
-        </div>
-      </AppCtx.Provider>
+      <div
+        $context={AppCtx(state)}
+        style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}
+      >
+        <NoSelectorConsumer />
+        <SelectorConsumer />
+        <TransformConsumer />
+      </div>
 
       <details style={{ marginTop: "1rem", fontSize: "0.8rem", color: "#555" }}>
         <summary>Expected behavior</summary>

--- a/examples/src/components/PortalDemo.tsx
+++ b/examples/src/components/PortalDemo.tsx
@@ -101,32 +101,31 @@ export function* PortalDemo() {
       {/* Portal content – rendered into the target container */}
       {containerRef.current && showModal
         ? createPortal(
-            <PortalThemeCtx.Provider value={theme}>
-              <div
-                data-testid="portal-modal"
-                style={{
-                  padding: "1rem",
-                  background: theme === "dark" ? "#222" : "#fff",
-                  color: theme === "dark" ? "#eee" : "#333",
-                  border: "1px solid #ccc",
-                  borderRadius: "6px",
-                }}
-              >
-                <h3 style={{ marginTop: 0 }}>Portal Modal</h3>
-                <p>
-                  This content is rendered via <code>createPortal</code> into the dashed container
-                  above.
-                </p>
-                <div style={{ marginBottom: "0.5rem" }}>
-                  <strong>Context inheritance: </strong>
-                  <PortalThemeConsumer />
-                </div>
-                <div>
-                  <strong>Events: </strong>
-                  <PortalCounter />
-                </div>
+            <div
+              $context={PortalThemeCtx(theme)}
+              data-testid="portal-modal"
+              style={{
+                padding: "1rem",
+                background: theme === "dark" ? "#222" : "#fff",
+                color: theme === "dark" ? "#eee" : "#333",
+                border: "1px solid #ccc",
+                borderRadius: "6px",
+              }}
+            >
+              <h3 style={{ marginTop: 0 }}>Portal Modal</h3>
+              <p>
+                This content is rendered via <code>createPortal</code> into the dashed container
+                above.
+              </p>
+              <div style={{ marginBottom: "0.5rem" }}>
+                <strong>Context inheritance: </strong>
+                <PortalThemeConsumer />
               </div>
-            </PortalThemeCtx.Provider>,
+              <div>
+                <strong>Events: </strong>
+                <PortalCounter />
+              </div>
+            </div>,
             containerRef.current,
           )
         : false}

--- a/examples/src/components/SiblingProvidersDemo.tsx
+++ b/examples/src/components/SiblingProvidersDemo.tsx
@@ -44,22 +44,20 @@ export function* SiblingProvidersDemo() {
         </button>
       </div>
       <div style={{ display: "flex", gap: "1rem" }}>
-        <ThemeCtx.Provider value={valA}>
-          <div
-            data-testid="sibling-panel-a"
-            style={{ padding: "0.5rem", border: "1px solid #ccc" }}
-          >
-            Subtree A: <SiblingConsumerA />
-          </div>
-        </ThemeCtx.Provider>
-        <ThemeCtx.Provider value={valB}>
-          <div
-            data-testid="sibling-panel-b"
-            style={{ padding: "0.5rem", border: "1px solid #ccc" }}
-          >
-            Subtree B: <SiblingConsumerB />
-          </div>
-        </ThemeCtx.Provider>
+        <div
+          $context={ThemeCtx(valA)}
+          data-testid="sibling-panel-a"
+          style={{ padding: "0.5rem", border: "1px solid #ccc" }}
+        >
+          Subtree A: <SiblingConsumerA />
+        </div>
+        <div
+          $context={ThemeCtx(valB)}
+          data-testid="sibling-panel-b"
+          style={{ padding: "0.5rem", border: "1px solid #ccc" }}
+        >
+          Subtree B: <SiblingConsumerB />
+        </div>
       </div>
     </div>
   );

--- a/examples/src/components/ThemeDemo.tsx
+++ b/examples/src/components/ThemeDemo.tsx
@@ -61,9 +61,7 @@ export function* ThemeDemo() {
       >
         Toggle theme (current: {theme})
       </button>
-      <ThemeContext.Provider value={theme}>
-        <ThemedCard />
-      </ThemeContext.Provider>
+      <ThemedCard $context={ThemeContext(theme)} />
     </section>
   );
 }

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2024", "DOM"],
     "jsx": "react-jsx",
     "jsxImportSource": "yract",
     "strict": true,

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -528,4 +528,85 @@ describe("createContext / useContext", () => {
       expect(container.querySelector("span")?.textContent).toBe("1:99");
     });
   });
+
+  describe("conditional $context", () => {
+    it("switching between branches with different $context values", () => {
+      const CtxA = createContext("defaultA");
+      const CtxB = createContext("defaultB");
+
+      function* Consumer() {
+        const a = yield* useContext(CtxA);
+        const b = yield* useContext(CtxB);
+        return createElement("span", null, `${a}:${b}`);
+      }
+
+      let setMode!: (v: number) => void;
+
+      function* Parent() {
+        const [mode, _setMode] = yield* useState(0);
+        setMode = _setMode;
+
+        if (mode === 0) {
+          return createElement(
+            "div",
+            { $context: [CtxA("A0"), CtxB("B0")] },
+            createElement(Consumer as never, {}),
+          );
+        }
+        if (mode === 1) {
+          return createElement(
+            "div",
+            { $context: CtxA("A1") },
+            createElement(Consumer as never, {}),
+          );
+        }
+        return createElement("div", null, createElement(Consumer as never, {}));
+      }
+
+      render(createElement(Parent as never, {}), container);
+      expect(container.querySelector("span")?.textContent).toBe("A0:B0");
+
+      setMode(1);
+      expect(container.querySelector("span")?.textContent).toBe("A1:defaultB");
+
+      setMode(2);
+      expect(container.querySelector("span")?.textContent).toBe("defaultA:defaultB");
+
+      setMode(0);
+      expect(container.querySelector("span")?.textContent).toBe("A0:B0");
+    });
+
+    it("switching $context on a Fragment between branches", () => {
+      const Ctx = createContext("default");
+
+      function* Consumer() {
+        const v = yield* useContext(Ctx);
+        return createElement("span", null, v);
+      }
+
+      let setMode!: (v: number) => void;
+
+      function* Parent() {
+        const [mode, _setMode] = yield* useState(0);
+        setMode = _setMode;
+
+        return createElement(
+          "div",
+          null,
+          mode === 0
+            ? createElement(Consumer as never, { $context: Ctx("provided") })
+            : createElement(Consumer as never, {}),
+        );
+      }
+
+      render(createElement(Parent as never, {}), container);
+      expect(container.querySelector("span")?.textContent).toBe("provided");
+
+      setMode(1);
+      expect(container.querySelector("span")?.textContent).toBe("default");
+
+      setMode(0);
+      expect(container.querySelector("span")?.textContent).toBe("provided");
+    });
+  });
 });

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -31,7 +31,7 @@ describe("createContext / useContext", () => {
     expect(container.querySelector("span")?.textContent).toBe("default");
   });
 
-  it("passes a value through Context.Provider to a consumer component", () => {
+  it("passes a value through $context to a consumer component", () => {
     const Ctx = createContext("default");
 
     function* Consumer() {
@@ -39,14 +39,7 @@ describe("createContext / useContext", () => {
       return createElement("span", null, value);
     }
 
-    render(
-      createElement(
-        Ctx.Provider as never,
-        { value: "provided" },
-        createElement(Consumer as never, {}),
-      ),
-      container,
-    );
+    render(createElement(Consumer as never, { $context: Ctx("provided") }), container);
     expect(container.querySelector("span")?.textContent).toBe("provided");
   });
 
@@ -60,17 +53,9 @@ describe("createContext / useContext", () => {
 
     render(
       createElement(
-        Ctx.Provider as never,
-        { value: "outer" },
-        createElement(
-          "div",
-          null,
-          createElement(
-            Ctx.Provider as never,
-            { value: "inner" },
-            createElement(Consumer as never, {}),
-          ),
-        ),
+        "div",
+        { $context: Ctx("outer") },
+        createElement(Consumer as never, { $context: Ctx("inner") }),
       ),
       container,
     );
@@ -89,11 +74,7 @@ describe("createContext / useContext", () => {
       createElement(
         "div",
         null,
-        createElement(
-          Ctx.Provider as never,
-          { value: 99 },
-          createElement("span", { id: "inside" }, "ignored"),
-        ),
+        createElement("span", { id: "inside", $context: Ctx(99) }, "ignored"),
         createElement(Consumer as never, {}),
       ),
       container,
@@ -115,11 +96,7 @@ describe("createContext / useContext", () => {
     function* Parent() {
       const [theme, st] = yield* useState(7);
       setTheme = st;
-      return createElement(
-        Ctx.Provider as never,
-        { value: theme },
-        createElement(Consumer as never, {}),
-      );
+      return createElement(Consumer as never, { $context: Ctx(theme) });
     }
 
     render(createElement(Parent as never, {}), container);
@@ -148,11 +125,7 @@ describe("createContext / useContext", () => {
     function* Parent() {
       const [val, setVal] = yield* useState("A");
       setCtxValue = setVal;
-      return createElement(
-        Ctx.Provider as never,
-        { value: val },
-        createElement(Child as never, {}),
-      );
+      return createElement(Child as never, { $context: Ctx(val) });
     }
 
     render(createElement(Parent as never, {}), container);
@@ -186,11 +159,7 @@ describe("createContext / useContext", () => {
     function* Root() {
       const [val, setVal] = yield* useState("first");
       setCtxValue = setVal;
-      return createElement(
-        Ctx.Provider as never,
-        { value: val },
-        createElement(Middle as never, {}),
-      );
+      return createElement(Middle as never, { $context: Ctx(val) });
     }
 
     render(createElement(Root as never, {}), container);
@@ -225,16 +194,8 @@ describe("createContext / useContext", () => {
       return createElement(
         "div",
         null,
-        createElement(
-          Ctx.Provider as never,
-          { value: valA },
-          createElement(ConsumerA as never, {}),
-        ),
-        createElement(
-          Ctx.Provider as never,
-          { value: valB },
-          createElement(ConsumerB as never, {}),
-        ),
+        createElement(ConsumerA as never, { $context: Ctx(valA) }),
+        createElement(ConsumerB as never, { $context: Ctx(valB) }),
       );
     }
 
@@ -264,21 +225,13 @@ describe("createContext / useContext", () => {
 
     // Middle re-provides a fixed inner value
     function* Middle() {
-      return createElement(
-        Ctx.Provider as never,
-        { value: "inner" },
-        createElement(Consumer as never, {}),
-      );
+      return createElement(Consumer as never, { $context: Ctx("inner") });
     }
 
     function* Root() {
       const [outer, setOuter_] = yield* useState("outer-1");
       setOuter = setOuter_;
-      return createElement(
-        Ctx.Provider as never,
-        { value: outer },
-        createElement(Middle as never, {}),
-      );
+      return createElement(Middle as never, { $context: Ctx(outer) });
     }
 
     render(createElement(Root as never, {}), container);
@@ -307,18 +260,14 @@ describe("createContext / useContext", () => {
         "div",
         null,
         createElement("span", { "data-testid": "middle" }, outerVal),
-        createElement(Ctx.Provider as never, { value: "inner" }, createElement(Child as never, {})),
+        createElement(Child as never, { $context: Ctx("inner") }),
       );
     }
 
     function* Root() {
       const [val, setVal] = yield* useState("outer");
       setOuter = setVal;
-      return createElement(
-        Ctx.Provider as never,
-        { value: val },
-        createElement(Middle as never, {}),
-      );
+      return createElement(Middle as never, { $context: Ctx(val) });
     }
 
     render(createElement(Root as never, {}), container);
@@ -358,11 +307,7 @@ describe("createContext / useContext", () => {
     function* Root() {
       const [val, setVal] = yield* useState("v1");
       setCtxValue = setVal;
-      return createElement(
-        Ctx.Provider as never,
-        { value: val },
-        createElement(Middle as never, {}),
-      );
+      return createElement(Middle as never, { $context: Ctx(val) });
     }
 
     render(createElement(Root as never, {}), container);
@@ -398,15 +343,9 @@ describe("createContext / useContext", () => {
       const [valB, sB] = yield* useState("B1");
       setA = sA;
       setB = sB;
-      return createElement(
-        CtxA.Provider as never,
-        { value: valA },
-        createElement(
-          CtxB.Provider as never,
-          { value: valB },
-          createElement(Consumer as never, {}),
-        ),
-      );
+      return createElement(Consumer as never, {
+        $context: [CtxA(valA), CtxB(valB)],
+      });
     }
 
     render(createElement(Root as never, {}), container);
@@ -428,14 +367,7 @@ describe("createContext / useContext", () => {
         return createElement("span", null, `${val.a}:${val.b}`);
       }
 
-      render(
-        createElement(
-          Ctx.Provider as never,
-          { value: { a: 1, b: 2 } },
-          createElement(Consumer as never, {}),
-        ),
-        container,
-      );
+      render(createElement(Consumer as never, { $context: Ctx({ a: 1, b: 2 }) }), container);
       expect(container.querySelector("span")?.textContent).toBe("1:2");
     });
 
@@ -453,11 +385,7 @@ describe("createContext / useContext", () => {
       function* Parent() {
         const [val, sv] = yield* useState({ a: 1, b: 1 });
         setVal = sv;
-        return createElement(
-          Ctx.Provider as never,
-          { value: val },
-          createElement(Consumer as never, {}),
-        );
+        return createElement(Consumer as never, { $context: Ctx(val) });
       }
 
       render(createElement(Parent as never, {}), container);
@@ -483,11 +411,7 @@ describe("createContext / useContext", () => {
       function* Parent() {
         const [val, sv] = yield* useState({ a: 1, b: 1 });
         setVal = sv;
-        return createElement(
-          Ctx.Provider as never,
-          { value: val },
-          createElement(Consumer as never, {}),
-        );
+        return createElement(Consumer as never, { $context: Ctx(val) });
       }
 
       render(createElement(Parent as never, {}), container);
@@ -512,11 +436,9 @@ describe("createContext / useContext", () => {
       }
 
       render(
-        createElement(
-          Ctx.Provider as never,
-          { value: { name: "Alice", age: 30 } },
-          createElement(Consumer as never, {}),
-        ),
+        createElement(Consumer as never, {
+          $context: Ctx({ name: "Alice", age: 30 }),
+        }),
         container,
       );
       expect(container.querySelector("span")?.textContent).toBe("ALICE");
@@ -540,11 +462,7 @@ describe("createContext / useContext", () => {
       function* Parent() {
         const [val, sv] = yield* useState({ name: "Alice", count: 0 });
         setVal = sv;
-        return createElement(
-          Ctx.Provider as never,
-          { value: val },
-          createElement(Consumer as never, {}),
-        );
+        return createElement(Consumer as never, { $context: Ctx(val) });
       }
 
       render(createElement(Parent as never, {}), container);
@@ -570,11 +488,7 @@ describe("createContext / useContext", () => {
       function* Parent() {
         const [val, sv] = yield* useState({ a: 1, b: 1 });
         setVal = sv;
-        return createElement(
-          Ctx.Provider as never,
-          { value: val },
-          createElement(Consumer as never, {}),
-        );
+        return createElement(Consumer as never, { $context: Ctx(val) });
       }
 
       render(createElement(Parent as never, {}), container);
@@ -602,11 +516,7 @@ describe("createContext / useContext", () => {
       function* Parent() {
         const [val, sv] = yield* useState({ a: 1, b: 1 });
         setVal = sv;
-        return createElement(
-          Ctx.Provider as never,
-          { value: val },
-          createElement(Consumer as never, {}),
-        );
+        return createElement(Consumer as never, { $context: Ctx(val) });
       }
 
       render(createElement(Parent as never, {}), container);

--- a/src/__tests__/deps-prop.test.ts
+++ b/src/__tests__/deps-prop.test.ts
@@ -202,12 +202,12 @@ describe("$deps prop", () => {
     function* Provider() {
       const [theme, setT] = yield* useState("light");
       setTheme = setT;
-      return createElement(
-        ThemeCtx.Provider as never,
-        { value: theme },
-        // $deps is stable (empty) but context should still trigger rerender
-        createElement(Consumer as never, { extra: 42, $deps: [] }),
-      );
+      // $deps is stable (empty) but context should still trigger rerender
+      return createElement(Consumer as never, {
+        extra: 42,
+        $deps: [],
+        $context: ThemeCtx(theme),
+      });
     }
 
     render(createElement(Provider as never, {}), container);

--- a/src/__tests__/no-wrapper-spans.test.ts
+++ b/src/__tests__/no-wrapper-spans.test.ts
@@ -189,14 +189,7 @@ describe("no wrapper spans in rendered output", () => {
       return createElement("span", null, value);
     }
 
-    render(
-      createElement(
-        Ctx.Provider as never,
-        { value: "provided" },
-        createElement(Consumer as never, {}),
-      ),
-      container,
-    );
+    render(createElement(Consumer as never, { $context: Ctx("provided") }), container);
     expect(container.querySelector("span")?.textContent).toBe("provided");
     expectNoDisplayContentsSpans(container);
   });
@@ -211,13 +204,9 @@ describe("no wrapper spans in rendered output", () => {
 
     render(
       createElement(
-        Ctx.Provider as never,
-        { value: "outer" },
-        createElement(
-          Ctx.Provider as never,
-          { value: "inner" },
-          createElement(Consumer as never, {}),
-        ),
+        "div",
+        { $context: Ctx("outer") },
+        createElement(Consumer as never, { $context: Ctx("inner") }),
       ),
       container,
     );
@@ -245,13 +234,9 @@ describe("no wrapper spans in rendered output", () => {
 
     render(
       createElement(
-        Ctx.Provider as never,
-        { value: "deep" },
-        createElement(
-          Middle as never,
-          {},
-          createElement(PlainWrapper as never, {}, createElement(Leaf as never, {})),
-        ),
+        Middle as never,
+        { $context: Ctx("deep") },
+        createElement(PlainWrapper as never, {}, createElement(Leaf as never, {})),
       ),
       container,
     );

--- a/src/__tests__/portal.test.ts
+++ b/src/__tests__/portal.test.ts
@@ -73,8 +73,8 @@ describe("createPortal", () => {
 
     function* App() {
       return createElement(
-        Ctx.Provider as never,
-        { value: "provided" },
+        "div",
+        { $context: Ctx("provided") },
         createPortal(createElement(Consumer as never, {}), portalTarget),
       );
     }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,6 @@
-import { $USE_CONTEXT, $USE_SET_CONTEXT, type ContextDescriptor } from "./hooks/descriptors";
+import { $USE_CONTEXT, type ContextDescriptor } from "./hooks/descriptors";
 import type { ComponentGenerator } from "./hooks/types";
 import { depsChanged } from "./hooks/types";
-import { type Child, type Component, createElement, Fragment, type InternalProps } from "./jsx";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -84,35 +83,6 @@ export function createContext<T>(defaultValue: T): PublicContext<T> {
   } satisfies Context<T>);
   return ctx;
 }
-
-// ---------------------------------------------------------------------------
-// Internal context bridge — transparent component for Fragment-with-$context
-// ---------------------------------------------------------------------------
-
-/**
- * Transparent passthrough component that sets context values via
- * `$USE_SET_CONTEXT` and renders its children as a Fragment.
- *
- * Used internally when a Fragment VNode carries `$context` — `createElement`
- * swaps the Fragment for this component so the context participates in the
- * normal component lifecycle (mount, reconcile, propagate).
- *
- * @internal
- */
-function* _ContextBridge(props: InternalProps): ComponentGenerator<Child> {
-  const ctxProp = props["$context"] as ContextEntry | ContextEntry[] | undefined;
-  if (ctxProp) {
-    const entries = Array.isArray(ctxProp) ? ctxProp : [ctxProp];
-    for (const entry of entries) {
-      yield { type: $USE_SET_CONTEXT, ctx: entry.ctx as Context<unknown>, value: entry.value };
-    }
-  }
-  const children = props.children as Child[] | undefined;
-  return createElement(Fragment, null, ...(children ?? []));
-}
-
-/** @internal — exposed for createElement to use. */
-export const ContextBridge: Component = _ContextBridge;
 
 /**
  * Consume a context value inside a component.

--- a/src/context.ts
+++ b/src/context.ts
@@ -11,21 +11,36 @@ import { type Child, type Component, createElement, Fragment, type InternalProps
  * A context object. Holds only the default value.
  *
  * Internal contexts (like `BatchContext` and `PriorityContext`) use this
- * minimal shape — they have no Provider component.
+ * minimal shape — they are not callable.
  */
 export interface Context<T> {
-  readonly _defaultValue: T;
+  readonly defaultValue: T;
 }
 
 /**
- * A context object returned by `createContext`.
- * Use `Context.Provider` to supply a value, `useContext` to consume it.
+ * A context entry produced by calling a context object with a value.
+ * Passed to the `$context` framework prop to provide context to a subtree.
  *
- * Extends the minimal `Context<T>` with a `Provider` symbol that can be
- * used as a VNode type in JSX.
+ * @example
+ * const ThemeCtx = createContext<'light' | 'dark'>('light');
+ * <Child $context={ThemeCtx('dark')} />
+ */
+export interface ContextEntry<T = unknown> {
+  readonly ctx: Context<T>;
+  readonly value: T;
+}
+
+/**
+ * A callable context object returned by `createContext`.
+ * Call it with a value to produce a `ContextEntry` for the `$context` prop.
+ * Use `useContext` to consume the value.
+ *
+ * @example
+ * const ThemeCtx = createContext<'light' | 'dark'>('light');
+ * <Child $context={ThemeCtx('dark')} />
  */
 export interface PublicContext<T> extends Context<T> {
-  readonly Provider: Component<InternalProps & { value: T; children?: Child[] }>;
+  (value: T): ContextEntry<T>;
 }
 
 // ---------------------------------------------------------------------------
@@ -47,16 +62,15 @@ interface UseContextDescriptor {
 /**
  * Create a new context with a default value.
  *
+ * Call the returned context with a value to produce a `ContextEntry`
+ * for the `$context` prop. Use `useContext` to consume the value.
+ *
  * @example
  * const ThemeCtx = createContext<'light' | 'dark'>('light');
  *
  * function* App() {
  *   const [theme] = yield* useState<'light' | 'dark'>('light');
- *   return (
- *     <ThemeCtx.Provider value={theme}>
- *       <Child />
- *     </ThemeCtx.Provider>
- *   );
+ *   return <Child $context={ThemeCtx(theme)} />;
  * }
  *
  * function* Child() {
@@ -65,23 +79,40 @@ interface UseContextDescriptor {
  * }
  */
 export function createContext<T>(defaultValue: T): PublicContext<T> {
-  const ctx: PublicContext<T> = {
-    _defaultValue: defaultValue,
-    Provider: undefined as never,
-  };
-
-  function* ContextProvider(
-    props: InternalProps & { value: T; children?: Child[] },
-  ): ComponentGenerator<Child> {
-    yield { type: $USE_SET_CONTEXT, ctx, value: props.value };
-    return createElement(Fragment, null, ...(props.children ?? []));
-  }
-
-  (ctx as { Provider: Component<InternalProps & { value: T; children?: Child[] }> }).Provider =
-    ContextProvider;
-
+  const ctx: PublicContext<T> = Object.assign((value: T): ContextEntry<T> => ({ ctx, value }), {
+    defaultValue: defaultValue,
+  } satisfies Context<T>);
   return ctx;
 }
+
+// ---------------------------------------------------------------------------
+// Internal context bridge — transparent component for Fragment-with-$context
+// ---------------------------------------------------------------------------
+
+/**
+ * Transparent passthrough component that sets context values via
+ * `$USE_SET_CONTEXT` and renders its children as a Fragment.
+ *
+ * Used internally when a Fragment VNode carries `$context` — `createElement`
+ * swaps the Fragment for this component so the context participates in the
+ * normal component lifecycle (mount, reconcile, propagate).
+ *
+ * @internal
+ */
+function* _ContextBridge(props: InternalProps): ComponentGenerator<Child> {
+  const ctxProp = props["$context"] as ContextEntry | ContextEntry[] | undefined;
+  if (ctxProp) {
+    const entries = Array.isArray(ctxProp) ? ctxProp : [ctxProp];
+    for (const entry of entries) {
+      yield { type: $USE_SET_CONTEXT, ctx: entry.ctx as Context<unknown>, value: entry.value };
+    }
+  }
+  const children = props.children as Child[] | undefined;
+  return createElement(Fragment, null, ...(children ?? []));
+}
+
+/** @internal — exposed for createElement to use. */
+export const ContextBridge: Component = _ContextBridge;
 
 /**
  * Consume a context value inside a component.
@@ -198,14 +229,14 @@ export function processContext(
 
 /**
  * Resolve the effective value for `ctx` from `map`, falling back to the
- * context's `_defaultValue` when no Provider has supplied a value.
+ * context's `defaultValue` when no Provider has supplied a value.
  *
  * TODO: eliminate in favor of `yield* getContext()` in generator code.
  * Kept for synchronous code that cannot yield (hooks, helpers, scheduler).
  * @internal
  */
 export function resolveCtx<T>(map: ReadonlyMap<Context<unknown>, unknown>, ctx: Context<T>): T {
-  return (map.has(ctx) ? map.get(ctx) : ctx._defaultValue) as T;
+  return (map.has(ctx) ? map.get(ctx) : ctx.defaultValue) as T;
 }
 
 // ---------------------------------------------------------------------------
@@ -220,7 +251,7 @@ export function resolveCtx<T>(map: ReadonlyMap<Context<unknown>, unknown>, ctx: 
  * @internal
  */
 export const BatchContext: Context<"live" | "default"> = {
-  _defaultValue: "default",
+  defaultValue: "default",
 };
 
 /**
@@ -253,7 +284,7 @@ export function withBatch(
  * @internal
  */
 export const PriorityContext: Context<number> = {
-  _defaultValue: 0,
+  defaultValue: 0,
 };
 
 /**

--- a/src/hooks/useRender.ts
+++ b/src/hooks/useRender.ts
@@ -1,5 +1,5 @@
-import { createContext, useContext } from "../context";
-import { type Child, createElement } from "../jsx";
+import { type ContextEntry, createContext, useContext } from "../context";
+import type { Child, VNode } from "../jsx";
 import type { HookState } from "../render/types";
 import { $USE_RENDER, type RenderDescriptor } from "./descriptors";
 import type { ComponentGenerator, DependencyList } from "./types";
@@ -104,17 +104,15 @@ export function* useRender<T>(
   };
 
   const isInline = typeof fnOrChild === "function";
+  const resumeEntry = _resumeCtx(resumeCallback as (value: unknown) => void);
 
   while (slot.status === "waiting") {
     const rawChild = isInline
       ? (fnOrChild as UseRenderFn<T>)({ resume: resumeCallback })
       : (fnOrChild as Child);
-    // Wrap in the internal resume context so nested components can access `resume` via useResume().
-    yield createElement(
-      _resumeCtx.Provider,
-      { value: resumeCallback as (value: unknown) => void },
-      rawChild,
-    );
+    // Attach resume context via $context on the child VNode so nested
+    // components can access `resume` via useResume().
+    yield withContextEntry(rawChild, resumeEntry);
   }
 
   return slot.value as T;
@@ -159,6 +157,22 @@ export function* useResume<T>(): ComponentGenerator<(value: T) => void> {
     throw new Error("useResume must be called inside a component rendered by useRender");
   }
   return fn as (value: T) => void;
+}
+
+function isVNode(child: Child): child is VNode {
+  return child !== null && child !== undefined && typeof child === "object";
+}
+
+/** Merge a ContextEntry into a child's $context prop. */
+function withContextEntry(child: Child, entry: ContextEntry): Child {
+  if (!isVNode(child)) return child;
+  const existing = child.props.$context;
+  const merged = existing ? [...(Array.isArray(existing) ? existing : [existing]), entry] : entry;
+  return {
+    type: child.type,
+    props: { ...child.props, $context: merged },
+    children: child.children,
+  };
 }
 
 /** @internal */

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,3 +1,4 @@
+import { ContextBridge, type ContextEntry } from "./context";
 import type { ComponentGenerator, DependencyList } from "./hooks/types";
 import type { IntrinsicElements as IntrinsicElementsDef } from "./jsx-types";
 
@@ -58,6 +59,18 @@ export interface FrameworkProps {
    * only cares about a subset of values.
    */
   $deps?: DependencyList;
+  /**
+   * Provide context values to this element/component and its descendants.
+   *
+   * Accepts a single `ContextEntry` or an array for multiple contexts.
+   * Create entries by calling a context object: `MyCtx(value)`.
+   *
+   * @example
+   * const ThemeCtx = createContext<'light' | 'dark'>('light');
+   * <Child $context={ThemeCtx('dark')} />
+   * <div $context={[ThemeCtx('dark'), LocaleCtx('fi')]}>...</div>
+   */
+  $context?: ContextEntry | ContextEntry[];
 }
 
 /**
@@ -212,8 +225,11 @@ export function createElement(
   props: Record<string, unknown> | null,
   ...children: Child[]
 ): VNode {
+  // Fragment with $context → swap to ContextBridge component so context
+  // participates in the normal component lifecycle.
+  const effectiveType = type === Fragment && props?.["$context"] ? ContextBridge : type;
   return {
-    type,
+    type: effectiveType,
     props: (props ?? {}) satisfies InternalProps,
     children: children.flat() satisfies Child[],
   };
@@ -243,7 +259,7 @@ declare global {
      * declared in the component's own props type.
      *
      * Only framework-level props (`key`, `$shown`, `$patch`, `$deferred`,
-     * `$deps`) are universally available. `children` and `$ref` must be
+     * `$deps`, `$context`) are universally available. `children` and `$ref` must be
      * explicitly declared in a component's props type to be accepted.
      */
     interface IntrinsicAttributes extends FrameworkProps {}

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -162,11 +162,10 @@ export const RawFragment: unique symbol = Symbol("RawFragment");
  *   );
  * }
  */
-function* _Fragment(props: InternalProps): ComponentGenerator<Child> {
+export function* Fragment(props: InternalProps): ComponentGenerator<Child> {
   const children = props.children as Child[] | undefined;
   return { type: RawFragment, props: {}, children: children ?? [] } satisfies VNode;
 }
-export const Fragment: Component = _Fragment;
 
 /**
  * Portal symbol – used as the `type` of VNodes created by `createPortal`.

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -1,4 +1,4 @@
-import { ContextBridge, type ContextEntry } from "./context";
+import type { ContextEntry } from "./context";
 import type { ComponentGenerator, DependencyList } from "./hooks/types";
 import type { IntrinsicElements as IntrinsicElementsDef } from "./jsx-types";
 
@@ -137,12 +137,24 @@ export type Component<P extends InternalProps = InternalProps> = (
 ) => ComponentGenerator<Child>;
 
 /**
- * Fragment symbol – use instead of a wrapper element when you need to
+ * Internal raw fragment symbol — the primitive grouping mechanism used by
+ * `buildNode` and `flattenChildren`. Not part of the public API.
+ *
+ * @internal
+ */
+export const RawFragment: unique symbol = Symbol("RawFragment");
+
+/**
+ * Fragment component — use instead of a wrapper element when you need to
  * return multiple children.
+ *
+ * Framework directives (`$context`, `$patch`, `$deferred`) placed on a
+ * Fragment work correctly because Fragment is a real component that
+ * participates in the normal lifecycle (mount, reconcile, propagate).
  *
  * @example
  * function* List() {
- *   yield (
+ *   return (
  *     <>
  *       <li>One</li>
  *       <li>Two</li>
@@ -150,14 +162,18 @@ export type Component<P extends InternalProps = InternalProps> = (
  *   );
  * }
  */
-export const Fragment: unique symbol = Symbol("Fragment");
+function* _Fragment(props: InternalProps): ComponentGenerator<Child> {
+  const children = props.children as Child[] | undefined;
+  return { type: RawFragment, props: {}, children: children ?? [] } satisfies VNode;
+}
+export const Fragment: Component = _Fragment;
 
 /**
  * Portal symbol – used as the `type` of VNodes created by `createPortal`.
  *
  * Portal VNodes render their children into an arbitrary DOM container
  * outside the render root, while maintaining component-tree context
- * (Providers, `$patch`, `$deferred`).
+ * (`$context`, `$patch`, `$deferred`).
  */
 export const Portal: unique symbol = Symbol("Portal");
 
@@ -209,7 +225,7 @@ export function createElement<P extends InternalProps>(
   ...children: Child[]
 ): VNode;
 
-// Overload 3: symbol (Fragment)
+// Overload 3: symbol (RawFragment, Portal)
 export function createElement(type: symbol, props: null, ...children: Child[]): VNode;
 
 // Overload 4: escape-hatch (jsx-runtime, dynamic types)
@@ -225,11 +241,8 @@ export function createElement(
   props: Record<string, unknown> | null,
   ...children: Child[]
 ): VNode {
-  // Fragment with $context → swap to ContextBridge component so context
-  // participates in the normal component lifecycle.
-  const effectiveType = type === Fragment && props?.["$context"] ? ContextBridge : type;
   return {
-    type: effectiveType,
+    type,
     props: (props ?? {}) satisfies InternalProps,
     children: children.flat() satisfies Child[],
   };

--- a/src/render/driver.ts
+++ b/src/render/driver.ts
@@ -31,7 +31,7 @@ export type RenderGenerator<TReturn> = Generator<unknown, TReturn, unknown>;
 
 /** Yield to update a context value for the current subtree. */
 export function* setContext<T>(
-  ctx: { readonly _defaultValue: T },
+  ctx: { readonly defaultValue: T },
   updater: (current: T) => T,
 ): RenderGenerator<void> {
   yield { op: $SET_CONTEXT, key: ctx, updater };
@@ -43,16 +43,16 @@ export function* getContextMap(): RenderGenerator<CtxMap> {
 }
 
 /** Yield to read a single context value. */
-export function* getContext<T>(ctx: { readonly _defaultValue: T }): RenderGenerator<T> {
+export function* getContext<T>(ctx: { readonly defaultValue: T }): RenderGenerator<T> {
   const map = yield* getContextMap();
-  return (map.has(ctx) ? map.get(ctx) : ctx._defaultValue) as T;
+  return (map.has(ctx) ? map.get(ctx) : ctx.defaultValue) as T;
 }
 
 // ── Type guards ──────────────────────────────────────────────────────────
 
 function isSetContext(v: unknown): v is {
   op: typeof $SET_CONTEXT;
-  key: { _defaultValue: unknown };
+  key: { defaultValue: unknown };
   updater: (c: unknown) => unknown;
 } {
   return (
@@ -112,7 +112,7 @@ export function drive<T>(
     if (yielded === undefined) {
       result = gen.next(undefined);
     } else if (isSetContext(yielded)) {
-      const prev = ctxMap.has(yielded.key) ? ctxMap.get(yielded.key) : yielded.key._defaultValue;
+      const prev = ctxMap.has(yielded.key) ? ctxMap.get(yielded.key) : yielded.key.defaultValue;
       const next = new Map(ctxMap);
       next.set(yielded.key, yielded.updater(prev));
       ctxMap = next;
@@ -152,7 +152,7 @@ export function* driveWithContext<T>(ctxMap: CtxMap, gen: RenderGenerator<T>): R
     if (isSetContext(yielded)) {
       const prev = currentMap.has(yielded.key)
         ? currentMap.get(yielded.key)
-        : yielded.key._defaultValue;
+        : yielded.key.defaultValue;
       const next = new Map(currentMap);
       next.set(yielded.key, yielded.updater(prev));
       currentMap = next;

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -10,8 +10,8 @@ import type { Renderable } from "../hooks";
 import {
   type Child,
   type Component,
-  Fragment,
   type InternalProps,
+  RawFragment,
   type SpecialProps,
   type VNode,
 } from "../jsx";
@@ -64,11 +64,11 @@ export function onlyPatchChanged(a: InternalProps, b: InternalProps): boolean {
   return patchDiffers;
 }
 
-/** Recursively flatten Fragment VNodes into a flat list of non-Fragment children. */
+/** Recursively flatten RawFragment VNodes into a flat list of non-fragment children. */
 export function flattenChildren(children: Child[]): Child[] {
   const result: Child[] = [];
   for (const child of children) {
-    if (isVNode(child) && child.type === Fragment) {
+    if (isVNode(child) && child.type === RawFragment) {
       result.push(...flattenChildren(child.children));
     } else {
       result.push(child);
@@ -90,30 +90,38 @@ export function mergedProps(vnode: VNode): InternalProps {
 }
 
 /**
- * Build a child context map from a parent map, applying `$patch` and
- * `$deferred` from the given props.
+ * Apply `$context` entries to a context map, skipping entries whose value
+ * is already the same. Returns the original map if nothing changed.
+ */
+function withContextEntries(
+  map: ReadonlyMap<Context<unknown>, unknown>,
+  ctxProp: ContextEntry | ContextEntry[],
+): ReadonlyMap<Context<unknown>, unknown> {
+  const entries = Array.isArray(ctxProp) ? ctxProp : [ctxProp];
+  let newMap: Map<Context<unknown>, unknown> | undefined;
+  for (const entry of entries) {
+    if (!Object.is(resolveCtx(newMap ?? map, entry.ctx), entry.value)) {
+      if (!newMap) newMap = new Map(map);
+      newMap.set(entry.ctx, entry.value);
+    }
+  }
+  return newMap ?? map;
+}
+
+/**
+ * Build a child context map from a parent map, applying framework
+ * directives (`$patch`, `$deferred`, `$context`) from the given props.
  *
- * Returns the parent map unchanged if neither directive is set.
+ * Returns the parent map unchanged if no directive is set.
  */
 export function childContextMap(
   parentMap: ReadonlyMap<Context<unknown>, unknown>,
   props: SpecialProps,
 ): ReadonlyMap<Context<unknown>, unknown> {
   let map = parentMap;
-  const { $patch, $context, $deferred } = props;
-  if ($patch !== undefined) map = withBatch(map, $patch);
-  if ($deferred) map = withPriority(map, resolveCtx(map, PriorityContext) + 1);
-  if ($context) {
-    const entries = Array.isArray($context) ? $context : [$context];
-    let newMap: Map<Context<unknown>, unknown> | undefined;
-    for (const entry of entries) {
-      if (!Object.is(resolveCtx(newMap ?? map, entry.ctx), entry.value)) {
-        if (!newMap) newMap = new Map(map);
-        newMap.set(entry.ctx, entry.value);
-      }
-    }
-    if (newMap) map = newMap;
-  }
+  if (props.$patch !== undefined) map = withBatch(map, props.$patch);
+  if (props.$deferred) map = withPriority(map, resolveCtx(map, PriorityContext) + 1);
+  if (props.$context) map = withContextEntries(map, props.$context);
   return map;
 }
 

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -1,4 +1,11 @@
-import { type Context, PriorityContext, resolveCtx, withBatch, withPriority } from "../context";
+import {
+  type Context,
+  type ContextEntry,
+  PriorityContext,
+  resolveCtx,
+  withBatch,
+  withPriority,
+} from "../context";
 import type { Renderable } from "../hooks";
 import {
   type Child,
@@ -96,7 +103,22 @@ export function childContextMap(
   const batch = props.$patch;
   if (batch !== undefined) map = withBatch(map, batch);
   if (props.$deferred) map = withPriority(map, resolveCtx(map, PriorityContext) + 1);
+  const ctxProp = props.$context;
+  if (ctxProp) {
+    const entries = Array.isArray(ctxProp) ? ctxProp : [ctxProp];
+    const newMap = new Map(map);
+    for (const entry of entries) {
+      newMap.set(entry.ctx, entry.value);
+    }
+    map = newMap;
+  }
   return map;
+}
+
+/** Normalize a `$context` prop to an array of entries. */
+export function contextEntries(ctxProp: ContextEntry | ContextEntry[] | undefined): ContextEntry[] {
+  if (!ctxProp) return [];
+  return Array.isArray(ctxProp) ? ctxProp : [ctxProp];
 }
 
 /**
@@ -108,8 +130,8 @@ export function childContextMap(
  * directive is present (no allocation).
  */
 export function stripFrameworkDirectives(props: InternalProps): InternalProps {
-  if (!("$deferred" in props) && !("$deps" in props)) return props;
-  const { $deferred: _d, $deps: _p, ...rest } = props;
+  if (!("$deferred" in props) && !("$deps" in props) && !("$context" in props)) return props;
+  const { $deferred: _d, $deps: _p, $context: _c, ...rest } = props;
   return rest satisfies InternalProps;
 }
 
@@ -123,7 +145,7 @@ export function stripFrameworkDirectives(props: InternalProps): InternalProps {
  * If `$deferred` is not present, returns the original object (no allocation).
  */
 export function stripDeferred(props: InternalProps): InternalProps {
-  if (!("$deferred" in props)) return props;
-  const { $deferred: _, ...rest } = props;
+  if (!("$deferred" in props) && !("$context" in props)) return props;
+  const { $deferred: _d, $context: _c, ...rest } = props;
   return rest satisfies InternalProps;
 }

--- a/src/render/helpers.ts
+++ b/src/render/helpers.ts
@@ -100,17 +100,19 @@ export function childContextMap(
   props: SpecialProps,
 ): ReadonlyMap<Context<unknown>, unknown> {
   let map = parentMap;
-  const batch = props.$patch;
-  if (batch !== undefined) map = withBatch(map, batch);
-  if (props.$deferred) map = withPriority(map, resolveCtx(map, PriorityContext) + 1);
-  const ctxProp = props.$context;
-  if (ctxProp) {
-    const entries = Array.isArray(ctxProp) ? ctxProp : [ctxProp];
-    const newMap = new Map(map);
+  const { $patch, $context, $deferred } = props;
+  if ($patch !== undefined) map = withBatch(map, $patch);
+  if ($deferred) map = withPriority(map, resolveCtx(map, PriorityContext) + 1);
+  if ($context) {
+    const entries = Array.isArray($context) ? $context : [$context];
+    let newMap: Map<Context<unknown>, unknown> | undefined;
     for (const entry of entries) {
-      newMap.set(entry.ctx, entry.value);
+      if (!Object.is(resolveCtx(newMap ?? map, entry.ctx), entry.value)) {
+        if (!newMap) newMap = new Map(map);
+        newMap.set(entry.ctx, entry.value);
+      }
     }
-    map = newMap;
+    if (newMap) map = newMap;
   }
   return map;
 }

--- a/src/render/hooks-runtime.ts
+++ b/src/render/hooks-runtime.ts
@@ -359,7 +359,11 @@ function _hasStableSelectors(
  * selectors are not stable under the new value. Stops at inner Providers
  * for the same context.
  */
-function propagateContextUpdate(ctx: Context<unknown>, newValue: unknown, slots: Slot[]): void {
+export function propagateContextUpdate(
+  ctx: Context<unknown>,
+  newValue: unknown,
+  slots: Slot[],
+): void {
   for (const slot of slots) {
     const inst = slot.componentInstance;
     // Stop at an inner Provider for the same context — it overrides the outer value.

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -56,10 +56,16 @@ export function* buildNode(child: Child): RenderGenerator<Node> {
   if (!child.type) {
     throw new InvalidChildError(child);
   }
-  const { $shown, $patch, $deferred } = child.props;
+  const { $shown, $patch, $deferred, $context } = child.props;
   if ($shown === false) return document.createTextNode("");
   if ($patch) yield* setContext(BatchContext, () => $patch);
   if ($deferred) yield* setContext(PriorityContext, (current) => current + 1);
+  if ($context) {
+    const entries = Array.isArray($context) ? $context : [$context];
+    for (const entry of entries) {
+      yield* setContext(entry.ctx, () => entry.value);
+    }
+  }
 
   const effectiveProps = isComponentNode(child) ? mergedProps(child) : child.props;
   const map = yield* getContextMap();
@@ -152,8 +158,9 @@ function* resumeInstance(instance: ComponentInstance): RenderGenerator<void> {
   let result = gen.next();
 
   while (!result.done && isHookDescriptor(result.value)) {
+    const descriptor = result.value as HookDescriptor;
     const hookResult = processOneDescriptor(
-      result.value as HookDescriptor,
+      descriptor,
       hookIndex++,
       instance.hookStates,
       instance.cleanupFns,
@@ -163,6 +170,11 @@ function* resumeInstance(instance: ComponentInstance): RenderGenerator<void> {
       instance,
       ctxMap,
     );
+    // Sync driver's ctxMap when a context value is set via useSetContext
+    if (descriptor.type === $USE_SET_CONTEXT) {
+      const { ctx, value } = descriptor as { ctx: Context<unknown>; value: unknown };
+      yield* setContext(ctx, () => value);
+    }
     result = gen.next(hookResult);
   }
 

--- a/src/render/mount.ts
+++ b/src/render/mount.ts
@@ -16,7 +16,7 @@
 import { BatchContext, type Context, PriorityContext, withBatch } from "../context";
 import type { HookDescriptor } from "../hooks/descriptors";
 import { $USE_EFFECT, $USE_SET_CONTEXT } from "../hooks/descriptors";
-import { type Child, type Component, Fragment, type InternalProps, Portal } from "../jsx";
+import { type Child, type Component, type InternalProps, Portal, RawFragment } from "../jsx";
 import {
   drive,
   driveWithContext,
@@ -78,7 +78,7 @@ export function* buildNode(child: Child): RenderGenerator<Node> {
     return document.createComment("portal");
   }
 
-  if (child.type === Fragment) {
+  if (child.type === RawFragment) {
     const frag = document.createDocumentFragment();
     for (const c of child.children) {
       frag.appendChild(yield* driveWithContext(map, buildNode(c)));

--- a/src/render/reconciler.ts
+++ b/src/render/reconciler.ts
@@ -23,6 +23,7 @@ import { acquirePortalDelegation } from "./delegation";
 import { drive, getContext, getContextMap } from "./driver";
 import {
   childContextMap,
+  contextEntries,
   flattenChildren,
   isComponentNode,
   isElementNode,
@@ -33,7 +34,7 @@ import {
   stripDeferred,
   stripFrameworkDirectives,
 } from "./helpers";
-import { unmountSlot } from "./hooks-runtime";
+import { propagateContextUpdate, unmountSlot } from "./hooks-runtime";
 import { buildNode, mountComponent } from "./mount";
 import {
   domAppendChild,
@@ -541,6 +542,13 @@ function* reconcileComponent(
         prevSlot.props = slotProps;
       }
       if (inst) {
+        // Update providedContexts from $context prop.
+        const entries = contextEntries(allPropsRaw.$context);
+        inst.providedContexts.clear();
+        for (const entry of entries) {
+          inst.providedContexts.add(entry.ctx);
+        }
+
         // Check if any consumed context value differs from capturedCtx.
         let contextChanged = false;
         for (const ctx of inst.consumedContexts) {
@@ -557,7 +565,15 @@ function* reconcileComponent(
           inst.capturedCtx = childCtxMap;
           void inst.rerender();
         } else {
-          inst.capturedCtx = withBatch(inst.capturedCtx, currentBatch);
+          // Detect $context value changes that need propagation to descendants.
+          const prevCtx = inst.capturedCtx;
+          inst.capturedCtx = childCtxMap;
+          for (const entry of entries) {
+            const prevVal = resolveCtx(prevCtx, entry.ctx);
+            if (!Object.is(prevVal, entry.value)) {
+              propagateContextUpdate(entry.ctx, entry.value, inst.slots);
+            }
+          }
         }
       }
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
@@ -585,10 +601,12 @@ function* reconcileComponent(
     // Component with changed props → rerender in place
     if (prevSlot.componentInstance) {
       prevSlot.componentInstance.props = allProps;
-      prevSlot.componentInstance.capturedCtx = withBatch(
-        prevSlot.componentInstance.capturedCtx,
-        currentBatch,
-      );
+      prevSlot.componentInstance.capturedCtx = childCtxMap;
+      const entries = contextEntries(allPropsRaw.$context);
+      prevSlot.componentInstance.providedContexts.clear();
+      for (const entry of entries) {
+        prevSlot.componentInstance.providedContexts.add(entry.ctx);
+      }
       void prevSlot.componentInstance.rerender();
       prevSlot.props = slotProps;
       return { slot: prevSlot, node: prevSlot.node, replaced: false };
@@ -614,6 +632,10 @@ function* reconcileComponent(
     childCtxMap,
     mountComponent(component, allProps),
   ).value;
+  const entries = contextEntries(allPropsRaw.$context);
+  for (const entry of entries) {
+    componentInstance.providedContexts.add(entry.ctx);
+  }
   return {
     slot: {
       type: vnode.type,

--- a/src/render/state.ts
+++ b/src/render/state.ts
@@ -20,7 +20,7 @@ import type { RenderContext } from "./types";
  * @internal
  */
 export const RenderCtx: Context<RenderContext> = {
-  _defaultValue: undefined as never,
+  defaultValue: undefined as never,
 };
 
 /**


### PR DESCRIPTION
## Summary

- Replace `Context.Provider` with a `$context` framework prop — context objects are now callable: `ThemeCtx("dark")` returns a `ContextEntry` for `<Child $context={ThemeCtx("dark")} />`
- Fragment is now a component — directives (`$context`, `$patch`, `$deferred`) work naturally on Fragments
- Fix #145: add driver ctxMap sync to `resumeInstance` for internal `useSetContext`
- Rename `_defaultValue` → `defaultValue` on `Context` interface

## Changes

- **`src/context.ts`** — `createContext` returns callable `PublicContext<T>`, added `ContextEntry` type
- **`src/jsx.ts`** — Added `$context` to `FrameworkProps`; Fragment is now a component backed by internal `RawFragment` symbol
- **`src/render/mount.ts`** — `buildNode` processes `$context`; fixed `resumeInstance` driver sync (#145)
- **`src/render/reconciler.ts`** — Handles `$context` changes: propagation, `providedContexts`, `childCtxMap`
- **`src/render/helpers.ts`** — `childContextMap`/strip functions handle `$context`; extracted `withContextEntries` helper (skips allocation when values unchanged)
- **`src/render/hooks-runtime.ts`** — Exported `propagateContextUpdate`
- **`src/hooks/useRender.ts`** — `_resumeCtx` uses `$context` on child VNode instead of Provider
- **`src/render/driver.ts`**, **`src/render/state.ts`** — `_defaultValue` → `defaultValue`
- **`examples/tsconfig.json`** — lib ES2020 → ES2024
- **Tests** — Added conditional `$context` tests; migrated Provider usages
- **Examples** — All Provider usages migrated to `$context` prop

Closes #150
Fixes #145

## Verification

All checks passed: knip, lint, build, typecheck:examples, 248 unit tests, 402 visual tests.

## CLAUDE.md Update

Not yet — will update if this PR is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)