### PR TITLE
refactor: rename $ref to ref, inline helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ function* Counter(_props: object) {
 | `render/reconciler.ts`    | Positional reconciliation (diff + patch)                                |
 | `render/hooks-runtime.ts` | Hook descriptor dispatch, effect flushing, unmount                      |
 | `render/helpers.ts`       | Type guards, shallow equality, props merging, `flattenChildren`         |
-| `render/props.ts`         | `applyProps`, `updateProps`, `setRef`, `clearRef`                       |
+| `render/props.ts`         | `applyProps`, `updateProps`                                             |
 | `render/scheduler.ts`     | Priority-aware cooperative scheduler                                    |
 | `render/patch-queue.ts`   | Atomic DOM commit queue                                                 |
 | `render/patch.ts`         | Global/local UI patch (`startUIPatch`/`commitUIPatch`)                  |

--- a/examples/src/components/KeyShuffleDemo.tsx
+++ b/examples/src/components/KeyShuffleDemo.tsx
@@ -15,7 +15,7 @@ function* CounterItem({ id, color }: { id: string; color: string }) {
 
   return (
     <div
-      $ref={nodeRef}
+      ref={nodeRef}
       data-testid={`item-${id}`}
       data-id={id}
       style={{

--- a/examples/src/components/PortalDemo.tsx
+++ b/examples/src/components/PortalDemo.tsx
@@ -85,7 +85,7 @@ export function* PortalDemo() {
       {/* Portal target container (rendered in normal flow for demo visibility) */}
       <div
         data-testid="portal-target"
-        $ref={containerRef}
+        ref={containerRef}
         style={{
           border: "2px dashed #999",
           borderRadius: "6px",

--- a/src/__tests__/type-safety.typetest.tsx
+++ b/src/__tests__/type-safety.typetest.tsx
@@ -1,5 +1,5 @@
 /**
- * Compile-time type safety tests for children and $ref props.
+ * Compile-time type safety tests for children and ref props.
  *
  * This file is checked by `npm run typecheck`.
  * Lines marked `@ts-expect-error` MUST produce a type error — if they
@@ -21,7 +21,7 @@ function* NoProps(): ComponentGenerator<Child> {
   return <div>no props</div>;
 }
 
-/** Component that accepts some props but NOT children or $ref. */
+/** Component that accepts some props but NOT children or ref. */
 function* WithName(_props: { name: string }): ComponentGenerator<Child> {
   return <div />;
 }
@@ -31,43 +31,43 @@ function* WithChildren(_props: { children?: Child[] }): ComponentGenerator<Child
   return <div />;
 }
 
-/** Component that explicitly declares $ref. */
+/** Component that explicitly declares ref. */
 function* WithRef(_props: {
-  $ref?: { current: HTMLElement | undefined };
+  ref?: { current: HTMLElement | undefined };
 }): ComponentGenerator<Child> {
   return <div />;
 }
 
-/** Component that explicitly declares both children and $ref. */
+/** Component that explicitly declares both children and ref. */
 function* WithBoth(_props: {
   children?: Child[];
-  $ref?: { current: HTMLElement | undefined };
+  ref?: { current: HTMLElement | undefined };
 }): ComponentGenerator<Child> {
   return <div />;
 }
 
 // ---------------------------------------------------------------------------
-// 1. Components without props must NOT accept children or $ref
+// 1. Components without props must NOT accept children or ref
 // ---------------------------------------------------------------------------
 
 // @ts-expect-error — children not declared in NoProps
 _sink(<NoProps children={[]} />);
 
-// @ts-expect-error — $ref not declared in NoProps
-_sink(<NoProps $ref={{ current: null }} />);
+// @ts-expect-error — ref not declared in NoProps
+_sink(<NoProps ref={{ current: null }} />);
 
 // Valid: NoProps with no special props
 _sink(<NoProps />);
 
 // ---------------------------------------------------------------------------
-// 2. Components with unrelated props must NOT accept children or $ref
+// 2. Components with unrelated props must NOT accept children or ref
 // ---------------------------------------------------------------------------
 
 // @ts-expect-error — children not declared in WithName
 _sink(<WithName name="hello" children={[]} />);
 
-// @ts-expect-error — $ref not declared in WithName
-_sink(<WithName name="hello" $ref={{ current: null }} />);
+// @ts-expect-error — ref not declared in WithName
+_sink(<WithName name="hello" ref={{ current: null }} />);
 
 // Valid: WithName with only declared props
 _sink(<WithName name="hello" />);
@@ -81,19 +81,19 @@ _sink(<WithChildren children={["text", <span />]} />);
 _sink(<WithChildren />);
 
 // ---------------------------------------------------------------------------
-// 4. Components that declare $ref CAN receive it
+// 4. Components that declare ref CAN receive it
 // ---------------------------------------------------------------------------
 
-_sink(<WithRef $ref={{ current: undefined }} />);
+_sink(<WithRef ref={{ current: undefined }} />);
 _sink(<WithRef />);
 
 // ---------------------------------------------------------------------------
-// 5. Components with both children and $ref CAN receive them
+// 5. Components with both children and ref CAN receive them
 // ---------------------------------------------------------------------------
 
-_sink(<WithBoth children={[]} $ref={{ current: undefined }} />);
+_sink(<WithBoth children={[]} ref={{ current: undefined }} />);
 _sink(<WithBoth children={[]} />);
-_sink(<WithBoth $ref={{ current: undefined }} />);
+_sink(<WithBoth ref={{ current: undefined }} />);
 _sink(<WithBoth />);
 
 // ---------------------------------------------------------------------------
@@ -120,18 +120,18 @@ _sink(<div children={["text"]} />);
 _sink(<span children={["text"]} />);
 
 // ---------------------------------------------------------------------------
-// 8. HTML elements always accept $ref (via SpecialProps in HTMLAttributes)
+// 8. HTML elements always accept ref (via SpecialProps in HTMLAttributes)
 // ---------------------------------------------------------------------------
 
-_sink(<div $ref={{ current: undefined as HTMLDivElement | undefined }} />);
-_sink(<input $ref={{ current: undefined as HTMLInputElement | undefined }} />);
-_sink(<button $ref={{ current: undefined }} />);
+_sink(<div ref={{ current: undefined as HTMLDivElement | undefined }} />);
+_sink(<input ref={{ current: undefined as HTMLInputElement | undefined }} />);
+_sink(<button ref={{ current: undefined }} />);
 
 // ---------------------------------------------------------------------------
-// 9. HTML elements accept both children and $ref together
+// 9. HTML elements accept both children and ref together
 // ---------------------------------------------------------------------------
 
-_sink(<div children={["text"]} $ref={{ current: undefined as HTMLDivElement | undefined }} />);
+_sink(<div children={["text"]} ref={{ current: undefined as HTMLDivElement | undefined }} />);
 
 // ---------------------------------------------------------------------------
 // 10. HTML elements also accept framework props

--- a/src/__tests__/use-ref.test.tsx
+++ b/src/__tests__/use-ref.test.tsx
@@ -3,7 +3,7 @@ import { render } from "../render";
 
 // jsdom is provided by vitest (see vitest.config.ts)
 
-describe("$ref", () => {
+describe("ref", () => {
   let container: HTMLElement;
 
   beforeEach(() => {

--- a/src/hooks/useRef.ts
+++ b/src/hooks/useRef.ts
@@ -23,7 +23,7 @@ export interface RefObject<T> {
  * @example
  * function* InputFocus() {
  *   const ref = yield* useRef<HTMLInputElement>();
- *   return <input $ref={ref} />;
+ *   return <input ref={ref} />;
  * }
  *
  * **Overload 2 — with initial value:** `.current` is `T` (non-optional).

--- a/src/jsx.ts
+++ b/src/jsx.ts
@@ -76,10 +76,10 @@ export interface FrameworkProps {
 /**
  * Full set of special props for intrinsic HTML/SVG elements.
  *
- * Extends {@link FrameworkProps} with `children` and `$ref`, which are
+ * Extends {@link FrameworkProps} with `children` and `ref`, which are
  * only available on elements and on components that explicitly declare them.
  *
- * @typeParam TRef - The concrete element type for `$ref`.
+ * @typeParam TRef - The concrete element type for `ref`.
  *   Narrowed to the specific `HTMLElement` / `SVGElement` subtype in
  *   per-element attribute interfaces.
  */
@@ -87,14 +87,14 @@ export interface SpecialProps<TRef = unknown> extends FrameworkProps {
   /** Nested children passed to the component or element. */
   children?: Child | Child[];
   /** Ref object — `.current` is set to the DOM element on mount, `undefined` on unmount. */
-  $ref?: { current: TRef | undefined };
+  ref?: { current: TRef | undefined };
 }
 
 /**
  * Props object as stored and passed internally by the framework.
  *
- * Combines the well-typed `$`-prefixed framework props (`SpecialProps`)
- * with an open string index for arbitrary user-defined props.
+ * Combines the well-typed framework props (`SpecialProps`) with an open
+ * string index for arbitrary user-defined props.
  *
  * Use this instead of raw `Record<string, unknown>` whenever a function
  * receives or returns a merged/internal props object.
@@ -271,7 +271,7 @@ declare global {
      * declared in the component's own props type.
      *
      * Only framework-level props (`key`, `$shown`, `$patch`, `$deferred`,
-     * `$deps`, `$context`) are universally available. `children` and `$ref` must be
+     * `$deps`, `$context`) are universally available. `children` and `ref` must be
      * explicitly declared in a component's props type to be accepted.
      */
     interface IntrinsicAttributes extends FrameworkProps {}

--- a/src/render/hooks-runtime.ts
+++ b/src/render/hooks-runtime.ts
@@ -39,7 +39,6 @@ import { _processUIPatch } from "../hooks/useUIPatch";
 
 import { releasePortalDelegation } from "./delegation";
 import { flushPendingVNodes } from "./patch";
-import { clearRef } from "./props";
 import { RenderCtx } from "./state";
 import type { ComponentInstance, HookState, Slot } from "./types";
 
@@ -113,9 +112,9 @@ export function unmountSlot(slot: Slot): void {
   for (const child of slot.childSlots) {
     unmountSlot(child);
   }
-  // Clear $ref on HTML element slots
-  if (typeof slot.type === "string" && slot.props.$ref) {
-    clearRef(slot.props.$ref);
+  // Clear ref on HTML element slots
+  if (typeof slot.type === "string" && slot.props.ref) {
+    slot.props.ref.current = undefined;
   }
   if (slot.componentInstance) {
     for (const child of slot.componentInstance.slots) {

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -9,18 +9,6 @@ import {
 import { addNonDelegatedListener, removeNonDelegatedListener } from "./events";
 import { requireActiveCtx } from "./state";
 
-// ── Ref helpers ─────────────────────────────────────────────────────────────
-
-/** Attach a $ref object to a DOM element. */
-function setRef(ref: { current: unknown } | undefined, el: Element): void {
-  if (ref) ref.current = el;
-}
-
-/** Clear a $ref object (set .current to undefined). */
-export function clearRef(ref: { current: unknown } | undefined): void {
-  if (ref) ref.current = undefined;
-}
-
 // ── Event registration helpers ─────────────────────────────────────────────
 
 /**
@@ -69,7 +57,7 @@ function _unregisterEvent(el: HTMLElement, propKey: string): void {
  *   encountered and a fresh element is created.
  *
  * **Prop handling rules:**
- * - All `$`-prefixed props are skipped (framework-internal special props).
+ * - All `$`-prefixed props, `ref`, and `children` are skipped.
  * - `onXxx` props → delegated or per-element via `_registerEvent`.
  * - `className` → `el.className`.
  * - `htmlFor` → `el.setAttribute('for', …)`.
@@ -89,7 +77,7 @@ function _unregisterEvent(el: HTMLElement, propKey: string): void {
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: prop type dispatch with many branches
 export function applyProps(el: HTMLElement, props: InternalProps): void {
   for (const [key, value] of Object.entries(props)) {
-    if (key.startsWith("$")) continue;
+    if (key === "ref" || key === "children" || key.startsWith("$")) continue;
     if (key.startsWith("on") && typeof value === "function") {
       _registerEvent(el, key, value as (e: SyntheticEvent) => void);
     } else if (key === "className") {
@@ -118,8 +106,8 @@ export function applyProps(el: HTMLElement, props: InternalProps): void {
     }
   }
 
-  // Handle $ref on initial mount
-  setRef(props.$ref, el);
+  // Handle ref on initial mount
+  if (props.ref) props.ref.current = el;
 
   // Default <button> type to "button" to prevent accidental form submission.
   // The HTML default is "submit", which is almost never the intended behaviour.
@@ -166,7 +154,7 @@ export function updateProps(
 ): void {
   // 1. Remove props that no longer exist in nextProps
   for (const key in prevProps) {
-    if (key.startsWith("$")) continue;
+    if (key === "ref" || key === "children" || key.startsWith("$")) continue;
     if (key in nextProps) continue;
     if (key.startsWith("on") && typeof prevProps[key] === "function") {
       _unregisterEvent(el, key);
@@ -183,7 +171,7 @@ export function updateProps(
 
   // 2. Add or update props that changed
   for (const key in nextProps) {
-    if (key.startsWith("$")) continue;
+    if (key === "ref" || key === "children" || key.startsWith("$")) continue;
     const next = nextProps[key];
     const prev = prevProps[key];
     if (Object.is(next, prev)) continue;
@@ -221,11 +209,11 @@ export function updateProps(
     }
   }
 
-  // 3. Handle $ref changes
-  const prevRef = prevProps.$ref;
-  const nextRef = nextProps.$ref;
+  // 3. Handle ref changes
+  const prevRef = prevProps.ref;
+  const nextRef = nextProps.ref;
   if (!Object.is(prevRef, nextRef)) {
-    clearRef(prevRef);
-    setRef(nextRef, el);
+    if (prevRef) prevRef.current = undefined;
+    if (nextRef) nextRef.current = el;
   }
 }


### PR DESCRIPTION
## Summary

Renames the `$ref` special prop to `ref` to align with the standard React convention, and removes the unnecessary `setRef`/`clearRef` helper functions by inlining their one-liner logic at call sites.

## Changes

- **`src/jsx.ts`**: Rename `$ref` to `ref` in `SpecialProps` interface and update JSDoc
- **`src/render/props.ts`**: Remove `setRef`/`clearRef` helpers, inline ref logic in `applyProps`/`updateProps`. Add explicit `ref` and `children` skips in prop loops (since `ref` no longer benefits from the `$`-prefix blanket skip)
- **`src/render/hooks-runtime.ts`**: Inline ref clearing in `unmountSlot`, remove `clearRef` import
- **`src/hooks/useRef.ts`**: Update JSDoc example
- **`src/__tests__/type-safety.typetest.tsx`**: Rename all `$ref` to `ref`
- **`src/__tests__/use-ref.test.tsx`**: Rename describe block
- **`examples/src/components/KeyShuffleDemo.tsx`**: `$ref` → `ref`
- **`examples/src/components/PortalDemo.tsx`**: `$ref` → `ref`
- **`CLAUDE.md`**: Remove `setRef`/`clearRef` from Core Module Map

## Verification

All checks passed: knip, lint, build, typecheck:examples, 248 unit tests, 402 visual tests.

## CLAUDE.md Update

Updated Core Module Map to remove `setRef`/`clearRef` from `render/props.ts` entry.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)