### PR TITLE
chore: add noInferrableTypes rule, relax lint severity to warn

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,8 +20,8 @@
     "rules": {
       "recommended": true,
       "suspicious": {
-        "noExplicitAny": "error",
-        "noConfusingVoidType": "error"
+        "noExplicitAny": "warn",
+        "noConfusingVoidType": "warn"
       },
       "complexity": {
         "noExcessiveCognitiveComplexity": {
@@ -29,20 +29,21 @@
           "options": { "maxAllowedComplexity": 15 }
         },
         "noForEach": "warn",
-        "useFlatMap": "error",
+        "useFlatMap": "warn",
         "useLiteralKeys": "off"
       },
       "style": {
+        "noInferrableTypes": "warn",
         "noNonNullAssertion": "warn",
-        "useConst": "error",
-        "noParameterAssign": "error",
-        "useExportType": "error",
-        "useImportType": "error",
+        "useConst": "warn",
+        "noParameterAssign": "warn",
+        "useExportType": "warn",
+        "useImportType": "warn",
         "useNodejsImportProtocol": "off"
       },
       "correctness": {
-        "noUnusedVariables": "error",
-        "noUnusedImports": "error",
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn",
         "useExhaustiveDependencies": "off",
         "useYield": "off"
       },


### PR DESCRIPTION
## Summary
Add the Biome `noInferrableTypes` lint rule and change all project-specific rules from `error` to `warn` so lint violations surface as warnings rather than blocking builds.

## Changes
- Add `noInferrableTypes: "warn"` to catch unnecessary explicit type annotations
- Change 9 rules from `error` to `warn`: `noExplicitAny`, `noConfusingVoidType`, `useFlatMap`, `useConst`, `noParameterAssign`, `useExportType`, `useImportType`, `noUnusedVariables`, `noUnusedImports`

Closes #160

## Verification
All checks passed: knip, lint, build, typecheck:examples, unit tests (248), visual tests (402).

## CLAUDE.md Update
No update needed — no workflow or structural changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)